### PR TITLE
Add NODE_MODULE to AST for module-based organization

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -144,7 +144,11 @@ void node_free(Node* node) {
         nodelist_free(&node->as.enum_decl.values);
         break;
     case NODE_PROGRAM:
-        nodelist_free(&node->as.program.decls);
+        nodelist_free(&node->as.program.modules);
+        break;
+    case NODE_MODULE:
+        free(node->as.module.name);
+        nodelist_free(&node->as.module.decls);
         break;
     case NODE_EXTERN_MODULE:
         nodelist_free(&node->as.extern_module.decls);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -41,6 +41,7 @@ typedef enum {
     NODE_ENUM_DECL,
 
     NODE_EXTERN_MODULE,
+    NODE_MODULE,
 
     // Other
     NODE_PARAM,
@@ -273,9 +274,16 @@ struct Node {
             NodeList decls;
         } extern_module;
 
+        // Module
+        struct {
+            char*    name;
+            int      name_length;
+            NodeList decls;
+        } module;
+
         // Program
         struct {
-            NodeList decls;
+            NodeList modules;
         } program;
     } as;
 };

--- a/w0/check_decl.c
+++ b/w0/check_decl.c
@@ -53,7 +53,7 @@ void check_decl(Checker* checker, Node* node) {
                 Type*           func_type = get_function_type(checker, decl);
 
                 checker_define(checker, fdn->name, SYM_FUNC, func_type, 0, fdn->is_public,
-                               fdn->source_module);
+                               checker->current_module);
             }
         }
 
@@ -114,7 +114,7 @@ void check_decl(Checker* checker, Node* node) {
 
         // Pre-declare function for recursion
         checker_define(checker, mangled_name, SYM_FUNC, func_type, 1, fdn->is_public,
-                       fdn->source_module);
+                       checker->current_module);
 
         // For methods, also register the method on the struct type
         if (is_method) {
@@ -241,7 +241,7 @@ void check_decl(Checker* checker, Node* node) {
         }
 
         checker_define(checker, name, SYM_TYPE, struct_type, 0, node->as.struct_decl.is_public,
-                       node->as.struct_decl.source_module);
+                       checker->current_module);
         break;
     }
 
@@ -260,7 +260,7 @@ void check_decl(Checker* checker, Node* node) {
         enum_type->as.enm.value_names = malloc(value_count * sizeof(char*));
 
         checker_define(checker, name, SYM_TYPE, enum_type, 0, node->as.enum_decl.is_public,
-                       node->as.enum_decl.source_module);
+                       checker->current_module);
 
         // Define enum values as constants
         for (int i = 0; i < value_count; i++) {

--- a/w0/check_statement.c
+++ b/w0/check_statement.c
@@ -63,7 +63,7 @@ void check_statement(Checker* checker, Node* node) {
         }
 
         checker_define(checker, name, SYM_VAR, var_type, node->as.var_decl.is_const,
-                       node->as.var_decl.is_public, node->as.var_decl.source_module);
+                       node->as.var_decl.is_public, checker->current_module);
         break;
     }
 

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1,5 +1,6 @@
 #include "checker.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -37,6 +38,11 @@ static int is_module_accessible(Checker* checker, const char* source_module) {
         return 1;
     }
 
+    // If we're currently in the same module, it's accessible
+    if (checker->current_module && strcmp(checker->current_module, source_module) == 0) {
+        return 1;
+    }
+
     // Use current function's accessible modules if set, otherwise use global direct_imports
     char** modules = checker->current_accessible_modules;
     int    count   = checker->current_accessible_modules_count;
@@ -66,7 +72,11 @@ Symbol* checker_lookup(Checker* checker, const char* name) {
                     continue; // Symbol exists but not accessible from this module
                 }
                 // Symbols from library imports must be public to be accessible
-                if (sym->source_module && !sym->is_public) {
+                // Exception: private symbols are accessible if we're in the same module
+                int same_module = (sym->source_module == NULL && checker->current_module == NULL) ||
+                                  (sym->source_module && checker->current_module &&
+                                   strcmp(sym->source_module, checker->current_module) == 0);
+                if (sym->source_module && !sym->is_public && !same_module) {
                     continue; // Private symbol from library import
                 }
                 return sym;
@@ -110,22 +120,58 @@ int checker_check(Checker* checker, Node* ast) {
 
     checker_push_scope(checker); // Global scope
 
-    // First pass: declare all types and functions (for forward references)
-    for (int i = 0; i < ast->as.program.decls.count; i++) {
-        Node* decl = ast->as.program.decls.nodes[i];
-        if (decl->type == NODE_STRUCT_DECL || decl->type == NODE_ENUM_DECL) {
-            check_decl(checker, decl);
+    // First pass: declare all types (structs, enums) for forward references
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        // Set current module context (NULL for "main", module name for library imports)
+        checker->current_module =
+            strcmp(mod->as.module.name, "main") == 0 ? NULL : mod->as.module.name;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type == NODE_STRUCT_DECL || decl->type == NODE_ENUM_DECL) {
+                check_decl(checker, decl);
+            }
         }
     }
 
-    // Second pass: check everything
-    for (int i = 0; i < ast->as.program.decls.count; i++) {
-        Node* decl = ast->as.program.decls.nodes[i];
-        if (decl->type != NODE_STRUCT_DECL && decl->type != NODE_ENUM_DECL) {
-            check_decl(checker, decl);
+    // Second pass: check everything else
+    // Process library modules (non-main) first, then main module last
+    // This ensures library functions are declared before main uses them
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        // Skip main module in this pass
+        if (strcmp(mod->as.module.name, "main") == 0)
+            continue;
+        checker->current_module = mod->as.module.name;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type != NODE_STRUCT_DECL && decl->type != NODE_ENUM_DECL) {
+                check_decl(checker, decl);
+            }
         }
     }
 
+    // Third pass: check main module
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        if (strcmp(mod->as.module.name, "main") != 0)
+            continue;
+        checker->current_module = NULL;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type != NODE_STRUCT_DECL && decl->type != NODE_ENUM_DECL) {
+                check_decl(checker, decl);
+            }
+        }
+    }
+
+    checker->current_module = NULL;
     checker_pop_scope(checker);
 
     return checker->error_count == 0;

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -45,6 +45,9 @@ struct Checker {
     // Library modules accessible from the current function (NULL = use direct_imports)
     char** current_accessible_modules;
     int    current_accessible_modules_count;
+
+    // Current module being processed (NULL = main module)
+    const char* current_module;
 };
 
 void checker_init(Checker* checker);

--- a/w0/checker_util.c
+++ b/w0/checker_util.c
@@ -34,6 +34,7 @@ void checker_init(Checker* checker) {
     checker->direct_imports_count             = 0;
     checker->current_accessible_modules       = NULL;
     checker->current_accessible_modules_count = 0;
+    checker->current_module                   = NULL;
     types_init();
 }
 

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -840,60 +840,75 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit(gen, "\n");
 
     // Forward declarations for structs
-    for (int i = 0; i < ast->as.program.decls.count; i++) {
-        Node* decl = ast->as.program.decls.nodes[i];
-        if (decl->type == NODE_STRUCT_DECL) {
-            emit(gen, "typedef struct %s %s;\n", decl->as.struct_decl.name,
-                 decl->as.struct_decl.name);
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type == NODE_STRUCT_DECL) {
+                emit(gen, "typedef struct %s %s;\n", decl->as.struct_decl.name,
+                     decl->as.struct_decl.name);
+            }
         }
     }
     emit(gen, "\n");
 
     // Forward declarations for functions and methods
-    for (int i = 0; i < ast->as.program.decls.count; i++) {
-        Node* decl = ast->as.program.decls.nodes[i];
-        if (decl->type == NODE_FUNC_DECL) {
-            func_decl_node* fdn       = &decl->as.func_decl;
-            int             is_method = (fdn->receiver_type != NULL);
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type == NODE_FUNC_DECL) {
+                func_decl_node* fdn       = &decl->as.func_decl;
+                int             is_method = (fdn->receiver_type != NULL);
 
-            // Emit static for private functions (except main)
-            if (!fdn->is_public && strcmp(fdn->name, "main") != 0) {
-                emit(gen, "static ");
-            }
-
-            emit_type(gen, fdn->return_type);
-
-            if (is_method) {
-                emit(gen, " %s_%s(", fdn->receiver_type, fdn->name);
-                // Emit self parameter
-                if (fdn->receiver_is_const) {
-                    emit(gen, "const ");
+                // Emit static for private functions (except main)
+                if (!fdn->is_public && strcmp(fdn->name, "main") != 0) {
+                    emit(gen, "static ");
                 }
-                emit(gen, "%s* self", fdn->receiver_type);
-                if (fdn->params.count > 0) {
-                    emit(gen, ", ");
-                }
-            } else {
-                emit(gen, " %s(", fdn->name);
-            }
 
-            if (fdn->params.count == 0 && !is_method) {
-                emit(gen, "void");
-            } else {
-                for (int j = 0; j < fdn->params.count; j++) {
-                    if (j > 0)
+                emit_type(gen, fdn->return_type);
+
+                if (is_method) {
+                    emit(gen, " %s_%s(", fdn->receiver_type, fdn->name);
+                    // Emit self parameter
+                    if (fdn->receiver_is_const) {
+                        emit(gen, "const ");
+                    }
+                    emit(gen, "%s* self", fdn->receiver_type);
+                    if (fdn->params.count > 0) {
                         emit(gen, ", ");
-                    Node* param = fdn->params.nodes[j];
-                    emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+                    }
+                } else {
+                    emit(gen, " %s(", fdn->name);
                 }
+
+                if (fdn->params.count == 0 && !is_method) {
+                    emit(gen, "void");
+                } else {
+                    for (int j = 0; j < fdn->params.count; j++) {
+                        if (j > 0)
+                            emit(gen, ", ");
+                        Node* param = fdn->params.nodes[j];
+                        emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+                    }
+                }
+                emit(gen, ");\n");
             }
-            emit(gen, ");\n");
         }
     }
     emit(gen, "\n");
 
     // Emit all declarations
-    for (int i = 0; i < ast->as.program.decls.count; i++) {
-        emit_decl(gen, ast->as.program.decls.nodes[i]);
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            emit_decl(gen, mod->as.module.decls.nodes[i]);
+        }
     }
 }

--- a/w0/parse_import.c
+++ b/w0/parse_import.c
@@ -99,29 +99,6 @@ static void add_direct_import(Parser* parser, const char* module_name, size_t le
     parser->direct_imports[parser->direct_imports_count++] = name_copy;
 }
 
-// Set source_module on a declaration node
-static void set_decl_source_module(Node* decl, const char* source_module) {
-    if (!decl)
-        return;
-
-    switch (decl->type) {
-    case NODE_FUNC_DECL:
-        decl->as.func_decl.source_module = source_module ? strdup(source_module) : NULL;
-        break;
-    case NODE_STRUCT_DECL:
-        decl->as.struct_decl.source_module = source_module ? strdup(source_module) : NULL;
-        break;
-    case NODE_ENUM_DECL:
-        decl->as.enum_decl.source_module = source_module ? strdup(source_module) : NULL;
-        break;
-    case NODE_VAR_DECL:
-        decl->as.var_decl.source_module = source_module ? strdup(source_module) : NULL;
-        break;
-    default:
-        break;
-    }
-}
-
 // Check if file exists
 static int file_exists(const char* path) {
     FILE* f = fopen(path, "r");
@@ -182,7 +159,7 @@ static void build_import_path(Parser* parser, char* path, size_t path_size, cons
     snprintf(path, path_size, "lib/%.*s.w", (int)module_length, module_name);
 }
 
-int parse_import_stmt(Parser* parser, NodeList* decls) {
+int parse_import_stmt(Parser* parser, Node* program, Node* current_module) {
     // Expect identifier or string after 'import'
     Token       import_token = parser->current;
     const char* module_name;
@@ -291,61 +268,58 @@ int parse_import_stmt(Parser* parser, NodeList* decls) {
         return 0;
     }
 
-    // For library imports, track as direct import and set source_module
-    // For relative imports, declarations stay in the same module (source_module = NULL)
-    char* source_module_name = NULL;
+    // For library imports, track as direct import
     if (!is_relative) {
-        // Library import: track as direct import
         add_direct_import(parser, module_name, module_length);
-
-        // Create source module name string
-        source_module_name = malloc(module_length + 1);
-        if (source_module_name) {
-            memcpy(source_module_name, module_name, module_length);
-            source_module_name[module_length] = '\0';
-        }
     }
 
-    // Merge declarations from imported file into current program
+    // Handle the imported AST based on import type
     if (import_ast && import_ast->type == NODE_PROGRAM) {
-        for (int i = 0; i < import_ast->as.program.decls.count; i++) {
-            Node* decl = import_ast->as.program.decls.nodes[i];
-
-            // For library imports, set source_module on declarations that don't already have one
-            // (declarations that already have source_module are from transitive library imports)
-            if (!is_relative && decl) {
-                // Check if this declaration already has a source_module (from a transitive import)
-                char* existing_module = NULL;
-                switch (decl->type) {
-                case NODE_FUNC_DECL:
-                    existing_module = decl->as.func_decl.source_module;
-                    break;
-                case NODE_STRUCT_DECL:
-                    existing_module = decl->as.struct_decl.source_module;
-                    break;
-                case NODE_ENUM_DECL:
-                    existing_module = decl->as.enum_decl.source_module;
-                    break;
-                case NODE_VAR_DECL:
-                    existing_module = decl->as.var_decl.source_module;
-                    break;
-                default:
-                    break;
-                }
-
-                // Only set source_module if not already set (preserve transitive import info)
-                if (!existing_module) {
-                    set_decl_source_module(decl, source_module_name);
+        if (is_relative) {
+            // Relative import: merge only the "main" module's declarations into current_module
+            // Keep library modules (non-main) as separate modules in the program
+            for (int m = 0; m < import_ast->as.program.modules.count; m++) {
+                Node* imported_module = import_ast->as.program.modules.nodes[m];
+                if (imported_module && imported_module->type == NODE_MODULE) {
+                    if (strcmp(imported_module->as.module.name, "main") == 0) {
+                        // Merge main module's declarations into current module
+                        for (int i = 0; i < imported_module->as.module.decls.count; i++) {
+                            Node* decl = imported_module->as.module.decls.nodes[i];
+                            nodelist_push(&current_module->as.module.decls, decl);
+                        }
+                        // Clear to prevent double-free
+                        imported_module->as.module.decls.count = 0;
+                    } else {
+                        // Keep library modules as separate modules
+                        nodelist_push(&program->as.program.modules, imported_module);
+                    }
                 }
             }
-
-            nodelist_push(decls, decl);
+            // Clear to prevent double-free (only main was freed, others moved)
+            import_ast->as.program.modules.count = 0;
+        } else {
+            // Library import: move modules from imported AST to program
+            // The first module (main) of the library becomes a module named after the import
+            for (int m = 0; m < import_ast->as.program.modules.count; m++) {
+                Node* imported_module = import_ast->as.program.modules.nodes[m];
+                if (imported_module && imported_module->type == NODE_MODULE) {
+                    // Rename "main" module to the library name
+                    if (strcmp(imported_module->as.module.name, "main") == 0) {
+                        free(imported_module->as.module.name);
+                        imported_module->as.module.name = malloc(module_length + 1);
+                        if (imported_module->as.module.name) {
+                            memcpy(imported_module->as.module.name, module_name, module_length);
+                            imported_module->as.module.name[module_length] = '\0';
+                            imported_module->as.module.name_length         = (int)module_length;
+                        }
+                    }
+                    nodelist_push(&program->as.program.modules, imported_module);
+                }
+            }
+            // Clear to prevent double-free
+            import_ast->as.program.modules.count = 0;
         }
-        // Don't free the individual declaration nodes, just the program wrapper
-        import_ast->as.program.decls.count = 0; // Prevent double-free
     }
-
-    free(source_module_name);
 
     node_free(import_ast);
     return 1;

--- a/w0/parse_import.h
+++ b/w0/parse_import.h
@@ -4,6 +4,6 @@
 #include "ast.h"
 #include "parser.h"
 
-int parse_import_stmt(Parser* parser, NodeList* decls);
+int parse_import_stmt(Parser* parser, Node* program, Node* current_module);
 
 #endif

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1,6 +1,7 @@
 #include "parser.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "parse_enum_decl.h"
 #include "parse_extern_decls.h"
@@ -102,12 +103,24 @@ Node* parser_parse(Parser* parser) {
         parse_error(parser, "Out of memory");
         return NULL;
     }
-    nodelist_init(&program->as.program.decls);
+    nodelist_init(&program->as.program.modules);
+
+    // Create main module for the entry file
+    Node* main_module = node_new(NODE_MODULE, 1, 1);
+    if (!main_module) {
+        parse_error(parser, "Out of memory");
+        node_free(program);
+        return NULL;
+    }
+    main_module->as.module.name        = strdup("main");
+    main_module->as.module.name_length = 4;
+    nodelist_init(&main_module->as.module.decls);
+    nodelist_push(&program->as.program.modules, main_module);
 
     while (!check_token(parser, TOK_EOF)) {
         // Handle import statements
         if (match_token(parser, TOK_IMPORT)) {
-            if (!parse_import_stmt(parser, &program->as.program.decls)) {
+            if (!parse_import_stmt(parser, program, main_module)) {
                 // Import failed, but continue parsing
                 if (parser->panic_mode)
                     synchronize(parser);
@@ -117,7 +130,7 @@ Node* parser_parse(Parser* parser) {
 
         Node* decl = parse_declaration(parser);
         if (decl) {
-            nodelist_push(&program->as.program.decls, decl);
+            nodelist_push(&main_module->as.module.decls, decl);
         }
         if (parser->panic_mode)
             synchronize(parser);

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -30,8 +30,14 @@ void print_ast(Node* node, int depth) {
     switch (node->type) {
     case NODE_PROGRAM:
         printf("Program\n");
-        for (int i = 0; i < node->as.program.decls.count; i++) {
-            print_ast(node->as.program.decls.nodes[i], depth + 1);
+        for (int i = 0; i < node->as.program.modules.count; i++) {
+            print_ast(node->as.program.modules.nodes[i], depth + 1);
+        }
+        break;
+    case NODE_MODULE:
+        printf("Module: %.*s\n", node->as.module.name_length, node->as.module.name);
+        for (int i = 0; i < node->as.module.decls.count; i++) {
+            print_ast(node->as.module.decls.nodes[i], depth + 1);
         }
         break;
     case NODE_EXTERN_MODULE:


### PR DESCRIPTION
## Summary
- Add `NODE_MODULE` to AST hierarchy, changing structure from `Program -> {decls}` to `Program -> {modules} -> {decls}`
- Entry file becomes the `main` module, library imports become separate modules, relative imports merge into importing module
- Update parser, checker, codegen, and print_ast to handle the new module structure

## Test plan
- [x] `make` builds successfully
- [x] `make test` passes all 38 tests
- [x] `bin/w0 --ast test/hello.w` shows separate `main` and `std` modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)