### PR TITLE
Require module qualification for library imports

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -39,8 +39,8 @@ This document describes the grammar of the Whist language in BNF (Backus-Naur Fo
 
 Import statements load declarations from external Whist source files. There are two forms:
 
-- **Module import:** `import std;` resolves the module name from the `lib/` directory (e.g., `lib/std.w`).
-- **Relative import:** `import "./path/to/file.w";` or `import "../file.w";` resolves the path relative to the importing file's directory. String imports must start with `./` or `../`.
+- **Module import:** `import std;` resolves the module name from the `lib/` directory (e.g., `lib/std.w`). Symbols from module imports must be accessed with module qualification: `std.print("hello")`. Unqualified access is an error.
+- **Relative import:** `import "./path/to/file.w";` or `import "../file.w";` resolves the path relative to the importing file's directory. String imports must start with `./` or `../`. Symbols from relative imports are merged into the current module and accessed without qualification.
 
 ### Function Declaration
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -69,6 +69,7 @@ void node_free(Node* node) {
         node_free(node->as.member.object);
         free(node->as.member.name);
         free(node->as.member.struct_name);
+        free(node->as.member.module_name);
         break;
     case NODE_ASSIGN:
         node_free(node->as.assign.target);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -149,6 +149,7 @@ struct Node {
             int   length;
             int   is_ref;      // Set by checker: 1 if object is a struct reference
             char* struct_name; // Set by checker if this is a method access (NULL otherwise)
+            char* module_name; // Set by checker for module-qualified access (e.g., "std")
         } member;
 
         // Assignment

--- a/w0/check_expression.c
+++ b/w0/check_expression.c
@@ -257,6 +257,22 @@ Type* check_expression(Checker* checker, Node* node) {
     }
 
     case NODE_MEMBER: {
+        // Check for module-qualified access first (e.g., std.print)
+        if (node->as.member.object->type == NODE_IDENT) {
+            const char* name = node->as.member.object->as.ident.name;
+            if (is_imported_module(checker, name)) {
+                Symbol* sym = checker_lookup_in_module(checker, name, node->as.member.name);
+                if (!sym) {
+                    check_error(checker, node->line, node->column,
+                                "Module '%s' has no public symbol '%s'", name,
+                                node->as.member.name);
+                    return type_error;
+                }
+                node->as.member.module_name = strdup(name);
+                return sym->type;
+            }
+        }
+
         Type* object = check_expression(checker, node->as.member.object);
 
         if (object->kind == TYPE_ERROR)

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -62,6 +62,44 @@ static int is_module_accessible(Checker* checker, const char* source_module) {
     return 0;
 }
 
+// Check if a name is a directly imported library module
+int is_imported_module(Checker* checker, const char* name) {
+    // Use current function's accessible modules if set, otherwise use global direct_imports
+    char** modules = checker->current_accessible_modules;
+    int    count   = checker->current_accessible_modules_count;
+
+    if (!modules) {
+        modules = checker->direct_imports;
+        count   = checker->direct_imports_count;
+    }
+
+    for (int i = 0; i < count; i++) {
+        if (strcmp(modules[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+// Look up a symbol from a specific module (for module-qualified access)
+Symbol* checker_lookup_in_module(Checker* checker, const char* module_name,
+                                 const char* symbol_name) {
+    for (Scope* scope = checker->scope; scope; scope = scope->parent) {
+        unsigned int index = hash_string(symbol_name) % scope->size;
+        for (Symbol* sym = scope->symbols[index]; sym; sym = sym->next) {
+            if (strcmp(sym->name, symbol_name) == 0 && sym->source_module &&
+                strcmp(sym->source_module, module_name) == 0) {
+                // Must be public for module-qualified access
+                if (!sym->is_public) {
+                    return NULL;
+                }
+                return sym;
+            }
+        }
+    }
+    return NULL;
+}
+
 Symbol* checker_lookup(Checker* checker, const char* name) {
     for (Scope* scope = checker->scope; scope; scope = scope->parent) {
         unsigned int index = hash_string(name) % scope->size;
@@ -71,13 +109,13 @@ Symbol* checker_lookup(Checker* checker, const char* name) {
                 if (!is_module_accessible(checker, sym->source_module)) {
                     continue; // Symbol exists but not accessible from this module
                 }
-                // Symbols from library imports must be public to be accessible
-                // Exception: private symbols are accessible if we're in the same module
+                // Symbols from library imports require module qualification
+                // Skip them here - they must be accessed via module.symbol syntax
                 int same_module = (sym->source_module == NULL && checker->current_module == NULL) ||
                                   (sym->source_module && checker->current_module &&
                                    strcmp(sym->source_module, checker->current_module) == 0);
-                if (sym->source_module && !sym->is_public && !same_module) {
-                    continue; // Private symbol from library import
+                if (sym->source_module && !same_module) {
+                    continue; // Library symbol - require module qualification
                 }
                 return sym;
             }

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -65,4 +65,9 @@ Symbol* checker_lookup(Checker* checker, const char* name);
 Symbol* checker_lookup_any(Checker* checker, const char* name); // Ignores module visibility
 Symbol* checker_lookup_local(Checker* checker, const char* name);
 
+// Module-qualified access
+int     is_imported_module(Checker* checker, const char* name);
+Symbol* checker_lookup_in_module(Checker* checker, const char* module_name,
+                                 const char* symbol_name);
+
 #endif

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -324,8 +324,18 @@ static void emit_expr(CodeGen* gen, Node* node) {
 
     case NODE_CALL: {
         Node* func = node->as.call.func;
-        // Check if this is a method call (func is a member access with struct_name set)
-        if (func->type == NODE_MEMBER && func->as.member.struct_name != NULL) {
+        // Check if this is a module-qualified call (e.g., std.print())
+        if (func->type == NODE_MEMBER && func->as.member.module_name != NULL) {
+            // Module-qualified call: emit module_func(args...)
+            emit(gen, "%s_%.*s(", func->as.member.module_name, func->as.member.length,
+                 func->as.member.name);
+            for (int i = 0; i < node->as.call.args.count; i++) {
+                if (i > 0)
+                    emit(gen, ", ");
+                emit_expr(gen, node->as.call.args.nodes[i]);
+            }
+            emit(gen, ")");
+        } else if (func->type == NODE_MEMBER && func->as.member.struct_name != NULL) {
             // Method call: emit StructName_method(obj, args...)
             // With struct references, objects are already pointers
             emit(gen, "%s_%.*s(", func->as.member.struct_name, func->as.member.length,
@@ -711,9 +721,12 @@ static void emit_decl(CodeGen* gen, Node* node) {
         // Return type
         emit_type(gen, node->as.func_decl.return_type);
 
-        // Function name (mangled for methods)
+        // Function name (mangled for methods and library functions)
         if (is_method) {
             emit(gen, " %s_%s(", node->as.func_decl.receiver_type, node->as.func_decl.name);
+        } else if (gen->current_module != NULL) {
+            // Library function: emit with module prefix
+            emit(gen, " %s_%s(", gen->current_module, node->as.func_decl.name);
         } else {
             emit(gen, " %s(", node->as.func_decl.name);
         }
@@ -859,6 +872,11 @@ void codegen_emit(CodeGen* gen, Node* ast) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
             continue;
+        // Determine if this is a library module (not "main")
+        const char* module_prefix = NULL;
+        if (strcmp(mod->as.module.name, "main") != 0) {
+            module_prefix = mod->as.module.name;
+        }
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             if (decl->type == NODE_FUNC_DECL) {
@@ -882,6 +900,9 @@ void codegen_emit(CodeGen* gen, Node* ast) {
                     if (fdn->params.count > 0) {
                         emit(gen, ", ");
                     }
+                } else if (module_prefix != NULL) {
+                    // Library function: emit with module prefix
+                    emit(gen, " %s_%s(", module_prefix, fdn->name);
                 } else {
                     emit(gen, " %s(", fdn->name);
                 }
@@ -907,8 +928,11 @@ void codegen_emit(CodeGen* gen, Node* ast) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
             continue;
+        // Set current module context (NULL for "main", module name for library imports)
+        gen->current_module = strcmp(mod->as.module.name, "main") == 0 ? NULL : mod->as.module.name;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             emit_decl(gen, mod->as.module.decls.nodes[i]);
         }
     }
+    gen->current_module = NULL;
 }

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -12,10 +12,11 @@ typedef struct {
     int   indent;
     int   temp_count; // For generating temporary variables
     // Defer support
-    Node** defer_stack;         // Stack of deferred statements
-    int    defer_count;         // Number of deferred statements
-    int    defer_capacity;      // Capacity of defer stack
-    Node*  current_return_type; // Return type of current function (for __ret variable)
+    Node**      defer_stack;         // Stack of deferred statements
+    int         defer_count;         // Number of deferred statements
+    int         defer_capacity;      // Capacity of defer stack
+    Node*       current_return_type; // Return type of current function (for __ret variable)
+    const char* current_module;      // Current module name (NULL for "main")
 } CodeGen;
 
 void codegen_init(CodeGen* gen, FILE* out);

--- a/w0/test/error_private_import.w
+++ b/w0/test/error_private_import.w
@@ -1,14 +1,14 @@
-// Test that private symbols from library imports are not accessible
-// EXPECT_ERROR: Undefined identifier '_internal_std'
+// Test that private symbols from library imports are not accessible via module qualification
+// EXPECT_ERROR: Module 'std' has no public symbol '_internal_std'
 
 import std;
 
 func main(): i32 {
     // This should work - abs_i64 is public in std
-    var a = abs_i64(-5);
+    var a = std.abs_i64(-5);
 
     // This should FAIL - _internal_std is private in std
-    var b = _internal_std();
+    var b = std._internal_std();
 
     return 0;
 }

--- a/w0/test/hello.w
+++ b/w0/test/hello.w
@@ -2,6 +2,6 @@
 import std;
 
 func main(): i32 {
-    print("Hello, world!\n");
+    std.print("Hello, world!\n");
     return 0;
 }

--- a/w0/test/import_parent.w
+++ b/w0/test/import_parent.w
@@ -7,10 +7,10 @@ func main(): i32 {
     var a = quadruple(3);
 
     if (a != 12) {
-        print("FAIL: import_parent.w\n");
+        std.print("FAIL: import_parent.w\n");
         return 1;
     }
 
-    print("PASS: import_parent.w\n");
+    std.print("PASS: import_parent.w\n");
     return 0;
 }

--- a/w0/test/import_relative.w
+++ b/w0/test/import_relative.w
@@ -8,10 +8,10 @@ func main(): i32 {
     var b = triple(4);
 
     if (a != 10 || b != 12) {
-        print("FAIL: import_relative.w\n");
+        std.print("FAIL: import_relative.w\n");
         return 1;
     }
 
-    print("PASS: import_relative.w\n");
+    std.print("PASS: import_relative.w\n");
     return 0;
 }

--- a/w0/test/import_std.w
+++ b/w0/test/import_std.w
@@ -1,17 +1,17 @@
-// Test importing the std library
+// Test importing the std library with module qualification
 
 import std;
 
 func main(): i32 {
-    var a = abs_i64(-42);
-    var b = max_i64(10, 20);
-    var c = min_i64(5, 3);
+    var a = std.abs_i64(-42);
+    var b = std.max_i64(10, 20);
+    var c = std.min_i64(5, 3);
 
     if (a != 42 || b != 20 || c != 3) {
-        print("FAIL: import_std.w\n");
+        std.print("FAIL: import_std.w\n");
         return 1;
     }
 
-    print("PASS: import_std.w\n");
+    std.print("PASS: import_std.w\n");
     return 0;
 }

--- a/w0/test/module_visibility.w
+++ b/w0/test/module_visibility.w
@@ -1,18 +1,18 @@
 // Test that relative imports work but library symbols aren't re-exported
-// double_abs uses abs_i64 internally, but we can't call abs_i64 directly
+// double_abs uses std.abs_i64 internally, but we can't call abs_i64 directly
 
 import "./util/std_helper.w";
-import std;  // Need to import std ourselves to use print
+import std;  // Need to import std ourselves to use std.print
 
 func main(): i32 {
     // This should work - double_abs is defined in std_helper
     var a = double_abs(-5);
 
     if (a != 10) {
-        print("FAIL: module_visibility.w - double_abs\n");
+        std.print("FAIL: module_visibility.w - double_abs\n");
         return 1;
     }
 
-    print("PASS: module_visibility.w\n");
+    std.print("PASS: module_visibility.w\n");
     return 0;
 }

--- a/w0/test/util/std_helper.w
+++ b/w0/test/util/std_helper.w
@@ -4,5 +4,5 @@ import std;
 
 // Expose a function that uses std internally
 func double_abs(x: i64): i64 {
-    return abs_i64(x) * 2;
+    return std.abs_i64(x) * 2;
 }


### PR DESCRIPTION
## Summary
- Library imports (`import std;`) now require module-qualified access: `std.print()` instead of `print()`
- Unqualified access to library symbols produces "Undefined identifier" error
- Relative imports (`import "./file.w"`) continue to merge into current module without qualification

## Test plan
- [x] `make test` passes (38/38 tests)
- [x] Verified `std.print()` compiles and runs correctly
- [x] Verified unqualified `print()` produces expected error

🤖 Generated with [Claude Code](https://claude.com/claude-code)