### PR TITLE
refactor: fix parser quality issues from code review

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -120,6 +120,10 @@ void node_free(Node* node) {
         node_free(node->as.index.object);
         node_free(node->as.index.index);
         break;
+    case NODE_ARRAY_TYPE:
+        node_free(node->as.array_type.elem_type);
+        node_free(node->as.array_type.size);
+        break;
     case NODE_SLICE:
         node_free(node->as.slice.object);
         node_free(node->as.slice.start);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -83,6 +83,9 @@ typedef enum {
     // Array literal
     NODE_ARRAY_LIT, // [e1, e2, ...]
 
+    // Array type: [n]T or []T
+    NODE_ARRAY_TYPE,
+
     // Generic types
     NODE_GENERIC_TYPE, // Box<i64>, Pair<K, V>
 
@@ -263,6 +266,12 @@ struct Node {
             NodeList elements;
             void*    resolved_type; // Type* set by checker (element type)
         } array_lit;
+
+        // Array type: [n]T or []T
+        struct {
+            Node* elem_type; // Element type
+            Node* size;      // Size expression (NULL for unsized/span)
+        } array_type;
 
         // Generic type reference: Box<i64>, Pair<K, V>
         struct {

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -815,19 +815,17 @@ static Type* resolve_type(Checker* checker, Node* type_node) {
         check_error(checker, type_node->line, type_node->column,
                     "Pointer types are no longer supported");
         return type_error;
-    case NODE_INDEX:
-        // Array type: [n]T
-        {
-            Type* elem = resolve_type(checker, type_node->as.index.object);
-            int   size = -1;
-            if (type_node->as.index.index) {
-                // For now, only support constant integer sizes
-                if (type_node->as.index.index->type == NODE_INT_LIT) {
-                    size = (int)type_node->as.index.index->as.int_lit.value;
-                }
+    case NODE_ARRAY_TYPE: {
+        Type* elem = resolve_type(checker, type_node->as.array_type.elem_type);
+        int   size = -1;
+        if (type_node->as.array_type.size) {
+            // For now, only support constant integer sizes
+            if (type_node->as.array_type.size->type == NODE_INT_LIT) {
+                size = (int)type_node->as.array_type.size->as.int_lit.value;
             }
-            return type_array(elem, size);
         }
+        return type_array(elem, size);
+    }
     case NODE_TUPLE_TYPE: {
         int    count = type_node->as.tuple_type.elem_types.count;
         Type** elems = xmalloc(count * sizeof(Type*));

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -243,12 +243,12 @@ static void emit_type(CodeGen* gen, Node* type_node) {
         // Pointer types no longer supported in the language
         emit(gen, "/* pointer types not supported */");
         break;
-    case NODE_INDEX:
+    case NODE_ARRAY_TYPE:
         // Array type: [n]T -> T[n] or T*
-        emit_type(gen, type_node->as.index.object);
-        if (type_node->as.index.index) {
+        emit_type(gen, type_node->as.array_type.elem_type);
+        if (type_node->as.array_type.size) {
             emit(gen, "[");
-            emit_expr(gen, type_node->as.index.index);
+            emit_expr(gen, type_node->as.array_type.size);
             emit(gen, "]");
         } else {
             emit(gen, "*");
@@ -476,11 +476,11 @@ static void emit_type_with_name(CodeGen* gen, Node* type_node, const char* name)
         return;
     }
 
-    if (type_node->type == NODE_INDEX && type_node->as.index.index) {
+    if (type_node->type == NODE_ARRAY_TYPE && type_node->as.array_type.size) {
         // Array: T name[n]
-        emit_type(gen, type_node->as.index.object);
+        emit_type(gen, type_node->as.array_type.elem_type);
         emit(gen, " %s[", name);
-        emit_expr(gen, type_node->as.index.index);
+        emit_expr(gen, type_node->as.array_type.size);
         emit(gen, "]");
     } else {
         emit_type(gen, type_node);
@@ -1814,11 +1814,11 @@ static Type* type_from_node(Node* type_node) {
         // User-defined type - return a struct type
         return type_struct(name);
     }
-    case NODE_INDEX: {
-        Type* elem = type_from_node(type_node->as.index.object);
+    case NODE_ARRAY_TYPE: {
+        Type* elem = type_from_node(type_node->as.array_type.elem_type);
         int   size = -1;
-        if (type_node->as.index.index && type_node->as.index.index->type == NODE_INT_LIT) {
-            size = (int)type_node->as.index.index->as.int_lit.value;
+        if (type_node->as.array_type.size && type_node->as.array_type.size->type == NODE_INT_LIT) {
+            size = (int)type_node->as.array_type.size->as.int_lit.value;
         }
         return type_array(elem, size);
     }
@@ -1865,9 +1865,9 @@ static void collect_tuple_types_from_node(CodeGen* gen, Node* type_node) {
         for (int i = 0; i < type_node->as.tuple_type.elem_types.count; i++) {
             collect_tuple_types_from_node(gen, type_node->as.tuple_type.elem_types.nodes[i]);
         }
-    } else if (type_node->type == NODE_INDEX) {
+    } else if (type_node->type == NODE_ARRAY_TYPE) {
         // Array type - recurse into element type
-        collect_tuple_types_from_node(gen, type_node->as.index.object);
+        collect_tuple_types_from_node(gen, type_node->as.array_type.elem_type);
     } else if (type_node->type == NODE_GENERIC_TYPE) {
         // Generic type - recurse into type arguments for any tuple types
         for (int i = 0; i < type_node->as.generic_type.type_args.count; i++) {

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -14,8 +14,27 @@
 // Parser Utilities
 // ============================================================================
 
-// Current recursion depth for expression parsing
-int parse_depth = 0;
+// Decode a single escape character (the character after the backslash)
+static char decode_escape(char c) {
+    switch (c) {
+    case 'n':
+        return '\n';
+    case 't':
+        return '\t';
+    case 'r':
+        return '\r';
+    case '0':
+        return '\0';
+    case '\\':
+        return '\\';
+    case '"':
+        return '"';
+    case '\'':
+        return '\'';
+    default:
+        return c;
+    }
+}
 
 void advance_token(Parser* parser) {
     parser->previous = parser->current;
@@ -186,13 +205,13 @@ static Node* parse_type(Parser* parser) {
         consume_token(parser, TOK_RBRACKET, "Expected ']' in array type");
         Node* elem = parse_type(parser);
 
-        Node* node = node_new(NODE_INDEX, token.line, token.column);
+        Node* node = node_new(NODE_ARRAY_TYPE, token.line, token.column);
         if (!node) {
             parse_error(parser, "Out of memory");
             return NULL;
         }
-        node->as.index.object = elem;
-        node->as.index.index  = size;
+        node->as.array_type.elem_type = elem;
+        node->as.array_type.size      = size;
         return node;
     }
 
@@ -373,33 +392,7 @@ static Node* parse_primary_expression(Parser* parser) {
         while (src < end) {
             if (*src == '\\' && src + 1 < end) {
                 src++;
-                switch (*src) {
-                case 'n':
-                    *dst++ = '\n';
-                    break;
-                case 't':
-                    *dst++ = '\t';
-                    break;
-                case 'r':
-                    *dst++ = '\r';
-                    break;
-                case '0':
-                    *dst++ = '\0';
-                    break;
-                case '\\':
-                    *dst++ = '\\';
-                    break;
-                case '"':
-                    *dst++ = '"';
-                    break;
-                case '\'':
-                    *dst++ = '\'';
-                    break;
-                default:
-                    *dst++ = *src;
-                    break;
-                }
-                src++;
+                *dst++ = decode_escape(*src++);
             } else {
                 *dst++ = *src++;
             }
@@ -417,29 +410,7 @@ static Node* parse_primary_expression(Parser* parser) {
         }
         // Handle escape sequences
         if (token.start[1] == '\\') {
-            switch (token.start[2]) {
-            case 'n':
-                node->as.char_lit.value = '\n';
-                break;
-            case 't':
-                node->as.char_lit.value = '\t';
-                break;
-            case 'r':
-                node->as.char_lit.value = '\r';
-                break;
-            case '0':
-                node->as.char_lit.value = '\0';
-                break;
-            case '\\':
-                node->as.char_lit.value = '\\';
-                break;
-            case '\'':
-                node->as.char_lit.value = '\'';
-                break;
-            default:
-                node->as.char_lit.value = token.start[2];
-                break;
-            }
+            node->as.char_lit.value = decode_escape(token.start[2]);
         } else {
             node->as.char_lit.value = token.start[1];
         }
@@ -800,16 +771,16 @@ static Precedence get_precedence(TokenType type) {
 }
 
 static Node* parse_binary(Parser* parser, Precedence min_prec) {
-    parse_depth++;
-    if (parse_depth > MAX_PARSE_DEPTH) {
+    parser->parse_depth++;
+    if (parser->parse_depth > MAX_PARSE_DEPTH) {
         parse_error(parser, "Maximum expression nesting depth exceeded");
-        parse_depth--;
+        parser->parse_depth--;
         return NULL;
     }
 
     Node* left = parse_unary(parser);
     if (!left) {
-        parse_depth--;
+        parser->parse_depth--;
         return NULL;
     }
 
@@ -823,7 +794,7 @@ static Node* parse_binary(Parser* parser, Precedence min_prec) {
         Node* binary = node_new(NODE_BINARY, op.line, op.column);
         if (!binary) {
             parse_error(parser, "Out of memory");
-            parse_depth--;
+            parser->parse_depth--;
             return NULL;
         }
         binary->as.binary.op    = op.type;
@@ -832,7 +803,7 @@ static Node* parse_binary(Parser* parser, Precedence min_prec) {
         left                    = binary;
     }
 
-    parse_depth--;
+    parser->parse_depth--;
     return left;
 }
 
@@ -1180,7 +1151,7 @@ static DestructPattern* parse_destruct_pattern_element(Parser* parser) {
             if (pattern->as.tuple.count >= 4) {
                 int new_cap = pattern->as.tuple.count * 2;
                 pattern->as.tuple.elements =
-                    realloc(pattern->as.tuple.elements, new_cap * sizeof(DestructPattern*));
+                    xrealloc(pattern->as.tuple.elements, new_cap * sizeof(DestructPattern*));
             }
             DestructPattern* elem = parse_destruct_pattern_element(parser);
             if (!elem) {
@@ -1968,7 +1939,7 @@ void parser_init_with_path(Parser* parser, const char* source, const char* sourc
     parser->had_error    = 0;
     parser->panic_mode   = 0;
     parser->error_msg[0] = '\0';
-    parse_depth          = 0; // Reset recursion depth
+    parser->parse_depth  = 0; // Reset recursion depth
 
     parser->source_path = source_path;
     parser->lib_path    = lib_path;

--- a/w0/parser.h
+++ b/w0/parser.h
@@ -32,6 +32,9 @@ typedef struct {
     char** direct_imports;
     int    direct_imports_count;
     int    direct_imports_capacity;
+
+    // Current recursion depth for expression parsing
+    int parse_depth;
 } Parser;
 
 // Precedence levels for binary operators
@@ -51,9 +54,6 @@ typedef enum {
 
 // Maximum recursion depth to prevent stack overflow
 #define MAX_PARSE_DEPTH 256
-
-// Current recursion depth for expression parsing
-extern int parse_depth;
 
 // Parser lifecycle
 void  parser_init(Parser* parser, const char* source);

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -359,6 +359,18 @@ void print_ast(Node* node, int depth) {
         }
         break;
 
+    case NODE_ARRAY_TYPE:
+        printf("ArrayType\n");
+        print_indent(depth + 1);
+        printf("ElemType:\n");
+        print_ast(node->as.array_type.elem_type, depth + 2);
+        if (node->as.array_type.size) {
+            print_indent(depth + 1);
+            printf("Size:\n");
+            print_ast(node->as.array_type.size, depth + 2);
+        }
+        break;
+
     case NODE_GENERIC_TYPE:
         printf("GenericType: %.*s\n", node->as.generic_type.base_name_length,
                node->as.generic_type.base_name);


### PR DESCRIPTION
## Summary
- Replace raw `realloc` with `xrealloc` in destructuring pattern growth to match codebase conventions and abort cleanly on OOM
- Move `parse_depth` from global variable into `Parser` struct to avoid state corruption when sub-parsers are created during import parsing
- Add dedicated `NODE_ARRAY_TYPE` for array type syntax `[n]T`, eliminating dual-use of `NODE_INDEX` for both type and expression contexts
- Extract `decode_escape()` helper to deduplicate escape sequence parsing between string and char literals

## Test plan
- [x] All 64 tests pass (43 valid programs, 21 error cases)
- [x] Clean build with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)