### PR TITLE
Add relative import support

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -34,10 +34,13 @@ This document describes the grammar of the Whist language in BNF (Backus-Naur Fo
 ### Import Statement
 
 ```bnf
-<import-stmt> ::= 'import' <identifier> ';'
+<import-stmt> ::= 'import' ( <identifier> | <string-literal> ) ';'
 ```
 
-Import statements load declarations from external Whist source files. The imported module is resolved from the `lib/` directory relative to the current working directory. For example, `import std;` loads and parses `lib/std.w`, and all declarations from that file become available in the importing file.
+Import statements load declarations from external Whist source files. There are two forms:
+
+- **Module import:** `import std;` resolves the module name from the `lib/` directory (e.g., `lib/std.w`).
+- **Relative import:** `import "./path/to/file.w";` or `import "../file.w";` resolves the path relative to the importing file's directory. String imports must start with `./` or `../`.
 
 ### Function Declaration
 

--- a/w0/parse_import.c
+++ b/w0/parse_import.c
@@ -87,10 +87,39 @@ static int file_exists(const char* path) {
     return 0;
 }
 
+// Check if path is a relative import (starts with ./ or ../)
+static int is_relative_path(const char* path, size_t length) {
+    if (length >= 2 && path[0] == '.' && path[1] == '/') {
+        return 1;
+    }
+    if (length >= 3 && path[0] == '.' && path[1] == '.' && path[2] == '/') {
+        return 1;
+    }
+    return 0;
+}
+
 // Build path to imported module
-// Tries source-relative path first, then falls back to cwd-relative path
+// For relative paths (./ or ../), resolves relative to source file
+// For module names, tries source-relative lib/ first, then falls back to cwd-relative lib/
 static void build_import_path(Parser* parser, char* path, size_t path_size, const char* module_name,
-                              size_t module_length) {
+                              size_t module_length, int is_relative) {
+    if (is_relative) {
+        // Relative import: resolve relative to source file's directory
+        if (parser->source_path) {
+            char* path_copy = strdup(parser->source_path);
+            if (path_copy) {
+                char* dir = dirname(path_copy);
+                snprintf(path, path_size, "%s/%.*s", dir, (int)module_length, module_name);
+                free(path_copy);
+                return;
+            }
+        }
+        // Fallback if no source path: use path as-is relative to cwd
+        snprintf(path, path_size, "%.*s", (int)module_length, module_name);
+        return;
+    }
+
+    // Standard library import: try lib/ directories
     if (parser->source_path) {
         // Make a copy because dirname may modify its argument
         char* path_copy = strdup(parser->source_path);
@@ -109,24 +138,51 @@ static void build_import_path(Parser* parser, char* path, size_t path_size, cons
 }
 
 int parse_import_stmt(Parser* parser, NodeList* decls) {
-    // Expect identifier after 'import'
-    Token module_name = parser->current;
-    consume_token(parser, TOK_IDENT, "Expected module name after 'import'");
+    // Expect identifier or string after 'import'
+    Token       import_token = parser->current;
+    const char* module_name;
+    size_t      module_length;
+    int         is_relative = 0;
+
+    if (parser->current.type == TOK_STRING) {
+        // String import: "./path/to/file.w" or "../path/to/file.w"
+        advance_token(parser);
+        // Extract path without quotes
+        module_name   = import_token.start + 1;
+        module_length = import_token.length - 2;
+        is_relative   = is_relative_path(module_name, module_length);
+        if (!is_relative) {
+            parse_error(parser, "String imports must be relative paths (start with ./ or ../)");
+            return 0;
+        }
+    } else if (parser->current.type == TOK_IDENT) {
+        // Identifier import: std
+        advance_token(parser);
+        module_name   = import_token.start;
+        module_length = import_token.length;
+    } else {
+        parse_error(parser, "Expected module name or path after 'import'");
+        return 0;
+    }
 
     // Expect semicolon
     consume_token(parser, TOK_SEMICOLON, "Expected ';' after import statement");
 
+    // Build path to import file first (needed for duplicate detection with relative paths)
+    char path[1024];
+    build_import_path(parser, path, sizeof(path), module_name, module_length, is_relative);
+
+    // For relative imports, use the resolved path as the module key for duplicate detection
+    const char* module_key        = is_relative ? path : module_name;
+    size_t      module_key_length = is_relative ? strlen(path) : module_length;
+
     // Check if already imported (skip silently)
-    if (is_module_imported(parser, module_name.start, module_name.length)) {
+    if (is_module_imported(parser, module_key, module_key_length)) {
         return 1; // Already imported, nothing to do
     }
 
     // Mark as imported before parsing (prevents cycles)
-    add_imported_module(parser, module_name.start, module_name.length);
-
-    // Build path to import file
-    char path[1024];
-    build_import_path(parser, path, sizeof(path), module_name.start, module_name.length);
+    add_imported_module(parser, module_key, module_key_length);
 
     // Read the imported file
     char* source = read_file(path);

--- a/w0/test/import_parent.w
+++ b/w0/test/import_parent.w
@@ -1,0 +1,16 @@
+// Test parent directory imports (../)
+
+import std;
+import "./util/inner/helper.w";
+
+func main(): i32 {
+    var a = quadruple(3);
+
+    if (a != 12) {
+        print("FAIL: import_parent.w\n");
+        return 1;
+    }
+
+    print("PASS: import_parent.w\n");
+    return 0;
+}

--- a/w0/test/import_relative.w
+++ b/w0/test/import_relative.w
@@ -1,0 +1,17 @@
+// Test relative imports
+
+import std;
+import "./util/math.w";
+
+func main(): i32 {
+    var a = twice(5);
+    var b = triple(4);
+
+    if (a != 10 || b != 12) {
+        print("FAIL: import_relative.w\n");
+        return 1;
+    }
+
+    print("PASS: import_relative.w\n");
+    return 0;
+}

--- a/w0/test/util/inner/helper.w
+++ b/w0/test/util/inner/helper.w
@@ -1,0 +1,7 @@
+// Test parent directory imports
+
+import "../math.w";
+
+func quadruple(x: i32): i32 {
+    return twice(twice(x));
+}

--- a/w0/test/util/math.w
+++ b/w0/test/util/math.w
@@ -1,0 +1,9 @@
+// Utility math functions for testing relative imports
+
+func twice(x: i32): i32 {
+    return x * 2;
+}
+
+func triple(x: i32): i32 {
+    return x * 3;
+}


### PR DESCRIPTION
## Summary
- Add support for relative imports using `./` and `../` path prefixes
- String imports like `import "./util/math.w";` resolve relative to the importing file's directory
- Nested relative imports work correctly (imported files can use relative imports too)
- Non-relative string imports are rejected with a clear error message

## Test plan
- [x] `make test` passes (35/35 tests)
- [x] New test `import_relative.w` verifies `./` imports
- [x] New test `import_parent.w` verifies `../` imports via nested modules
- [x] Error case: `import "std.w";` produces error about requiring `./` or `../` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)