### PR TITLE
fix: add missing Expected Error comments to error test cases

### DIFF
--- a/w0/test/error_module_visibility.w
+++ b/w0/test/error_module_visibility.w
@@ -1,5 +1,5 @@
 // Test that symbols from library imports are not accessible through relative imports
-// EXPECT_ERROR: Undefined identifier 'abs_i64'
+// Expected error: Undefined identifier 'abs_i64'
 
 import "./util/std_helper.w";
 

--- a/w0/test/error_private_import.w
+++ b/w0/test/error_private_import.w
@@ -1,5 +1,5 @@
 // Test that private symbols from library imports are not accessible via module qualification
-// EXPECT_ERROR: Module 'std' has no public symbol '_internal_std'
+// Expected error: Module 'std' has no public symbol '_internal_std'
 
 import std;
 

--- a/w0/test/error_span_data.w
+++ b/w0/test/error_span_data.w
@@ -1,4 +1,6 @@
 // Error test: accessing .data field on span should fail
+// Expected error: Span 'data' field is private; use indexing
+
 func main(): i32 {
     var arr: [5]i64;
     arr[0] = 1;

--- a/w0/test/error_span_type.w
+++ b/w0/test/error_span_type.w
@@ -1,4 +1,6 @@
 // Error test: Span with wrong number of type args
+// Expected error: Span requires exactly 1 type argument, got 2
+
 func main(): i32 {
     var s: Span<i64, i32>;  // Should error - Span takes 1 arg
     return 0;

--- a/w0/test/error_unqualified_import.w
+++ b/w0/test/error_unqualified_import.w
@@ -1,5 +1,5 @@
 // Test that library symbols cannot be accessed without module qualification
-// EXPECT_ERROR: Undefined identifier 'print'
+// Expected error: Undefined identifier 'print'
 
 import std;
 


### PR DESCRIPTION
## Summary
- Add missing `// Expected error:` comments to `error_span_data.w` and `error_span_type.w`
- Fix inconsistent `EXPECT_ERROR` format to use `Expected error` in import-related error tests
- All 5 error test files now follow the correct format expected by the test harness

## Test plan
- [x] `make test` passes (51/51 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)