### PR TITLE
Add module-level visibility for library imports

### DIFF
--- a/w0/ast.h
+++ b/w0/ast.h
@@ -68,6 +68,11 @@ typedef struct {
     NodeList params;
     Node*    return_type;
     Node*    body;
+    char*    source_module; // NULL = same module, else external module name
+
+    // Library modules accessible from this function's body
+    char** accessible_modules;
+    int    accessible_modules_count;
 } func_decl_node;
 
 typedef struct {
@@ -77,6 +82,7 @@ typedef struct {
     Node* type;
     Node* init;
     int   is_const;
+    char* source_module; // NULL = same module, else external module name
 } var_decl_node;
 
 struct Node {
@@ -242,6 +248,7 @@ struct Node {
             char*    name;
             int      name_length;
             NodeList fields;
+            char*    source_module; // NULL = same module, else external module name
         } struct_decl;
 
         // Field
@@ -256,7 +263,8 @@ struct Node {
             int      is_public;
             char*    name;
             int      name_length;
-            NodeList values; // list of ident nodes
+            NodeList values;        // list of ident nodes
+            char*    source_module; // NULL = same module, else external module name
         } enum_decl;
 
         struct {

--- a/w0/check_decl.c
+++ b/w0/check_decl.c
@@ -52,7 +52,8 @@ void check_decl(Checker* checker, Node* node) {
                 func_decl_node* fdn       = &decl->as.func_decl;
                 Type*           func_type = get_function_type(checker, decl);
 
-                checker_define(checker, fdn->name, SYM_FUNC, func_type, 0, fdn->is_public);
+                checker_define(checker, fdn->name, SYM_FUNC, func_type, 0, fdn->is_public,
+                               fdn->source_module);
             }
         }
 
@@ -112,7 +113,8 @@ void check_decl(Checker* checker, Node* node) {
         Type* func_type = get_function_type(checker, node);
 
         // Pre-declare function for recursion
-        checker_define(checker, mangled_name, SYM_FUNC, func_type, 1, fdn->is_public);
+        checker_define(checker, mangled_name, SYM_FUNC, func_type, 1, fdn->is_public,
+                       fdn->source_module);
 
         // For methods, also register the method on the struct type
         if (is_method) {
@@ -168,13 +170,20 @@ void check_decl(Checker* checker, Node* node) {
         Type* old_return             = checker->current_func_return;
         checker->current_func_return = func_type->as.func.return_type;
 
+        // Set this function's accessible modules for visibility checking
+        char** old_accessible_modules             = checker->current_accessible_modules;
+        int    old_accessible_modules_count       = checker->current_accessible_modules_count;
+        checker->current_accessible_modules       = fdn->accessible_modules;
+        checker->current_accessible_modules_count = fdn->accessible_modules_count;
+
         // For methods, inject 'self' into scope
         // self is a struct reference (the struct type itself, with reference semantics)
         if (is_method) {
             Symbol* struct_sym = checker_lookup(checker, receiver_type);
             if (struct_sym && struct_sym->kind == SYM_TYPE) {
                 Type* self_type = struct_sym->type;
-                checker_define(checker, "self", SYM_VAR, self_type, fdn->receiver_is_const, 0);
+                checker_define(checker, "self", SYM_VAR, self_type, fdn->receiver_is_const, 0,
+                               NULL);
             }
         }
 
@@ -184,7 +193,7 @@ void check_decl(Checker* checker, Node* node) {
             Type* ptype = func_type->as.func.param_types[i];
 
             if (!checker_define(checker, param->as.param.name, SYM_VAR, ptype,
-                                param->as.param.is_const, 0)) {
+                                param->as.param.is_const, 0, NULL)) {
                 check_error(checker, param->line, param->column, "Duplicate parameter name '%s'",
                             param->as.param.name);
             }
@@ -199,6 +208,10 @@ void check_decl(Checker* checker, Node* node) {
                 check_statement(checker, body->as.block.stmts.nodes[i]);
             }
         }
+
+        // Restore previous accessible modules context
+        checker->current_accessible_modules       = old_accessible_modules;
+        checker->current_accessible_modules_count = old_accessible_modules_count;
 
         checker->current_func_return = old_return;
         checker_pop_scope(checker);
@@ -227,7 +240,8 @@ void check_decl(Checker* checker, Node* node) {
             struct_type->as.struc.field_types[i] = resolve_type(checker, field->as.field.type);
         }
 
-        checker_define(checker, name, SYM_TYPE, struct_type, 0, node->as.struct_decl.is_public);
+        checker_define(checker, name, SYM_TYPE, struct_type, 0, node->as.struct_decl.is_public,
+                       node->as.struct_decl.source_module);
         break;
     }
 
@@ -245,7 +259,8 @@ void check_decl(Checker* checker, Node* node) {
         enum_type->as.enm.value_count = value_count;
         enum_type->as.enm.value_names = malloc(value_count * sizeof(char*));
 
-        checker_define(checker, name, SYM_TYPE, enum_type, 0, node->as.enum_decl.is_public);
+        checker_define(checker, name, SYM_TYPE, enum_type, 0, node->as.enum_decl.is_public,
+                       node->as.enum_decl.source_module);
 
         // Define enum values as constants
         for (int i = 0; i < value_count; i++) {

--- a/w0/check_statement.c
+++ b/w0/check_statement.c
@@ -63,7 +63,7 @@ void check_statement(Checker* checker, Node* node) {
         }
 
         checker_define(checker, name, SYM_VAR, var_type, node->as.var_decl.is_const,
-                       node->as.var_decl.is_public);
+                       node->as.var_decl.is_public, node->as.var_decl.source_module);
         break;
     }
 
@@ -148,8 +148,8 @@ void check_statement(Checker* checker, Node* node) {
         }
 
         // Add the loop variable as a const int64 (immutable)
-        Symbol* sym =
-            checker_define(checker, node->as.foreach_stmt.var_name, SYM_VAR, type_int64, 1, 0);
+        Symbol* sym = checker_define(checker, node->as.foreach_stmt.var_name, SYM_VAR, type_int64,
+                                     1, 0, NULL);
         if (!sym) {
             check_error(checker, node->line, node->column,
                         "Variable '%s' already declared in this scope",

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -7,7 +7,7 @@
 #include "checker_util.h"
 
 Symbol* checker_define(Checker* checker, const char* name, SymbolKind kind, Type* type,
-                       int is_const, int is_public) {
+                       int is_const, int is_public, const char* source_module) {
     Scope*       scope = checker->scope;
     unsigned int index = hash_string(name) % scope->size;
 
@@ -24,12 +24,60 @@ Symbol* checker_define(Checker* checker, const char* name, SymbolKind kind, Type
     sym->type             = type;
     sym->is_const         = is_const;
     sym->is_public        = is_public;
+    sym->source_module    = source_module ? strdup(source_module) : NULL;
     sym->next             = scope->symbols[index];
     scope->symbols[index] = sym;
     return sym;
 }
 
+// Check if a module is accessible from the current context
+static int is_module_accessible(Checker* checker, const char* source_module) {
+    // NULL source_module means same module - always accessible
+    if (!source_module) {
+        return 1;
+    }
+
+    // Use current function's accessible modules if set, otherwise use global direct_imports
+    char** modules = checker->current_accessible_modules;
+    int    count   = checker->current_accessible_modules_count;
+
+    if (!modules) {
+        modules = checker->direct_imports;
+        count   = checker->direct_imports_count;
+    }
+
+    // Check if module is in the accessible list
+    for (int i = 0; i < count; i++) {
+        if (strcmp(modules[i], source_module) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 Symbol* checker_lookup(Checker* checker, const char* name) {
+    for (Scope* scope = checker->scope; scope; scope = scope->parent) {
+        unsigned int index = hash_string(name) % scope->size;
+        for (Symbol* sym = scope->symbols[index]; sym; sym = sym->next) {
+            if (strcmp(sym->name, name) == 0) {
+                // Check module visibility
+                if (!is_module_accessible(checker, sym->source_module)) {
+                    continue; // Symbol exists but not accessible from this module
+                }
+                // Symbols from library imports must be public to be accessible
+                if (sym->source_module && !sym->is_public) {
+                    continue; // Private symbol from library import
+                }
+                return sym;
+            }
+        }
+    }
+    return NULL;
+}
+
+// Lookup without visibility checking (for error messages)
+Symbol* checker_lookup_any(Checker* checker, const char* name) {
     for (Scope* scope = checker->scope; scope; scope = scope->parent) {
         unsigned int index = hash_string(name) % scope->size;
         for (Symbol* sym = scope->symbols[index]; sym; sym = sym->next) {

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -21,7 +21,8 @@ struct Symbol {
     Type*      type;
     int        is_const;
     int        is_public;
-    Symbol*    next; // Hash chain
+    char*      source_module; // NULL = same module, else external module name
+    Symbol*    next;          // Hash chain
 };
 
 struct Scope {
@@ -36,9 +37,18 @@ struct Checker {
     int    in_loop;             // Are we inside a loop?
     int    error_count;
     char   error_msg[256];
+
+    // Library modules directly imported by the root file (for global scope)
+    char** direct_imports;
+    int    direct_imports_count;
+
+    // Library modules accessible from the current function (NULL = use direct_imports)
+    char** current_accessible_modules;
+    int    current_accessible_modules_count;
 };
 
 void checker_init(Checker* checker);
+void checker_set_direct_imports(Checker* checker, char** direct_imports, int count);
 void checker_free(Checker* checker);
 
 int checker_check(Checker* checker, Node* ast);
@@ -47,8 +57,9 @@ int checker_check(Checker* checker, Node* ast);
 void    checker_push_scope(Checker* checker);
 void    checker_pop_scope(Checker* checker);
 Symbol* checker_define(Checker* checker, const char* name, SymbolKind kind, Type* type,
-                       int is_const, int is_public);
+                       int is_const, int is_public, const char* source_module);
 Symbol* checker_lookup(Checker* checker, const char* name);
+Symbol* checker_lookup_any(Checker* checker, const char* name); // Ignores module visibility
 Symbol* checker_lookup_local(Checker* checker, const char* name);
 
 #endif

--- a/w0/checker_util.c
+++ b/w0/checker_util.c
@@ -25,12 +25,21 @@ unsigned int hash_string(const char* str) {
 }
 
 void checker_init(Checker* checker) {
-    checker->scope               = NULL;
-    checker->current_func_return = NULL;
-    checker->in_loop             = 0;
-    checker->error_count         = 0;
-    checker->error_msg[0]        = '\0';
+    checker->scope                            = NULL;
+    checker->current_func_return              = NULL;
+    checker->in_loop                          = 0;
+    checker->error_count                      = 0;
+    checker->error_msg[0]                     = '\0';
+    checker->direct_imports                   = NULL;
+    checker->direct_imports_count             = 0;
+    checker->current_accessible_modules       = NULL;
+    checker->current_accessible_modules_count = 0;
     types_init();
+}
+
+void checker_set_direct_imports(Checker* checker, char** direct_imports, int count) {
+    checker->direct_imports       = direct_imports;
+    checker->direct_imports_count = count;
 }
 
 void checker_free(Checker* checker) {
@@ -69,6 +78,7 @@ void checker_pop_scope(Checker* checker) {
         while (sym) {
             Symbol* next = sym->next;
             free(sym->name);
+            free(sym->source_module);
             free(sym);
             sym = next;
         }

--- a/w0/lib/std.w
+++ b/w0/lib/std.w
@@ -28,3 +28,8 @@ func min_i64(a: i64, b: i64): i64 {
     }
     return b;
 }
+
+// Private internal function - should not be visible outside std
+private func _internal_std(): i64 {
+    return 42;
+}

--- a/w0/main.c
+++ b/w0/main.c
@@ -58,12 +58,14 @@ static int compile_and_run(const char* source_path, int argc, char** argv) {
     // Type check
     Checker checker;
     checker_init(&checker);
+    checker_set_direct_imports(&checker, parser.direct_imports, parser.direct_imports_count);
     int ok = checker_check(&checker, ast);
     checker_free(&checker);
 
     if (!ok) {
         fprintf(stderr, "Type check failed\n");
         node_free(ast);
+        parser_free(&parser);
         free(source);
         return 1;
     }
@@ -265,6 +267,8 @@ int main(int argc, char** argv) {
         if (!parse_only) {
             Checker checker;
             checker_init(&checker);
+            checker_set_direct_imports(&checker, parser.direct_imports,
+                                       parser.direct_imports_count);
             int ok = checker_check(&checker, ast);
             checker_free(&checker);
 

--- a/w0/parse_func_decl.c
+++ b/w0/parse_func_decl.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
+#include <string.h>
 
 #include "parse_enum_decl.h"
+#include "parser.h"
 #include "parser_util.h"
 
 Node* parse_type(Parser* parser);
@@ -112,6 +114,20 @@ Node* parse_func_decl(Parser* parser, int is_public) {
 
     consume_token(parser, TOK_LBRACE, "Expected '{' before function body");
     fdn->body = parse_block(parser);
+
+    // Copy current file's direct imports to accessible_modules
+    // This determines which library modules this function can access
+    fdn->accessible_modules_count = parser->direct_imports_count;
+    if (parser->direct_imports_count > 0) {
+        fdn->accessible_modules = malloc(parser->direct_imports_count * sizeof(char*));
+        if (fdn->accessible_modules) {
+            for (int i = 0; i < parser->direct_imports_count; i++) {
+                fdn->accessible_modules[i] = strdup(parser->direct_imports[i]);
+            }
+        }
+    } else {
+        fdn->accessible_modules = NULL;
+    }
 
     return node;
 }

--- a/w0/parse_import.c
+++ b/w0/parse_import.c
@@ -77,6 +77,51 @@ static void add_imported_source(Parser* parser, char* source) {
     parser->imported_sources[parser->imported_sources_count++] = source;
 }
 
+// Add a direct import (library module directly imported by current file)
+static void add_direct_import(Parser* parser, const char* module_name, size_t length) {
+    // Grow array if needed
+    if (parser->direct_imports_count >= parser->direct_imports_capacity) {
+        int new_capacity =
+            parser->direct_imports_capacity == 0 ? 8 : parser->direct_imports_capacity * 2;
+        char** new_array = realloc(parser->direct_imports, new_capacity * sizeof(char*));
+        if (!new_array)
+            return;
+        parser->direct_imports          = new_array;
+        parser->direct_imports_capacity = new_capacity;
+    }
+
+    // Copy the module name
+    char* name_copy = malloc(length + 1);
+    if (!name_copy)
+        return;
+    memcpy(name_copy, module_name, length);
+    name_copy[length]                                      = '\0';
+    parser->direct_imports[parser->direct_imports_count++] = name_copy;
+}
+
+// Set source_module on a declaration node
+static void set_decl_source_module(Node* decl, const char* source_module) {
+    if (!decl)
+        return;
+
+    switch (decl->type) {
+    case NODE_FUNC_DECL:
+        decl->as.func_decl.source_module = source_module ? strdup(source_module) : NULL;
+        break;
+    case NODE_STRUCT_DECL:
+        decl->as.struct_decl.source_module = source_module ? strdup(source_module) : NULL;
+        break;
+    case NODE_ENUM_DECL:
+        decl->as.enum_decl.source_module = source_module ? strdup(source_module) : NULL;
+        break;
+    case NODE_VAR_DECL:
+        decl->as.var_decl.source_module = source_module ? strdup(source_module) : NULL;
+        break;
+    default:
+        break;
+    }
+}
+
 // Check if file exists
 static int file_exists(const char* path) {
     FILE* f = fopen(path, "r");
@@ -176,9 +221,15 @@ int parse_import_stmt(Parser* parser, NodeList* decls) {
     const char* module_key        = is_relative ? path : module_name;
     size_t      module_key_length = is_relative ? strlen(path) : module_length;
 
-    // Check if already imported (skip silently)
+    // Check if already imported
     if (is_module_imported(parser, module_key, module_key_length)) {
-        return 1; // Already imported, nothing to do
+        // Module already imported - but still track as direct import if it's a library import
+        // This allows this file to access the module's symbols even if a dependency imported it
+        // first
+        if (!is_relative) {
+            add_direct_import(parser, module_name, module_length);
+        }
+        return 1; // Already imported, nothing more to do
     }
 
     // Mark as imported before parsing (prevents cycles)
@@ -225,20 +276,76 @@ int parse_import_stmt(Parser* parser, NodeList* decls) {
     import_parser.imported_modules       = NULL;
     import_parser.imported_modules_count = 0;
 
+    // Free sub-parser's direct_imports (not needed - each file tracks its own imports via
+    // source_file)
+    for (int i = 0; i < import_parser.direct_imports_count; i++) {
+        free(import_parser.direct_imports[i]);
+    }
+    free(import_parser.direct_imports);
+    import_parser.direct_imports       = NULL;
+    import_parser.direct_imports_count = 0;
+
     if (import_parser.had_error) {
         fprintf(stderr, "Failed to parse imported file: %s\n", path);
         node_free(import_ast);
         return 0;
     }
 
+    // For library imports, track as direct import and set source_module
+    // For relative imports, declarations stay in the same module (source_module = NULL)
+    char* source_module_name = NULL;
+    if (!is_relative) {
+        // Library import: track as direct import
+        add_direct_import(parser, module_name, module_length);
+
+        // Create source module name string
+        source_module_name = malloc(module_length + 1);
+        if (source_module_name) {
+            memcpy(source_module_name, module_name, module_length);
+            source_module_name[module_length] = '\0';
+        }
+    }
+
     // Merge declarations from imported file into current program
     if (import_ast && import_ast->type == NODE_PROGRAM) {
         for (int i = 0; i < import_ast->as.program.decls.count; i++) {
-            nodelist_push(decls, import_ast->as.program.decls.nodes[i]);
+            Node* decl = import_ast->as.program.decls.nodes[i];
+
+            // For library imports, set source_module on declarations that don't already have one
+            // (declarations that already have source_module are from transitive library imports)
+            if (!is_relative && decl) {
+                // Check if this declaration already has a source_module (from a transitive import)
+                char* existing_module = NULL;
+                switch (decl->type) {
+                case NODE_FUNC_DECL:
+                    existing_module = decl->as.func_decl.source_module;
+                    break;
+                case NODE_STRUCT_DECL:
+                    existing_module = decl->as.struct_decl.source_module;
+                    break;
+                case NODE_ENUM_DECL:
+                    existing_module = decl->as.enum_decl.source_module;
+                    break;
+                case NODE_VAR_DECL:
+                    existing_module = decl->as.var_decl.source_module;
+                    break;
+                default:
+                    break;
+                }
+
+                // Only set source_module if not already set (preserve transitive import info)
+                if (!existing_module) {
+                    set_decl_source_module(decl, source_module_name);
+                }
+            }
+
+            nodelist_push(decls, decl);
         }
         // Don't free the individual declaration nodes, just the program wrapper
         import_ast->as.program.decls.count = 0; // Prevent double-free
     }
+
+    free(source_module_name);
 
     node_free(import_ast);
     return 1;

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -65,6 +65,11 @@ void parser_init_with_path(Parser* parser, const char* source, const char* sourc
     parser->imported_modules_count    = 0;
     parser->imported_modules_capacity = 0;
 
+    // Initialize direct imports tracking (library modules directly imported by this file)
+    parser->direct_imports          = NULL;
+    parser->direct_imports_count    = 0;
+    parser->direct_imports_capacity = 0;
+
     advance_token(parser); // Prime the parser
 }
 
@@ -80,6 +85,12 @@ void parser_free(Parser* parser) {
         free(parser->imported_modules[i]);
     }
     free(parser->imported_modules);
+
+    // Free all direct import names
+    for (int i = 0; i < parser->direct_imports_count; i++) {
+        free(parser->direct_imports[i]);
+    }
+    free(parser->direct_imports);
 }
 
 Node* parser_parse(Parser* parser) {

--- a/w0/parser.h
+++ b/w0/parser.h
@@ -24,6 +24,11 @@ typedef struct {
     char** imported_modules;
     int    imported_modules_count;
     int    imported_modules_capacity;
+
+    // Library modules directly imported by the root file (for visibility checking)
+    char** direct_imports;
+    int    direct_imports_count;
+    int    direct_imports_capacity;
 } Parser;
 
 // Precedence levels for binary operators

--- a/w0/test/error_module_visibility.w
+++ b/w0/test/error_module_visibility.w
@@ -1,0 +1,15 @@
+// Test that symbols from library imports are not accessible through relative imports
+// EXPECT_ERROR: Undefined identifier 'abs_i64'
+
+import "./util/std_helper.w";
+
+func main(): i32 {
+    // This should work - double_abs is defined in std_helper
+    var a = double_abs(-5);
+
+    // This should FAIL - abs_i64 is from std, which was imported by std_helper
+    // but not by this file
+    var b = abs_i64(-10);
+
+    return 0;
+}

--- a/w0/test/error_private_import.w
+++ b/w0/test/error_private_import.w
@@ -1,0 +1,14 @@
+// Test that private symbols from library imports are not accessible
+// EXPECT_ERROR: Undefined identifier '_internal_std'
+
+import std;
+
+func main(): i32 {
+    // This should work - abs_i64 is public in std
+    var a = abs_i64(-5);
+
+    // This should FAIL - _internal_std is private in std
+    var b = _internal_std();
+
+    return 0;
+}

--- a/w0/test/module_visibility.w
+++ b/w0/test/module_visibility.w
@@ -1,0 +1,18 @@
+// Test that relative imports work but library symbols aren't re-exported
+// double_abs uses abs_i64 internally, but we can't call abs_i64 directly
+
+import "./util/std_helper.w";
+import std;  // Need to import std ourselves to use print
+
+func main(): i32 {
+    // This should work - double_abs is defined in std_helper
+    var a = double_abs(-5);
+
+    if (a != 10) {
+        print("FAIL: module_visibility.w - double_abs\n");
+        return 1;
+    }
+
+    print("PASS: module_visibility.w\n");
+    return 0;
+}

--- a/w0/test/util/std_helper.w
+++ b/w0/test/util/std_helper.w
@@ -1,0 +1,8 @@
+// Helper module that imports std internally
+
+import std;
+
+// Expose a function that uses std internally
+func double_abs(x: i64): i64 {
+    return abs_i64(x) * 2;
+}


### PR DESCRIPTION
## Summary
- Library imports (`import <identifier>`) now have their symbols restricted to the importing file
- Other files cannot access library symbols unless they also import the library directly
- Relative imports remain part of the same module and share visibility
- Private symbols from library imports are hidden - only public symbols are accessible

## Test plan
- [x] `test/module_visibility.w` - Verifies relative imports work correctly
- [x] `test/error_module_visibility.w` - Verifies library symbols aren't accessible through transitive imports
- [x] `test/error_private_import.w` - Verifies private symbols from library imports are hidden
- [x] All existing tests pass (38/38)

🤖 Generated with [Claude Code](https://claude.ai/code)