### PR TITLE
feat: remove increment/decrement operators from language

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -181,7 +181,7 @@ Import statements load declarations from external Whist source files. There are 
 <unary-expr> ::= <unary-op> <unary-expr>
               | <postfix-expr>
 
-<unary-op> ::= '!' | '-' | '~' | '&' | '*' | '++' | '--'
+<unary-op> ::= '!' | '-' | '~' | '&' | '*'
 ```
 
 ### Postfix Expressions
@@ -193,8 +193,6 @@ Import statements load declarations from external Whist source files. There are 
               | '[' <expression> ']'           (* index *)
               | '.' <identifier>               (* member access *)
               | '->' <identifier>              (* pointer member access *)
-              | '++'                           (* postfix increment *)
-              | '--'                           (* postfix decrement *)
 
 <arg-list> ::= <expression> { ',' <expression> }
 ```
@@ -300,7 +298,7 @@ self     struct   true        var       while
 =     <     >
 +=    -=    *=    /=    %=    &=    |=    ^=
 ==    !=    <=    >=    &&    ||    <<    >>    <<=   >>=
-++    --    ->    ::    ..
+->    ::    ..
 (     )     {     }     [     ]     ;     :     ,     .
 ```
 
@@ -331,5 +329,5 @@ From lowest to highest precedence:
 | 9          | `<<` `>>`                                                | Left          |
 | 10         | `+` `-`                                                  | Left          |
 | 11         | `*` `/` `%`                                              | Left          |
-| 12         | `!` `-` `~` `&` `*` `++` `--` (unary prefix)             | Right         |
-| 13         | `()` `[]` `.` `->` `++` `--` (postfix)                   | Left          |
+| 12         | `!` `-` `~` `&` `*` (unary prefix)                       | Right         |
+| 13         | `()` `[]` `.` `->` (postfix)                             | Left          |

--- a/w0/CLAUDE.md
+++ b/w0/CLAUDE.md
@@ -32,7 +32,7 @@ bin/w0 program.w | cc -x c -o program -
 
 Types: `void`, `bool`, `i8`-`i64`, `u8`-`u64`, `f32`, `f64`, `char`, `string`, `*T`, `[n]T`, `struct`, `enum`
 
-Operators: `+ - * / %`, `== != < > <= >=`, `&& || !`, `& | ^ ~ << >>`, `++ --`, `. ->`
+Operators: `+ - * / %`, `== != < > <= >=`, `&& || !`, `& | ^ ~ << >>`, `. ->`
 
 ### Imports
 

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -137,7 +137,6 @@ struct Node {
         struct {
             TokenType op;
             Node*     operand;
-            int       postfix; // 1 for postfix ++/--, 0 for prefix
         } unary;
 
         // Function call

--- a/w0/check_expression.c
+++ b/w0/check_expression.c
@@ -182,15 +182,6 @@ Type* check_expression(Checker* checker, Node* node) {
             }
             return operand;
 
-        case TOK_PLUS_PLUS:
-        case TOK_MINUS_MINUS:
-            if (!type_is_integer(operand)) {
-                check_error(checker, node->line, node->column,
-                            "Increment/decrement requires integer");
-                return type_error;
-            }
-            return operand;
-
         default:
             check_error(checker, node->line, node->column, "Unknown unary operator");
             return type_error;

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -327,10 +327,6 @@ static const char* unary_op_str(TokenType op) {
         return "&";
     case TOK_STAR:
         return "*";
-    case TOK_PLUS_PLUS:
-        return "++";
-    case TOK_MINUS_MINUS:
-        return "--";
     default:
         return "?";
     }
@@ -449,15 +445,9 @@ static void emit_expr(CodeGen* gen, Node* node) {
         break;
 
     case NODE_UNARY:
-        if (node->as.unary.postfix) {
-            emit(gen, "(");
-            emit_expr(gen, node->as.unary.operand);
-            emit(gen, "%s)", unary_op_str(node->as.unary.op));
-        } else {
-            emit(gen, "(%s", unary_op_str(node->as.unary.op));
-            emit_expr(gen, node->as.unary.operand);
-            emit(gen, ")");
-        }
+        emit(gen, "(%s", unary_op_str(node->as.unary.op));
+        emit_expr(gen, node->as.unary.operand);
+        emit(gen, ")");
         break;
 
     case NODE_CALL: {

--- a/w0/lexer.c
+++ b/w0/lexer.c
@@ -313,14 +313,12 @@ Token lexer_next(Lexer* lexer) {
     case '^':
         return make_token(lexer, match(lexer, '=') ? TOK_CARET_EQ : TOK_CARET);
     case '+':
-        if (match(lexer, '+'))
-            return make_token(lexer, TOK_PLUS_PLUS);
         if (match(lexer, '='))
             return make_token(lexer, TOK_PLUS_EQ);
         return make_token(lexer, TOK_PLUS);
     case '-':
-        if (match(lexer, '-'))
-            return make_token(lexer, TOK_MINUS_MINUS);
+        if (match(lexer, '>'))
+            return make_token(lexer, TOK_ARROW);
         if (match(lexer, '='))
             return make_token(lexer, TOK_MINUS_EQ);
         return make_token(lexer, TOK_MINUS);
@@ -485,10 +483,6 @@ const char* token_type_name(TokenType type) {
         return "LT_LT_EQ";
     case TOK_GT_GT_EQ:
         return "GT_GT_EQ";
-    case TOK_PLUS_PLUS:
-        return "PLUS_PLUS";
-    case TOK_MINUS_MINUS:
-        return "MINUS_MINUS";
     case TOK_ARROW:
         return "ARROW";
     case TOK_LPAREN:

--- a/w0/lexer.h
+++ b/w0/lexer.h
@@ -56,27 +56,25 @@ typedef enum {
     TOK_GT,      // >
 
     // Multi-char operators
-    TOK_PLUS_EQ,     // +=
-    TOK_MINUS_EQ,    // -=
-    TOK_STAR_EQ,     // *=
-    TOK_SLASH_EQ,    // /=
-    TOK_PERCENT_EQ,  // %=
-    TOK_AMP_EQ,      // &=
-    TOK_PIPE_EQ,     // |=
-    TOK_CARET_EQ,    // ^=
-    TOK_EQ_EQ,       // ==
-    TOK_BANG_EQ,     // !=
-    TOK_LT_EQ,       // <=
-    TOK_GT_EQ,       // >=
-    TOK_AMP_AMP,     // &&
-    TOK_PIPE_PIPE,   // ||
-    TOK_LT_LT,       // <<
-    TOK_GT_GT,       // >>
-    TOK_LT_LT_EQ,    // <<=
-    TOK_GT_GT_EQ,    // >>=
-    TOK_PLUS_PLUS,   // ++
-    TOK_MINUS_MINUS, // --
-    TOK_ARROW,       // ->
+    TOK_PLUS_EQ,    // +=
+    TOK_MINUS_EQ,   // -=
+    TOK_STAR_EQ,    // *=
+    TOK_SLASH_EQ,   // /=
+    TOK_PERCENT_EQ, // %=
+    TOK_AMP_EQ,     // &=
+    TOK_PIPE_EQ,    // |=
+    TOK_CARET_EQ,   // ^=
+    TOK_EQ_EQ,      // ==
+    TOK_BANG_EQ,    // !=
+    TOK_LT_EQ,      // <=
+    TOK_GT_EQ,      // >=
+    TOK_AMP_AMP,    // &&
+    TOK_PIPE_PIPE,  // ||
+    TOK_LT_LT,      // <<
+    TOK_GT_GT,      // >>
+    TOK_LT_LT_EQ,   // <<=
+    TOK_GT_GT_EQ,   // >>=
+    TOK_ARROW,      // ->
 
     // Punctuation
     TOK_LPAREN,      // (

--- a/w0/parse_expression.c
+++ b/w0/parse_expression.c
@@ -57,18 +57,6 @@ static Node* parse_postfix(Parser* parser) {
             member->as.member.length = name.length;
             member->as.member.is_ref = 0; // Set by checker
             expr                     = member;
-        } else if (match_token(parser, TOK_PLUS_PLUS) || match_token(parser, TOK_MINUS_MINUS)) {
-            // Postfix increment/decrement
-            TokenType op    = parser->previous.type;
-            Node*     unary = node_new(NODE_UNARY, expr->line, expr->column);
-            if (!unary) {
-                parse_error(parser, "Out of memory");
-                return NULL;
-            }
-            unary->as.unary.op      = op;
-            unary->as.unary.operand = expr;
-            unary->as.unary.postfix = 1;
-            expr                    = unary;
         } else {
             break;
         }
@@ -79,8 +67,7 @@ static Node* parse_postfix(Parser* parser) {
 
 static Node* parse_unary(Parser* parser) {
     if (match_token(parser, TOK_BANG) || match_token(parser, TOK_MINUS) ||
-        match_token(parser, TOK_TILDE) || match_token(parser, TOK_PLUS_PLUS) ||
-        match_token(parser, TOK_MINUS_MINUS)) {
+        match_token(parser, TOK_TILDE)) {
         Token op      = parser->previous;
         Node* operand = parse_unary(parser);
         Node* node    = node_new(NODE_UNARY, op.line, op.column);
@@ -90,7 +77,6 @@ static Node* parse_unary(Parser* parser) {
         }
         node->as.unary.op      = op.type;
         node->as.unary.operand = operand;
-        node->as.unary.postfix = 0;
         return node;
     }
     return parse_postfix(parser);

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -219,8 +219,7 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_UNARY:
-        printf("Unary: %s%s\n", token_type_name(node->as.unary.op),
-               node->as.unary.postfix ? " (postfix)" : "");
+        printf("Unary: %s\n", token_type_name(node->as.unary.op));
         print_ast(node->as.unary.operand, depth + 1);
         break;
 

--- a/w0/test/control_flow.w
+++ b/w0/test/control_flow.w
@@ -16,12 +16,12 @@ func main(): i32 {
     }
 
     // For loop
-    for (var i = 0; i < 5; i++) {
+    for (var i = 0; i < 5; i += 1) {
         x = x + i;
     }
 
     // Break and continue
-    for (var j = 0; j < 100; j++) {
+    for (var j = 0; j < 100; j += 1) {
         if (j == 50) {
             break;
         }

--- a/w0/test/operators.w
+++ b/w0/test/operators.w
@@ -38,11 +38,5 @@ func main(): i32 {
     a *= 3;
     a /= 2;
 
-    // Increment/decrement
-    a++;
-    b--;
-    ++a;
-    --b;
-
     return a;
 }


### PR DESCRIPTION
## Summary
- Remove prefix and postfix `++` and `--` operators from Whist
- Users should use compound assignment (`x += 1`, `x -= 1`) instead
- Updates lexer, parser, type checker, code generator, and documentation

## Test plan
- [x] All 41 existing tests pass
- [x] Test files updated to use `i += 1` instead of `i++` in for loops
- [x] Verified compiler builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)