### PR TITLE
feat: add varargs support for extern C functions

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -50,7 +50,8 @@ Import statements load declarations from external Whist source files. There are 
 
 <receiver> ::= '(' [ 'const' ] <identifier> [ '<' <type-arg-list> '>' ] ')'
 
-<param-list> ::= <param> { ',' <param> }
+<param-list> ::= <param> { ',' <param> } [ ',' '...' ]
+               | '...'
 
 <param> ::= <identifier> [ ':' <type> ]
 

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -112,6 +112,7 @@ typedef struct {
     char*    name;
     int      name_length;
     NodeList params;
+    int      is_varargs;
     Node*    return_type;
     Node*    body;
     char*    source_module; // NULL = same module, else external module name

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -768,7 +768,7 @@ static Type* resolve_type(Checker* checker, Node* type_node) {
             free(method_params);
             free(method_args);
 
-            Type* method_type = type_func(param_types, param_count, return_type);
+            Type* method_type = type_func(param_types, param_count, return_type, 0);
 
             // Register the method on the struct type
             int n = struct_type->as.struc.method_count;
@@ -1247,14 +1247,24 @@ static Type* check_expression(Checker* checker, Node* node) {
         }
 
         // Check argument count
-        if (node->as.call.args.count != func_type->as.func.param_count) {
-            check_error(checker, node->line, node->column, "Expected %d arguments, got %d",
-                        func_type->as.func.param_count, node->as.call.args.count);
-            return type_error;
+        if (func_type->as.func.is_varargs) {
+            // Varargs: require at least param_count arguments
+            if (node->as.call.args.count < func_type->as.func.param_count) {
+                check_error(checker, node->line, node->column,
+                            "Expected at least %d arguments, got %d",
+                            func_type->as.func.param_count, node->as.call.args.count);
+                return type_error;
+            }
+        } else {
+            if (node->as.call.args.count != func_type->as.func.param_count) {
+                check_error(checker, node->line, node->column, "Expected %d arguments, got %d",
+                            func_type->as.func.param_count, node->as.call.args.count);
+                return type_error;
+            }
         }
 
-        // Check argument types
-        for (int i = 0; i < node->as.call.args.count; i++) {
+        // Check argument types (only for named params)
+        for (int i = 0; i < func_type->as.func.param_count; i++) {
             Type* arg_type   = check_expression(checker, node->as.call.args.nodes[i]);
             Type* param_type = func_type->as.func.param_types[i];
 
@@ -1264,6 +1274,11 @@ static Type* check_expression(Checker* checker, Node* node) {
                 check_error_type(checker, node->as.call.args.nodes[i]->line,
                                  node->as.call.args.nodes[i]->column, ctx, param_type, arg_type);
             }
+        }
+
+        // Type-check extra variadic arguments (but don't check against param types)
+        for (int i = func_type->as.func.param_count; i < node->as.call.args.count; i++) {
+            check_expression(checker, node->as.call.args.nodes[i]);
         }
 
         return func_type->as.func.return_type;
@@ -1777,7 +1792,7 @@ static Type* get_function_type(Checker* checker, Node* node) {
         param_types[i] = ptype;
     }
 
-    Type* func_type = type_func(param_types, param_count, return_type);
+    Type* func_type = type_func(param_types, param_count, return_type, fdn->is_varargs);
 
     return func_type;
 }

--- a/w0/lexer.c
+++ b/w0/lexer.c
@@ -307,7 +307,10 @@ Token lexer_next(Lexer* lexer) {
     case ',':
         return make_token(lexer, TOK_COMMA);
     case '.':
-        return make_token(lexer, match(lexer, '.') ? TOK_DOT_DOT : TOK_DOT);
+        if (match(lexer, '.')) {
+            return make_token(lexer, match(lexer, '.') ? TOK_ELLIPSIS : TOK_DOT_DOT);
+        }
+        return make_token(lexer, TOK_DOT);
     case '~':
         return make_token(lexer, TOK_TILDE);
     case '^':
@@ -441,6 +444,7 @@ static const char* token_names[] = {
     [TOK_COMMA]       = "COMMA",
     [TOK_DOT]         = "DOT",
     [TOK_DOT_DOT]     = "DOT_DOT",
+    [TOK_ELLIPSIS]    = "ELLIPSIS",
     [TOK_ERROR]       = "ERROR",
 };
 

--- a/w0/lexer.h
+++ b/w0/lexer.h
@@ -89,6 +89,7 @@ typedef enum {
     TOK_COMMA,       // ,
     TOK_DOT,         // .
     TOK_DOT_DOT,     // ..
+    TOK_ELLIPSIS,    // ...
 
     // Error
     TOK_ERROR

--- a/w0/lib/std.w
+++ b/w0/lib/std.w
@@ -1,7 +1,7 @@
 // Standard library for Whist
 
 private extern stdio {
-    func printf(fmt:string, s: string): void;
+    func printf(fmt: string, ...): i32;
 }
 
 func print(s: string): void {

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1344,42 +1344,56 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
         return NULL;
     }
     fdn->name_length = name.length;
+    fdn->is_varargs  = 0;
     nodelist_init(&fdn->params);
 
     consume_token(parser, TOK_LPAREN, "Expected '(' after function name");
 
     // Parameters
     if (!check_token(parser, TOK_RPAREN)) {
-        do {
-            // Check for 'const' modifier
-            int param_is_const = 0;
-            if (match_token(parser, TOK_CONST)) {
-                param_is_const = 1;
-            }
+        // Check for leading ... (no named params)
+        if (check_token(parser, TOK_ELLIPSIS)) {
+            fdn->is_varargs = 1;
+            advance_token(parser);
+        } else {
+            do {
+                // Check for ... after a comma (varargs after named params)
+                if (check_token(parser, TOK_ELLIPSIS)) {
+                    fdn->is_varargs = 1;
+                    advance_token(parser);
+                    break;
+                }
 
-            Token param_name = parser->current;
-            consume_token(parser, TOK_IDENT, "Expected parameter name");
+                // Check for 'const' modifier
+                int param_is_const = 0;
+                if (match_token(parser, TOK_CONST)) {
+                    param_is_const = 1;
+                }
 
-            Node* param = node_new(NODE_PARAM, param_name.line, param_name.column);
-            if (!param) {
-                parse_error(parser, "Out of memory");
-                return NULL;
-            }
-            param->as.param.name = copy_token_string(&param_name);
-            if (!param->as.param.name) {
-                parse_error(parser, "Out of memory");
-                return NULL;
-            }
-            param->as.param.name_length = param_name.length;
-            param->as.param.type        = NULL;
-            param->as.param.is_const    = param_is_const;
+                Token param_name = parser->current;
+                consume_token(parser, TOK_IDENT, "Expected parameter name");
 
-            if (match_token(parser, TOK_COLON)) {
-                param->as.param.type = parse_type(parser);
-            }
+                Node* param = node_new(NODE_PARAM, param_name.line, param_name.column);
+                if (!param) {
+                    parse_error(parser, "Out of memory");
+                    return NULL;
+                }
+                param->as.param.name = copy_token_string(&param_name);
+                if (!param->as.param.name) {
+                    parse_error(parser, "Out of memory");
+                    return NULL;
+                }
+                param->as.param.name_length = param_name.length;
+                param->as.param.type        = NULL;
+                param->as.param.is_const    = param_is_const;
 
-            nodelist_push(&fdn->params, param);
-        } while (match_token(parser, TOK_COMMA));
+                if (match_token(parser, TOK_COLON)) {
+                    param->as.param.type = parse_type(parser);
+                }
+
+                nodelist_push(&fdn->params, param);
+            } while (match_token(parser, TOK_COMMA));
+        }
     }
 
     consume_token(parser, TOK_RPAREN, "Expected ')' after parameters");

--- a/w0/test/varargs.w
+++ b/w0/test/varargs.w
@@ -1,0 +1,15 @@
+extern stdio {
+    func printf(fmt: string, ...): i32;
+}
+
+func main(): i32 {
+    // Call printf with various argument counts
+    printf("hello %s\n", "world");
+    printf("number: %d\n", 42);
+    printf("%d + %d = %d\n", 1, 2, 3);
+
+    // No args beyond format string
+    printf("varargs test passed\n");
+
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -100,11 +100,12 @@ Type* type_enum(const char* name) {
     return type;
 }
 
-Type* type_func(Type** params, int param_count, Type* return_type) {
+Type* type_func(Type** params, int param_count, Type* return_type, int is_varargs) {
     Type* type                = type_new(TYPE_FUNC);
     type->as.func.param_types = params;
     type->as.func.param_count = param_count;
     type->as.func.return_type = return_type;
+    type->as.func.is_varargs  = is_varargs;
     return type;
 }
 
@@ -195,6 +196,8 @@ int type_equals(Type* a, Type* b) {
         return strcmp(a->as.enm.name, b->as.enm.name) == 0;
     case TYPE_FUNC:
         if (a->as.func.param_count != b->as.func.param_count)
+            return 0;
+        if (a->as.func.is_varargs != b->as.func.is_varargs)
             return 0;
         if (!type_equals(a->as.func.return_type, b->as.func.return_type))
             return 0;

--- a/w0/types.h
+++ b/w0/types.h
@@ -80,6 +80,7 @@ struct Type {
             Type** param_types;
             int    param_count;
             Type*  return_type;
+            int    is_varargs;
         } func;
 
         // Tuple
@@ -121,7 +122,7 @@ Type* type_new(TypeKind kind);
 Type* type_array(Type* elem, int size);
 Type* type_struct(const char* name);
 Type* type_enum(const char* name);
-Type* type_func(Type** params, int param_count, Type* return_type);
+Type* type_func(Type** params, int param_count, Type* return_type, int is_varargs);
 Type* type_tuple(Type** elems, int count);
 Type* type_generic_param(const char* name);
 Type* type_span(Type* elem);


### PR DESCRIPTION
## Summary
- Add `...` (ellipsis) syntax for variadic parameters in extern function declarations (e.g., `func printf(fmt: string, ...): i32`)
- Lexer recognizes `TOK_ELLIPSIS` token, parser sets `is_varargs` on func decl nodes, type system tracks varargs on function types
- Checker enforces at least the named params are provided and only type-checks named arguments, allowing extra variadic args to pass through
- Updates `lib/std.w` printf declaration to use proper varargs signature

## Test plan
- [x] All 52 existing tests pass (`make test`)
- [x] New `test/varargs.w` exercises printf with 0, 1, and 3 extra variadic arguments
- [x] Generated C compiles and runs correctly (`bin/w0 test/varargs.w | cc -x c -o /tmp/varargs - && /tmp/varargs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)