### PR TITLE
fix: support Drop trait for generic structs and nested RC field cleanup

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -756,6 +756,15 @@ static Type* resolve_type(Checker* checker, Node* type_node) {
             }
         }
 
+        // Check if the base generic has a Drop trait impl and propagate to instantiation
+        for (int ti = 0; ti < checker->trait_impl_count; ti++) {
+            if (strcmp(checker->trait_impls[ti].trait_name, "Drop") == 0 &&
+                strcmp(checker->trait_impls[ti].type_name, base_name) == 0) {
+                struct_type->as.struc.has_drop = 1;
+                break;
+            }
+        }
+
         // Instantiate methods on the generic struct
         for (int m = 0; m < def->method_count; m++) {
             Node*           method_decl = def->methods[m];
@@ -2231,15 +2240,21 @@ static void check_decl(Checker* checker, Node* node) {
         Type* trait_type = trait_sym->type;
 
         // Look up the target type
-        Symbol* type_sym = checker_lookup(checker, type_name_str);
+        Symbol*     type_sym    = checker_lookup(checker, type_name_str);
+        GenericDef* generic_def = NULL;
+        int         is_generic  = 0;
         if (!type_sym || type_sym->kind != SYM_TYPE || type_sym->type->kind != TYPE_STRUCT) {
-            check_error(checker, node->line, node->column,
-                        "Cannot implement trait for unknown struct type '%s'", type_name_str);
-            return;
+            // Fallback: check if it's a generic struct template
+            generic_def = lookup_generic_def(checker, type_name_str);
+            if (!generic_def) {
+                check_error(checker, node->line, node->column,
+                            "Cannot implement trait for unknown struct type '%s'", type_name_str);
+                return;
+            }
+            is_generic = 1;
         }
 
-        // Process each method in the impl block as a regular NODE_FUNC_DECL
-        // This registers the method on the struct type and checks the body
+        // Process each method in the impl block
         for (int i = 0; i < node->as.impl_decl.methods.count; i++) {
             Node* method = node->as.impl_decl.methods.nodes[i];
 
@@ -2261,44 +2276,53 @@ static void check_decl(Checker* checker, Node* node) {
                 continue;
             }
 
-            // Verify the method signature matches the trait signature
-            Type* impl_func_type  = get_function_type(checker, method);
-            Type* trait_func_type = trait_type->as.trait.method_types[trait_method_idx];
+            if (is_generic) {
+                // For generic structs, the method has a generic receiver (e.g., func (Box<T>)
+                // drop()) Process it via check_decl which routes to the generic method registration
+                // path
+                check_decl(checker, method);
+            } else {
+                // Verify the method signature matches the trait signature
+                Type* impl_func_type  = get_function_type(checker, method);
+                Type* trait_func_type = trait_type->as.trait.method_types[trait_method_idx];
 
-            // Check return type
-            if (!type_equals(impl_func_type->as.func.return_type,
-                             trait_func_type->as.func.return_type)) {
-                check_error(checker, method->line, method->column,
-                            "Method '%s' return type mismatch: trait '%s' expects '%s', got '%s'",
-                            method_name, trait_name,
-                            type_name(trait_func_type->as.func.return_type),
-                            type_name(impl_func_type->as.func.return_type));
-                continue;
-            }
-
-            // Check parameter types
-            if (impl_func_type->as.func.param_count != trait_func_type->as.func.param_count) {
-                check_error(checker, method->line, method->column,
-                            "Method '%s' parameter count mismatch: trait '%s' expects %d, got %d",
-                            method_name, trait_name, trait_func_type->as.func.param_count,
-                            impl_func_type->as.func.param_count);
-                continue;
-            }
-
-            for (int p = 0; p < trait_func_type->as.func.param_count; p++) {
-                if (!type_equals(impl_func_type->as.func.param_types[p],
-                                 trait_func_type->as.func.param_types[p])) {
+                // Check return type
+                if (!type_equals(impl_func_type->as.func.return_type,
+                                 trait_func_type->as.func.return_type)) {
                     check_error(
                         checker, method->line, method->column,
-                        "Method '%s' parameter %d type mismatch: trait '%s' expects '%s', got '%s'",
-                        method_name, p + 1, trait_name,
-                        type_name(trait_func_type->as.func.param_types[p]),
-                        type_name(impl_func_type->as.func.param_types[p]));
+                        "Method '%s' return type mismatch: trait '%s' expects '%s', got '%s'",
+                        method_name, trait_name, type_name(trait_func_type->as.func.return_type),
+                        type_name(impl_func_type->as.func.return_type));
+                    continue;
                 }
-            }
 
-            // Process the method as a regular func_decl (registers on struct, checks body)
-            check_decl(checker, method);
+                // Check parameter types
+                if (impl_func_type->as.func.param_count != trait_func_type->as.func.param_count) {
+                    check_error(
+                        checker, method->line, method->column,
+                        "Method '%s' parameter count mismatch: trait '%s' expects %d, got %d",
+                        method_name, trait_name, trait_func_type->as.func.param_count,
+                        impl_func_type->as.func.param_count);
+                    continue;
+                }
+
+                for (int p = 0; p < trait_func_type->as.func.param_count; p++) {
+                    if (!type_equals(impl_func_type->as.func.param_types[p],
+                                     trait_func_type->as.func.param_types[p])) {
+                        check_error(
+                            checker, method->line, method->column,
+                            "Method '%s' parameter %d type mismatch: trait '%s' expects '%s', got "
+                            "'%s'",
+                            method_name, p + 1, trait_name,
+                            type_name(trait_func_type->as.func.param_types[p]),
+                            type_name(impl_func_type->as.func.param_types[p]));
+                    }
+                }
+
+                // Process the method as a regular func_decl (registers on struct, checks body)
+                check_decl(checker, method);
+            }
         }
 
         // Verify all required trait methods are implemented
@@ -2324,7 +2348,7 @@ static void check_decl(Checker* checker, Node* node) {
         impl->type_name  = xstrdup(type_name_str);
 
         // If implementing Drop, set the flag on the struct type
-        if (strcmp(trait_name, "Drop") == 0) {
+        if (strcmp(trait_name, "Drop") == 0 && !is_generic) {
             type_sym->type->as.struc.has_drop = 1;
         }
         break;

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1985,11 +1985,25 @@ static void collect_generic_methods(Node* ast, const char* struct_name, Node*** 
             continue;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
+            // Direct generic methods: func (Box<T>) get(): T
             if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.receiver_type != NULL &&
                 decl->as.func_decl.receiver_type_args.count > 0 &&
                 strcmp(decl->as.func_decl.receiver_type, struct_name) == 0) {
                 VEC_GROW(methods, count, capacity);
                 methods[count++] = decl;
+            }
+            // Methods inside impl blocks: impl Drop for Box { func (Box<T>) drop(): void }
+            if (decl->type == NODE_IMPL_DECL) {
+                for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
+                    Node* method = decl->as.impl_decl.methods.nodes[j];
+                    if (method->type == NODE_FUNC_DECL &&
+                        method->as.func_decl.receiver_type != NULL &&
+                        method->as.func_decl.receiver_type_args.count > 0 &&
+                        strcmp(method->as.func_decl.receiver_type, struct_name) == 0) {
+                        VEC_GROW(methods, count, capacity);
+                        methods[count++] = method;
+                    }
+                }
             }
         }
     }
@@ -2430,6 +2444,62 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     }
     emit(gen, "\n");
 
+    // Forward declare all __rc_dec_TypeName functions to handle cross-references
+    // (e.g., non-generic Container referencing __rc_dec_Box_Inner from generic instance)
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type != NODE_STRUCT_DECL)
+                continue;
+            if (decl->as.struct_decl.type_param_count > 0)
+                continue;
+            const char* sname = decl->as.struct_decl.name;
+            // Check if this struct needs a custom dec function
+            int needs_dec = 0;
+            for (int t = 0; t < gen->trait_impl_count; t++) {
+                if (strcmp(gen->trait_impls[t].trait_name, "Drop") == 0 &&
+                    strcmp(gen->trait_impls[t].type_name, sname) == 0) {
+                    needs_dec = 1;
+                    break;
+                }
+            }
+            if (!needs_dec) {
+                for (int f = 0; f < decl->as.struct_decl.fields.count; f++) {
+                    Node* field = decl->as.struct_decl.fields.nodes[f];
+                    if (field->as.field.type && is_struct_type(field->as.field.type)) {
+                        needs_dec = 1;
+                        break;
+                    }
+                }
+            }
+            if (needs_dec) {
+                emit(gen, "static inline void __rc_dec_%s(%s* ptr);\n", sname, sname);
+            }
+        }
+    }
+    for (int i = 0; i < gen->generic_instance_count; i++) {
+        GenericInstance* info = &gen->generic_instances[i];
+        Type*            t    = info->type;
+        if (!t || t->kind != TYPE_STRUCT)
+            continue;
+        int has_drop = 0;
+        for (int ti = 0; ti < gen->trait_impl_count; ti++) {
+            if (strcmp(gen->trait_impls[ti].trait_name, "Drop") == 0 &&
+                strcmp(gen->trait_impls[ti].type_name, info->base_name) == 0) {
+                has_drop = 1;
+                break;
+            }
+        }
+        if (has_drop || t->as.struc.has_rc_fields) {
+            emit(gen, "static inline void __rc_dec_%s(%s* ptr);\n", info->mangled_name,
+                 info->mangled_name);
+        }
+    }
+    emit(gen, "\n");
+
     // Emit type-specific __rc_dec_TypeName functions for structs with Drop or RC fields
     // Non-generic structs: scan modules for struct decls with resolved types
     for (int m = 0; m < ast->as.program.modules.count; m++) {
@@ -2480,14 +2550,22 @@ void codegen_emit(CodeGen* gen, Node* ast) {
                     rc_field_names = xrealloc(rc_field_names, rc_field_count * sizeof(char*));
                     rc_field_type_names =
                         xrealloc(rc_field_type_names, rc_field_count * sizeof(char*));
-                    rc_field_names[rc_field_count - 1] = field->as.field.name;
+                    rc_field_names[rc_field_count - 1] = xstrdup(field->as.field.name);
                     // Get the type name for the field
                     if (field->as.field.type->type == NODE_IDENT) {
                         rc_field_type_names[rc_field_count - 1] =
-                            field->as.field.type->as.ident.name;
+                            xstrdup(field->as.field.type->as.ident.name);
                     } else if (field->as.field.type->type == NODE_GENERIC_TYPE) {
-                        // For generic types, we'd need the mangled name
-                        rc_field_type_names[rc_field_count - 1] = NULL;
+                        // Build mangled name for generic type field (e.g., Box<Inner> -> Box_Inner)
+                        Node*  gtype     = field->as.field.type;
+                        int    arg_count = gtype->as.generic_type.type_args.count;
+                        Type** args      = xmalloc(arg_count * sizeof(Type*));
+                        for (int a = 0; a < arg_count; a++) {
+                            args[a] = type_from_node(gtype->as.generic_type.type_args.nodes[a]);
+                        }
+                        rc_field_type_names[rc_field_count - 1] =
+                            type_mangle_generic(gtype->as.generic_type.base_name, args, arg_count);
+                        free(args);
                     } else {
                         rc_field_type_names[rc_field_count - 1] = NULL;
                     }
@@ -2510,7 +2588,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
                 const char* field_tname            = rc_field_type_names[f];
                 int         field_needs_custom_dec = 0;
                 if (field_tname) {
-                    // Check if field type implements Drop
+                    // Check if field type implements Drop (exact name match for non-generic)
                     for (int t = 0; t < gen->trait_impl_count; t++) {
                         if (strcmp(gen->trait_impls[t].trait_name, "Drop") == 0 &&
                             strcmp(gen->trait_impls[t].type_name, field_tname) == 0) {
@@ -2518,7 +2596,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
                             break;
                         }
                     }
-                    // Check if field type has RC fields (scan other structs)
+                    // Check if field type has RC fields (scan non-generic structs)
                     if (!field_needs_custom_dec) {
                         for (int si = 0;
                              si < ast->as.program.modules.count && !field_needs_custom_dec; si++) {
@@ -2544,6 +2622,19 @@ void codegen_emit(CodeGen* gen, Node* ast) {
                             }
                         }
                     }
+                    // Also check generic instances (e.g., field type "Box_Inner")
+                    if (!field_needs_custom_dec) {
+                        for (int gi = 0; gi < gen->generic_instance_count; gi++) {
+                            if (strcmp(gen->generic_instances[gi].mangled_name, field_tname) == 0) {
+                                Type* git = gen->generic_instances[gi].type;
+                                if (git && git->kind == TYPE_STRUCT &&
+                                    (git->as.struc.has_drop || git->as.struc.has_rc_fields)) {
+                                    field_needs_custom_dec = 1;
+                                }
+                                break;
+                            }
+                        }
+                    }
                 }
                 if (field_needs_custom_dec) {
                     emit(gen, "        __rc_dec_%s(ptr->%s);\n", field_tname, rc_field_names[f]);
@@ -2563,6 +2654,10 @@ void codegen_emit(CodeGen* gen, Node* ast) {
             emit(gen, "    }\n");
             emit(gen, "}\n\n");
 
+            for (int f = 0; f < rc_field_count; f++) {
+                free(rc_field_names[f]);
+                free(rc_field_type_names[f]);
+            }
             free(rc_field_names);
             free(rc_field_type_names);
         }

--- a/w0/test/drop_generic_impl.w
+++ b/w0/test/drop_generic_impl.w
@@ -1,0 +1,19 @@
+// Test: impl Drop for a generic struct type-checks
+trait Drop {
+    func drop(): void;
+}
+
+struct Box<T> {
+    item: T,
+}
+
+impl Drop for Box {
+    func (Box<T>) drop(): void {
+        // cleanup
+    }
+}
+
+func main(): i32 {
+    var b = new Box<i64> { item: 42 };
+    return 0;
+}

--- a/w0/test/rc_runtime/rc_drop_generic_basic.w
+++ b/w0/test/rc_runtime/rc_drop_generic_basic.w
@@ -1,0 +1,20 @@
+// RC RUNTIME TEST: Drop on generic struct is called when refcount reaches 0
+
+trait Drop {
+    func drop(): void;
+}
+
+struct Box<T> {
+    item: T,
+}
+
+impl Drop for Box {
+    func (Box<T>) drop(): void {
+        // Generic drop called
+    }
+}
+
+func main(): i32 {
+    var b = new Box<i64> { item: 42 };
+    return 0;
+}

--- a/w0/test/rc_runtime/rc_drop_generic_nested.w
+++ b/w0/test/rc_runtime/rc_drop_generic_nested.w
@@ -1,0 +1,31 @@
+// RC RUNTIME TEST: Non-generic Container holding Box<Inner> where Inner has Drop
+// Exercises Bug 2 fix: generic-instance fields in non-generic __rc_dec
+
+trait Drop {
+    func drop(): void;
+}
+
+struct Inner {
+    value: i64,
+}
+
+impl Drop for Inner {
+    func (Inner) drop(): void {
+        // Inner cleanup
+    }
+}
+
+struct Box<T> {
+    item: T,
+}
+
+struct Container {
+    wrapped: Box<Inner>,
+}
+
+func main(): i32 {
+    var inner = new Inner { value: 10 };
+    var b = new Box<Inner> { item: inner };
+    var c = new Container { wrapped: b };
+    return 0;
+}

--- a/w0/test/rc_runtime/rc_drop_generic_two_fields.w
+++ b/w0/test/rc_runtime/rc_drop_generic_two_fields.w
@@ -1,0 +1,37 @@
+// RC RUNTIME TEST: Generic Pair<A,B> where both A and B have Drop
+
+trait Drop {
+    func drop(): void;
+}
+
+struct Alpha {
+    id: i64,
+}
+
+impl Drop for Alpha {
+    func (Alpha) drop(): void {
+        // Alpha cleanup
+    }
+}
+
+struct Beta {
+    id: i64,
+}
+
+impl Drop for Beta {
+    func (Beta) drop(): void {
+        // Beta cleanup
+    }
+}
+
+struct Pair<A, B> {
+    first: A,
+    second: B,
+}
+
+func main(): i32 {
+    var a = new Alpha { id: 1 };
+    var b = new Beta { id: 2 };
+    var p = new Pair<Alpha, Beta> { first: a, second: b };
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Allow `impl Drop for GenericStruct` by falling back to `lookup_generic_def()` when `checker_lookup()` can't find the type, and propagating `has_drop` to each concrete instantiation
- Fix non-generic structs with generic-instance fields (e.g., `Box<Inner>`) to use `__rc_dec_MangledName()` instead of plain `__rc_dec()`, preventing nested RC child leaks
- Add forward declarations for all `__rc_dec_*` functions to handle cross-references between non-generic and generic cleanup functions
- Extend `collect_generic_methods` to scan inside `NODE_IMPL_DECL` blocks for generic method discovery

## Test plan

- [x] `make` — compiler builds without warnings
- [x] `make test` — all 85 tests pass (81 existing + 4 new)
- [x] New type-check test: `impl Drop for Box` where `Box<T>` is generic
- [x] New runtime tests: generic Drop called, nested generic field cleanup, multi-field generic cleanup
- [x] Manual inspection of generated C confirms correct `__rc_dec_*` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)