### PR TITLE
feat: add nested tuple destructuring support

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -77,10 +77,15 @@ Import statements load declarations from external Whist source files. There are 
 
 ```bnf
 <var-decl> ::= ( 'var' | 'const' ) <identifier> [ ':' <type> ] [ '=' <expression> ] ';'
-            | 'var' '(' <identifier> { ',' <identifier> } ')' '=' <expression> ';'
+            | 'var' <destruct-pattern> '=' <expression> ';'
+
+<destruct-pattern> ::= '(' <destruct-element> ',' <destruct-element> { ',' <destruct-element> } ')'
+
+<destruct-element> ::= <identifier>
+                    | <destruct-pattern>
 ```
 
-**Tuple destructuring:** `var (a, b) = expr;` unpacks a tuple into individual variables. The number of identifiers must match the tuple's arity.
+**Tuple destructuring:** `var (a, b) = expr;` unpacks a tuple into individual variables. The number of elements must match the tuple's arity. Nested patterns are supported: `var (x, (y, z)) = (1, (2, 3));` unpacks nested tuples.
 
 ---
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -1,6 +1,58 @@
 #include "ast.h"
 
 #include <stdlib.h>
+#include <string.h>
+
+// ============================================================================
+// DestructPattern functions
+// ============================================================================
+
+DestructPattern* pattern_new_ident(const char* name, int length) {
+    DestructPattern* pattern = calloc(1, sizeof(DestructPattern));
+    pattern->kind            = PATTERN_IDENT;
+    pattern->as.ident.name   = malloc(length + 1);
+    memcpy(pattern->as.ident.name, name, length);
+    pattern->as.ident.name[length] = '\0';
+    pattern->as.ident.name_length  = length;
+    pattern->resolved_type         = NULL;
+    return pattern;
+}
+
+DestructPattern* pattern_new_tuple(int capacity) {
+    DestructPattern* pattern   = calloc(1, sizeof(DestructPattern));
+    pattern->kind              = PATTERN_TUPLE;
+    pattern->as.tuple.elements = malloc(capacity * sizeof(DestructPattern*));
+    pattern->as.tuple.count    = 0;
+    pattern->resolved_type     = NULL;
+    return pattern;
+}
+
+void pattern_tuple_push(DestructPattern* pattern, DestructPattern* elem) {
+    // Note: caller must ensure capacity; for simplicity we just store
+    pattern->as.tuple.elements[pattern->as.tuple.count++] = elem;
+}
+
+void pattern_free(DestructPattern* pattern) {
+    if (!pattern)
+        return;
+
+    switch (pattern->kind) {
+    case PATTERN_IDENT:
+        free(pattern->as.ident.name);
+        break;
+    case PATTERN_TUPLE:
+        for (int i = 0; i < pattern->as.tuple.count; i++) {
+            pattern_free(pattern->as.tuple.elements[i]);
+        }
+        free(pattern->as.tuple.elements);
+        break;
+    }
+    free(pattern);
+}
+
+// ============================================================================
+// Node functions
+// ============================================================================
 
 Node* node_new(NodeType type, int line, int column) {
     Node* node   = calloc(1, sizeof(Node));
@@ -89,14 +141,8 @@ void node_free(Node* node) {
         free(node->as.var_decl.name);
         node_free(node->as.var_decl.type);
         node_free(node->as.var_decl.init);
-        // Free destructuring names if present
-        if (node->as.var_decl.destruct_names) {
-            for (int i = 0; i < node->as.var_decl.destruct_count; i++) {
-                free(node->as.var_decl.destruct_names[i]);
-            }
-            free(node->as.var_decl.destruct_names);
-            free(node->as.var_decl.destruct_name_lens);
-        }
+        // Free destructuring pattern if present
+        pattern_free(node->as.var_decl.destruct_pattern);
         break;
     case NODE_BLOCK:
         nodelist_free(&node->as.block.stmts);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -3,6 +3,37 @@
 
 #include "lexer.h"
 
+// Forward declaration for destructuring patterns
+typedef struct DestructPattern DestructPattern;
+
+// Destructuring pattern kinds
+typedef enum {
+    PATTERN_IDENT, // Single identifier: x
+    PATTERN_TUPLE  // Nested tuple: (a, b) or (a, (b, c))
+} PatternKind;
+
+// Recursive destructuring pattern for tuple unpacking
+struct DestructPattern {
+    PatternKind kind;
+    union {
+        struct {
+            char* name;
+            int   name_length;
+        } ident;
+        struct {
+            DestructPattern** elements;
+            int               count;
+        } tuple;
+    } as;
+    void* resolved_type; // Type* set by checker (cast to void* to avoid dep)
+};
+
+// Pattern memory management
+DestructPattern* pattern_new_ident(const char* name, int length);
+DestructPattern* pattern_new_tuple(int capacity);
+void             pattern_tuple_push(DestructPattern* pattern, DestructPattern* elem);
+void             pattern_free(DestructPattern* pattern);
+
 typedef enum {
     // Expressions
     NODE_INT_LIT,
@@ -89,11 +120,8 @@ typedef struct {
     int   is_const;
     char* source_module; // NULL = same module, else external module name
 
-    // Destructuring support: var (a, b) = tuple;
-    char** destruct_names; // NULL if not destructuring
-    int*   destruct_name_lens;
-    int    destruct_count;      // 0 if not destructuring
-    void*  destruct_tuple_type; // Type* set by checker for codegen (cast to void* to avoid dep)
+    // Destructuring support: var (a, b) = tuple; or var (a, (b, c)) = nested;
+    DestructPattern* destruct_pattern; // NULL if not destructuring
 } var_decl_node;
 
 struct Node {

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -14,6 +14,14 @@ static Type* check_expression(Checker* checker, Node* node);
 static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
 static Type* resolve_type(Checker* checker, Node* type_node);
 
+// Forward declarations for destructuring pattern checking
+static int  check_destruct_pattern_redefinitions(Checker* checker, DestructPattern* pattern,
+                                                 int line, int col);
+static int  check_destruct_pattern_against_type(Checker* checker, DestructPattern* pattern,
+                                                Type* type, int line, int col);
+static void define_destruct_pattern_vars(Checker* checker, DestructPattern* pattern, Type* type,
+                                         int is_const, int is_public);
+
 // =============================================================================
 // Utility functions
 // =============================================================================
@@ -821,6 +829,118 @@ static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type) 
 }
 
 // =============================================================================
+// Destructuring pattern checking
+// =============================================================================
+
+// Check for redefinitions in a destructuring pattern (recursive)
+// Returns 1 if error found, 0 otherwise
+static int check_destruct_pattern_redefinitions(Checker* checker, DestructPattern* pattern,
+                                                int line, int col) {
+    if (!pattern)
+        return 0;
+
+    switch (pattern->kind) {
+    case PATTERN_IDENT:
+        if (checker_lookup_local(checker, pattern->as.ident.name)) {
+            check_error(checker, line, col, "Redefinition of '%s'", pattern->as.ident.name);
+            return 1;
+        }
+        return 0;
+
+    case PATTERN_TUPLE:
+        for (int i = 0; i < pattern->as.tuple.count; i++) {
+            if (check_destruct_pattern_redefinitions(checker, pattern->as.tuple.elements[i], line,
+                                                     col)) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    return 0;
+}
+
+// Check that a destructuring pattern matches a type (recursive)
+// Also sets resolved_type on each pattern node
+// Returns 1 if error found, 0 otherwise
+static int check_destruct_pattern_against_type(Checker* checker, DestructPattern* pattern,
+                                               Type* type, int line, int col) {
+    if (!pattern || !type)
+        return 1;
+
+    pattern->resolved_type = type;
+
+    switch (pattern->kind) {
+    case PATTERN_IDENT:
+        // Any type is valid for an identifier pattern
+        return 0;
+
+    case PATTERN_TUPLE:
+        // Pattern must match a tuple type
+        if (type->kind != TYPE_TUPLE && type->kind != TYPE_ERROR) {
+            check_error(checker, line, col, "Nested pattern requires a tuple, got '%s'",
+                        type_name(type));
+            return 1;
+        }
+
+        if (type->kind == TYPE_ERROR) {
+            // Propagate error type to all children
+            for (int i = 0; i < pattern->as.tuple.count; i++) {
+                check_destruct_pattern_against_type(checker, pattern->as.tuple.elements[i],
+                                                    type_error, line, col);
+            }
+            return 0;
+        }
+
+        // Check arity
+        if (type->as.tuple.elem_count != pattern->as.tuple.count) {
+            check_error(checker, line, col,
+                        "Nested pattern has %d elements, but tuple has %d elements",
+                        pattern->as.tuple.count, type->as.tuple.elem_count);
+            return 1;
+        }
+
+        // Recursively check each element
+        for (int i = 0; i < pattern->as.tuple.count; i++) {
+            if (check_destruct_pattern_against_type(checker, pattern->as.tuple.elements[i],
+                                                    type->as.tuple.elem_types[i], line, col)) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    return 0;
+}
+
+// Define variables for all identifiers in a destructuring pattern (recursive)
+static void define_destruct_pattern_vars(Checker* checker, DestructPattern* pattern, Type* type,
+                                         int is_const, int is_public) {
+    if (!pattern)
+        return;
+
+    switch (pattern->kind) {
+    case PATTERN_IDENT:
+        checker_define(checker, pattern->as.ident.name, SYM_VAR, type, is_const, is_public,
+                       checker->current_module);
+        break;
+
+    case PATTERN_TUPLE:
+        if (type->kind == TYPE_TUPLE) {
+            for (int i = 0; i < pattern->as.tuple.count; i++) {
+                define_destruct_pattern_vars(checker, pattern->as.tuple.elements[i],
+                                             type->as.tuple.elem_types[i], is_const, is_public);
+            }
+        } else {
+            // Error type - propagate to all children
+            for (int i = 0; i < pattern->as.tuple.count; i++) {
+                define_destruct_pattern_vars(checker, pattern->as.tuple.elements[i], type_error,
+                                             is_const, is_public);
+            }
+        }
+        break;
+    }
+}
+
+// =============================================================================
 // Statement checking
 // =============================================================================
 
@@ -835,49 +955,27 @@ static void check_statement(Checker* checker, Node* node) {
 
     case NODE_VAR_DECL: {
         // Check if this is a destructuring declaration
-        if (node->as.var_decl.destruct_count > 0) {
-            // Destructuring: var (a, b) = tuple;
+        DestructPattern* pattern = node->as.var_decl.destruct_pattern;
+        if (pattern) {
+            // Destructuring: var (a, b) = tuple; or var (a, (b, c)) = nested;
+
             // Check for redefinitions
-            for (int i = 0; i < node->as.var_decl.destruct_count; i++) {
-                if (checker_lookup_local(checker, node->as.var_decl.destruct_names[i])) {
-                    check_error(checker, node->line, node->column, "Redefinition of '%s'",
-                                node->as.var_decl.destruct_names[i]);
-                    return;
-                }
+            if (check_destruct_pattern_redefinitions(checker, pattern, node->line, node->column)) {
+                return;
             }
 
             // Initializer is required (parser enforces this)
             Type* init_type = check_expression(checker, node->as.var_decl.init);
 
-            // Check that init is a tuple
-            if (init_type->kind != TYPE_TUPLE && init_type->kind != TYPE_ERROR) {
-                check_error(checker, node->line, node->column,
-                            "Destructuring requires a tuple, got '%s'", type_name(init_type));
+            // Check pattern against initializer type
+            if (check_destruct_pattern_against_type(checker, pattern, init_type, node->line,
+                                                    node->column)) {
                 return;
             }
 
-            // Check arity matches
-            if (init_type->kind == TYPE_TUPLE &&
-                init_type->as.tuple.elem_count != node->as.var_decl.destruct_count) {
-                check_error(checker, node->line, node->column,
-                            "Destructuring pattern has %d variables, but tuple has %d elements",
-                            node->as.var_decl.destruct_count, init_type->as.tuple.elem_count);
-                return;
-            }
-
-            // Store the tuple type for codegen
-            if (init_type->kind == TYPE_TUPLE) {
-                node->as.var_decl.destruct_tuple_type = init_type;
-            }
-
-            // Define each variable
-            for (int i = 0; i < node->as.var_decl.destruct_count; i++) {
-                Type* elem_type =
-                    init_type->kind == TYPE_TUPLE ? init_type->as.tuple.elem_types[i] : type_error;
-                checker_define(checker, node->as.var_decl.destruct_names[i], SYM_VAR, elem_type,
-                               node->as.var_decl.is_const, node->as.var_decl.is_public,
-                               checker->current_module);
-            }
+            // Define all variables in the pattern
+            define_destruct_pattern_vars(checker, pattern, init_type, node->as.var_decl.is_const,
+                                         node->as.var_decl.is_public);
             break;
         }
 

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -12,6 +12,10 @@ static void emit_indent(CodeGen* gen) {
     }
 }
 
+// Forward declaration for recursive pattern emit
+static void emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* temp_prefix,
+                                  int is_const);
+
 static void emit(CodeGen* gen, const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
@@ -554,6 +558,57 @@ static void emit_struct_init(CodeGen* gen, Node* node) {
     emit(gen, "}");
 }
 
+// Emit code to extract values from a tuple into variables (recursive for nested patterns)
+// temp_prefix is the expression to access the current tuple (e.g., "__tuple0" or "__tuple0._1")
+static void emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* temp_prefix,
+                                  int is_const) {
+    if (!pattern)
+        return;
+
+    Type* type = (Type*)pattern->resolved_type;
+
+    switch (pattern->kind) {
+    case PATTERN_IDENT:
+        // Emit: [const] Type name = temp_prefix;
+        emit_indent(gen);
+        if (is_const) {
+            emit(gen, "const ");
+        }
+        emit_resolved_type(gen, type);
+        emit(gen, " %s = %s;\n", pattern->as.ident.name, temp_prefix);
+        break;
+
+    case PATTERN_TUPLE:
+        // For tuple patterns, we need to access each element
+        // The tuple value is at temp_prefix, elements are temp_prefix._0, temp_prefix._1, etc.
+        for (int i = 0; i < pattern->as.tuple.count; i++) {
+            DestructPattern* elem = pattern->as.tuple.elements[i];
+
+            // Build the accessor string for this element
+            char accessor[256];
+            snprintf(accessor, sizeof(accessor), "%s._%d", temp_prefix, i);
+
+            if (elem->kind == PATTERN_TUPLE) {
+                // For nested tuple patterns, first create a temp variable for this level
+                Type* elem_type = (Type*)elem->resolved_type;
+                emit_indent(gen);
+                emit_resolved_type(gen, elem_type);
+                int temp_id = gen->temp_count++;
+                emit(gen, " __tuple%d = %s;\n", temp_id, accessor);
+
+                // Then recursively emit the nested pattern
+                char nested_prefix[64];
+                snprintf(nested_prefix, sizeof(nested_prefix), "__tuple%d", temp_id);
+                emit_destruct_pattern(gen, elem, nested_prefix, is_const);
+            } else {
+                // Simple identifier - directly assign from accessor
+                emit_destruct_pattern(gen, elem, accessor, is_const);
+            }
+        }
+        break;
+    }
+}
+
 static void emit_stmt(CodeGen* gen, Node* node) {
     if (!node)
         return;
@@ -566,28 +621,23 @@ static void emit_stmt(CodeGen* gen, Node* node) {
         break;
 
     case NODE_VAR_DECL: {
-        // Handle destructuring: var (a, b) = tuple;
-        if (node->as.var_decl.destruct_count > 0) {
-            Type* tuple_type = (Type*)node->as.var_decl.destruct_tuple_type;
+        // Handle destructuring: var (a, b) = tuple; or var (a, (b, c)) = nested;
+        DestructPattern* pattern = node->as.var_decl.destruct_pattern;
+        if (pattern) {
+            Type* tuple_type = (Type*)pattern->resolved_type;
 
             // Emit a temporary variable to hold the tuple value
             emit_indent(gen);
             emit_resolved_type(gen, tuple_type);
-            emit(gen, " __tuple%d = ", gen->temp_count);
+            int temp_id = gen->temp_count++;
+            emit(gen, " __tuple%d = ", temp_id);
             emit_expr(gen, node->as.var_decl.init);
             emit(gen, ";\n");
-            int temp_id = gen->temp_count++;
 
-            // Emit each destructured variable
-            for (int i = 0; i < node->as.var_decl.destruct_count; i++) {
-                emit_indent(gen);
-                if (node->as.var_decl.is_const) {
-                    emit(gen, "const ");
-                }
-                emit_resolved_type(gen, tuple_type->as.tuple.elem_types[i]);
-                emit(gen, " %s = __tuple%d._%d;\n", node->as.var_decl.destruct_names[i], temp_id,
-                     i);
-            }
+            // Recursively emit the destructured variables
+            char temp_prefix[64];
+            snprintf(temp_prefix, sizeof(temp_prefix), "__tuple%d", temp_id);
+            emit_destruct_pattern(gen, pattern, temp_prefix, node->as.var_decl.is_const);
             break;
         }
 
@@ -1076,20 +1126,6 @@ static int register_tuple_type(CodeGen* gen, Type* type) {
     return gen->tuple_type_count++;
 }
 
-// Recursively register tuple types from a Type
-static void collect_tuple_types_from_type(CodeGen* gen, Type* type) {
-    if (!type)
-        return;
-    if (type->kind == TYPE_TUPLE) {
-        register_tuple_type(gen, type);
-        for (int i = 0; i < type->as.tuple.elem_count; i++) {
-            collect_tuple_types_from_type(gen, type->as.tuple.elem_types[i]);
-        }
-    } else if (type->kind == TYPE_ARRAY) {
-        collect_tuple_types_from_type(gen, type->as.array.elem);
-    }
-}
-
 // Collect tuple types from a type node
 static void collect_tuple_types_from_node(CodeGen* gen, Node* type_node);
 
@@ -1170,6 +1206,25 @@ static void collect_tuple_types_from_expr(CodeGen* gen, Node* node) {
     }
 }
 
+// Collect tuple types from a destructuring pattern (recursive)
+static void collect_tuple_types_from_pattern(CodeGen* gen, DestructPattern* pattern) {
+    if (!pattern)
+        return;
+
+    // Collect the resolved type if it's a tuple
+    Type* type = (Type*)pattern->resolved_type;
+    if (type && type->kind == TYPE_TUPLE) {
+        register_tuple_type(gen, type);
+    }
+
+    // Recurse into nested patterns
+    if (pattern->kind == PATTERN_TUPLE) {
+        for (int i = 0; i < pattern->as.tuple.count; i++) {
+            collect_tuple_types_from_pattern(gen, pattern->as.tuple.elements[i]);
+        }
+    }
+}
+
 // Collect tuple types from a statement node
 static void collect_tuple_types_from_stmt(CodeGen* gen, Node* node) {
     if (!node)
@@ -1180,9 +1235,9 @@ static void collect_tuple_types_from_stmt(CodeGen* gen, Node* node) {
             collect_tuple_types_from_node(gen, node->as.var_decl.type);
         if (node->as.var_decl.init)
             collect_tuple_types_from_expr(gen, node->as.var_decl.init);
-        // Also collect from destructuring type if present
-        if (node->as.var_decl.destruct_tuple_type) {
-            collect_tuple_types_from_type(gen, (Type*)node->as.var_decl.destruct_tuple_type);
+        // Also collect from destructuring pattern if present
+        if (node->as.var_decl.destruct_pattern) {
+            collect_tuple_types_from_pattern(gen, node->as.var_decl.destruct_pattern);
         }
         break;
     case NODE_EXPR_STMT:

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -119,11 +119,12 @@ char* copy_token_string(Token* token) {
 // Forward Declarations
 // ============================================================================
 
-static Node* parse_expression(Parser* parser);
-static Node* parse_type(Parser* parser);
-static Node* parse_block(Parser* parser);
-static Node* parse_statement(Parser* parser);
-static Node* parse_var_decl(Parser* parser, int is_const, int is_public);
+static Node*            parse_expression(Parser* parser);
+static Node*            parse_type(Parser* parser);
+static Node*            parse_block(Parser* parser);
+static Node*            parse_statement(Parser* parser);
+static Node*            parse_var_decl(Parser* parser, int is_const, int is_public);
+static DestructPattern* parse_destruct_pattern(Parser* parser);
 
 // ============================================================================
 // Type Parsing
@@ -1013,75 +1014,96 @@ static Node* parse_statement(Parser* parser) {
 // Declaration Parsing
 // ============================================================================
 
+// Parse a destructuring pattern element: either an identifier or a nested tuple pattern
+// Called after '(' has been consumed for the outer pattern, or recursively for nested patterns
+static DestructPattern* parse_destruct_pattern_element(Parser* parser) {
+    if (check_token(parser, TOK_LPAREN)) {
+        // Nested tuple pattern: (a, b) or (a, (b, c))
+        advance_token(parser); // consume '('
+
+        DestructPattern* pattern = pattern_new_tuple(4);
+
+        // Parse first element
+        DestructPattern* first = parse_destruct_pattern_element(parser);
+        if (!first) {
+            pattern_free(pattern);
+            return NULL;
+        }
+        pattern_tuple_push(pattern, first);
+
+        // Parse remaining elements (comma-separated)
+        while (match_token(parser, TOK_COMMA)) {
+            // Grow capacity if needed
+            if (pattern->as.tuple.count >= 4) {
+                int new_cap = pattern->as.tuple.count * 2;
+                pattern->as.tuple.elements =
+                    realloc(pattern->as.tuple.elements, new_cap * sizeof(DestructPattern*));
+            }
+            DestructPattern* elem = parse_destruct_pattern_element(parser);
+            if (!elem) {
+                pattern_free(pattern);
+                return NULL;
+            }
+            pattern_tuple_push(pattern, elem);
+        }
+
+        consume_token(parser, TOK_RPAREN, "Expected ')' after nested destructuring pattern");
+
+        // Require at least 2 elements for tuple pattern
+        if (pattern->as.tuple.count < 2) {
+            parse_error(parser, "Destructuring pattern requires at least 2 elements");
+            pattern_free(pattern);
+            return NULL;
+        }
+
+        return pattern;
+    } else if (check_token(parser, TOK_IDENT)) {
+        // Simple identifier
+        Token name_tok = parser->current;
+        advance_token(parser);
+        return pattern_new_ident(name_tok.start, name_tok.length);
+    } else {
+        parse_error(parser, "Expected variable name or nested pattern in destructuring");
+        return NULL;
+    }
+}
+
+// Parse the top-level destructuring pattern: var (pattern) = ...
+// Called after 'var' or 'const' keyword, when '(' is the next token
+static DestructPattern* parse_destruct_pattern(Parser* parser) {
+    // We expect '(' to already be the current token
+    if (!check_token(parser, TOK_LPAREN)) {
+        parse_error(parser, "Expected '(' for destructuring pattern");
+        return NULL;
+    }
+    return parse_destruct_pattern_element(parser);
+}
+
 static Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
     Token start = parser->current;
 
-    // Check for destructuring: var (a, b) = ...
+    // Check for destructuring: var (a, b) = ... or var (a, (b, c)) = ...
     if (check_token(parser, TOK_LPAREN)) {
-        advance_token(parser); // consume '('
+        DestructPattern* pattern = parse_destruct_pattern(parser);
+        if (!pattern) {
+            return NULL;
+        }
 
         Node* node = node_new(NODE_VAR_DECL, start.line, start.column);
         if (!node) {
             parse_error(parser, "Out of memory");
+            pattern_free(pattern);
             return NULL;
         }
         var_decl_node* vdn = &node->as.var_decl;
 
-        vdn->name               = NULL; // NULL indicates destructuring
-        vdn->name_length        = 0;
-        vdn->is_public          = is_public;
-        vdn->is_const           = is_const;
-        vdn->type               = NULL;
-        vdn->init               = NULL;
-        vdn->destruct_names     = NULL;
-        vdn->destruct_name_lens = NULL;
-        vdn->destruct_count     = 0;
-
-        // Collect names into a temporary list
-        int    capacity = 4;
-        char** names    = malloc(capacity * sizeof(char*));
-        int*   lens     = malloc(capacity * sizeof(int));
-        int    count    = 0;
-
-        // Parse first name
-        Token name_tok = parser->current;
-        consume_token(parser, TOK_IDENT, "Expected variable name in destructuring pattern");
-
-        names[count] = copy_token_string(&name_tok);
-        lens[count]  = name_tok.length;
-        count++;
-
-        // Parse remaining names (comma-separated)
-        while (match_token(parser, TOK_COMMA)) {
-            if (count >= capacity) {
-                capacity *= 2;
-                names = realloc(names, capacity * sizeof(char*));
-                lens  = realloc(lens, capacity * sizeof(int));
-            }
-            name_tok = parser->current;
-            consume_token(parser, TOK_IDENT, "Expected variable name after ',' in destructuring");
-            names[count] = copy_token_string(&name_tok);
-            lens[count]  = name_tok.length;
-            count++;
-        }
-
-        consume_token(parser, TOK_RPAREN, "Expected ')' after destructuring pattern");
-
-        // Require at least 2 names for destructuring
-        if (count < 2) {
-            parse_error(parser, "Destructuring requires at least 2 variables");
-            for (int i = 0; i < count; i++)
-                free(names[i]);
-            free(names);
-            free(lens);
-            node_free(node);
-            return NULL;
-        }
-
-        vdn->destruct_names      = names;
-        vdn->destruct_name_lens  = lens;
-        vdn->destruct_count      = count;
-        vdn->destruct_tuple_type = NULL; // Set by checker
+        vdn->name             = NULL; // NULL indicates destructuring
+        vdn->name_length      = 0;
+        vdn->is_public        = is_public;
+        vdn->is_const         = is_const;
+        vdn->type             = NULL;
+        vdn->init             = NULL;
+        vdn->destruct_pattern = pattern;
 
         // Optional type annotation
         if (match_token(parser, TOK_COLON)) {
@@ -1116,15 +1138,12 @@ static Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
         parse_error(parser, "Out of memory");
         return NULL;
     }
-    vdn->is_public           = is_public;
-    vdn->name_length         = name.length;
-    vdn->is_const            = is_const;
-    vdn->type                = NULL;
-    vdn->init                = NULL;
-    vdn->destruct_names      = NULL;
-    vdn->destruct_name_lens  = NULL;
-    vdn->destruct_count      = 0;
-    vdn->destruct_tuple_type = NULL;
+    vdn->is_public        = is_public;
+    vdn->name_length      = name.length;
+    vdn->is_const         = is_const;
+    vdn->type             = NULL;
+    vdn->init             = NULL;
+    vdn->destruct_pattern = NULL;
 
     // Optional type annotation
     if (match_token(parser, TOK_COLON)) {

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -9,6 +9,27 @@ static void print_indent(int depth) {
         printf("  ");
 }
 
+// Print a destructuring pattern (recursive)
+static void print_destruct_pattern(DestructPattern* pattern) {
+    if (!pattern)
+        return;
+
+    switch (pattern->kind) {
+    case PATTERN_IDENT:
+        printf("%.*s", pattern->as.ident.name_length, pattern->as.ident.name);
+        break;
+    case PATTERN_TUPLE:
+        printf("(");
+        for (int i = 0; i < pattern->as.tuple.count; i++) {
+            if (i > 0)
+                printf(", ");
+            print_destruct_pattern(pattern->as.tuple.elements[i]);
+        }
+        printf(")");
+        break;
+    }
+}
+
 static void print_visibility(int depth, int is_public) {
     print_indent(depth);
     if (is_public) {
@@ -108,15 +129,10 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_VAR_DECL:
-        if (node->as.var_decl.destruct_count > 0) {
-            printf("VarDecl: (");
-            for (int i = 0; i < node->as.var_decl.destruct_count; i++) {
-                if (i > 0)
-                    printf(", ");
-                printf("%.*s", node->as.var_decl.destruct_name_lens[i],
-                       node->as.var_decl.destruct_names[i]);
-            }
-            printf(")%s\n", node->as.var_decl.is_const ? " (const)" : "");
+        if (node->as.var_decl.destruct_pattern) {
+            printf("VarDecl: ");
+            print_destruct_pattern(node->as.var_decl.destruct_pattern);
+            printf("%s\n", node->as.var_decl.is_const ? " (const)" : "");
         } else {
             printf("VarDecl: %.*s%s\n", node->as.var_decl.name_length, node->as.var_decl.name,
                    node->as.var_decl.is_const ? " (const)" : "");

--- a/w0/test/tuples.w
+++ b/w0/test/tuples.w
@@ -13,11 +13,14 @@ func main(): i32 {
     // Destructuring
     var (a, b) = (10, 20);
 
+    // Nested destructuring
+    var (p, (q, r)) = (3, (4, 5));
+
     // Nested tuples
     var nested: (i64, (i64, i64)) = (1, (2, 3));
     var inner: (i64, i64) = nested[1];
     var innerFirst: i64 = inner[0];
 
     // Return sum to verify values
-    return x + pair[0] + pair[1] + a + b + innerFirst;
+    return x + pair[0] + pair[1] + a + b + p + q + r + innerFirst;
 }


### PR DESCRIPTION
## Summary

- Extends tuple destructuring to support nested patterns like `var (a, (b, c)) = (1, (2, 3));`
- Adds recursive `DestructPattern` type to AST with `PATTERN_IDENT` and `PATTERN_TUPLE` variants
- Updates parser, checker, and codegen to handle nested patterns recursively
- Updates grammar.md documentation with new `destruct-pattern` and `destruct-element` rules

## Test plan

- [x] All 41 existing tests pass
- [x] Nested destructuring compiles and runs correctly
- [x] Type checking validates pattern structure against tuple types
- [x] Error messages work for mismatched patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)