### PR TITLE
refactor: remove stack-based struct initialization

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -266,7 +266,6 @@ Create spans using slice syntax: `var s: Span<i64> = arr[:];`
                 | <enum-value-access>
                 | '(' <expression> ')'
                 | <new-expr>
-                | <struct-init>
                 | <tuple-literal>
                 | <array-literal>
 
@@ -275,8 +274,6 @@ Create spans using slice syntax: `var s: Span<i64> = arr[:];`
 <enum-value-access> ::= <identifier> '::' <identifier>
 
 <array-literal> ::= '[' [ <expression> { ',' <expression> } [ ',' ] ] ']'
-
-<struct-init> ::= '{' [ <field-init-list> ] '}'
 
 <field-init-list> ::= <field-init> { ',' <field-init> } [ ',' ]
 

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1724,17 +1724,7 @@ static void check_statement(Checker* checker, Node* node) {
         }
 
         if (node->as.var_decl.init) {
-            if (node->as.var_decl.init->type == NODE_STRUCT_INIT) {
-                if (!decl_type) {
-                    check_error(checker, node->line, node->column,
-                                "Struct initializer requires an explicit type");
-                    init_type = type_error;
-                } else {
-                    init_type = check_struct_init(checker, node->as.var_decl.init, decl_type);
-                }
-            } else {
-                init_type = check_expression(checker, node->as.var_decl.init);
-            }
+            init_type = check_expression(checker, node->as.var_decl.init);
         }
 
         Type* var_type;

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1264,31 +1264,7 @@ static void emit_stmt(CodeGen* gen, Node* node) {
             }
         }
         if (node->as.var_decl.init) {
-            if (struct_type && node->as.var_decl.init->type == NODE_STRUCT_INIT) {
-                // Struct type with struct init: allocate and initialize
-                // var p: Point = {...} => Point* p = malloc(sizeof(Point)); *p = (Point){...};
-                char* type_name = NULL;
-                if (node->as.var_decl.type->type == NODE_GENERIC_TYPE) {
-                    // Generic type: build mangled name (e.g., Box<i64> -> Box_i64)
-                    Node*  gtype     = node->as.var_decl.type;
-                    int    arg_count = gtype->as.generic_type.type_args.count;
-                    Type** args      = xmalloc(arg_count * sizeof(Type*));
-                    for (int i = 0; i < arg_count; i++) {
-                        args[i] = type_from_node(gtype->as.generic_type.type_args.nodes[i]);
-                    }
-                    type_name =
-                        type_mangle_generic(gtype->as.generic_type.base_name, args, arg_count);
-                    free(args);
-                } else {
-                    // Regular struct type
-                    type_name = xstrdup(node->as.var_decl.type->as.ident.name);
-                }
-                emit(gen, " = malloc(sizeof(%s));\n", type_name);
-                emit_indent(gen);
-                emit(gen, "*%s = (%s)", node->as.var_decl.name, type_name);
-                emit_struct_init(gen, node->as.var_decl.init);
-                free(type_name);
-            } else if (struct_type && node->as.var_decl.init->type == NODE_NULL_LIT) {
+            if (struct_type && node->as.var_decl.init->type == NODE_NULL_LIT) {
                 // Struct type with null: just assign NULL
                 emit(gen, " = NULL");
             } else {

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -563,10 +563,6 @@ static Node* parse_primary_expression(Parser* parser) {
         return node;
     }
 
-    if (match_token(parser, TOK_LBRACE)) {
-        return parse_struct_init(parser);
-    }
-
     // Array literal: [e1, e2, ...]
     if (match_token(parser, TOK_LBRACKET)) {
         Node* node = node_new(NODE_ARRAY_LIT, token.line, token.column);

--- a/w0/test/error_immutable_method.w
+++ b/w0/test/error_immutable_method.w
@@ -13,7 +13,7 @@ func (const Point) move(dx: i64, dy: i64): void {
 }
 
 func main(): i64 {
-    var p: Point = {x: 10, y: 20};
+    var p = new Point {x: 10, y: 20};
     p.move(5, 5);
 
     return 0;

--- a/w0/test/error_struct_init_missing_field.w
+++ b/w0/test/error_struct_init_missing_field.w
@@ -7,6 +7,6 @@ struct Point {
 }
 
 func main(): i32 {
-    var p: Point = {x: 10};
+    var p = new Point {x: 10};
     return p.x;
 }

--- a/w0/test/error_trait_bound.w
+++ b/w0/test/error_trait_bound.w
@@ -13,7 +13,7 @@ struct Plain {
 }
 
 func main(): i32 {
-    var p: Plain = {x: 1};
-    var b: Box<Plain> = {item: p};
+    var p = new Plain {x: 1};
+    var b = new Box<Plain> {item: p};
     return 0;
 }

--- a/w0/test/generics_basic.w
+++ b/w0/test/generics_basic.w
@@ -5,7 +5,7 @@ struct Box<T> {
 }
 
 func main(): i32 {
-    var b: Box<i64> = {value: 42};
+    var b = new Box<i64> {value: 42};
     if (b.value != 42) {
         return 1;
     }

--- a/w0/test/generics_methods.w
+++ b/w0/test/generics_methods.w
@@ -23,8 +23,8 @@ func (Pair<i32, Box<T>>) set(k: i32, v: Box<T>): void {
 }
 
 func main(): i32 {
-    var b: Box<i64> = {value: 10};
-    var p: Pair<i32, Box<i64>> = {key: 1, value: b};
+    var b = new Box<i64> {value: 10};
+    var p = new Pair<i32, Box<i64>> {key: 1, value: b};
 
     // Test get method
     if (b.get() != 10) {

--- a/w0/test/generics_pair.w
+++ b/w0/test/generics_pair.w
@@ -6,7 +6,7 @@ struct Pair<K, V> {
 }
 
 func main(): i32 {
-    var p: Pair<i64, i32> = {first: 100, second: 42};
+    var p = new Pair<i64, i32> {first: 100, second: 42};
     if (p.first != 100) {
         return 1;
     }

--- a/w0/test/methods.w
+++ b/w0/test/methods.w
@@ -20,7 +20,7 @@ func move_ref(p: Point): void {
 }
 
 func main(): i32 {
-    var p: Point = {x: 10, y: 20};
+    var p = new Point {x: 10, y: 20};
     p.move(5, 5);
     move_ref(p);     // Calls p.move(1, 1)
     return p.sum();  // Should return 42

--- a/w0/test/spans_with_generics.w
+++ b/w0/test/spans_with_generics.w
@@ -19,7 +19,7 @@ func main(): i32 {
     if (s[1] != 200) { return 2; }
 
     // Create a box with span value as element
-    var box: Box<i64> = {value: s[0]};
+    var box = new Box<i64> {value: s[0]};
     if (box.get() != 100) { return 3; }
 
     // Slice from span

--- a/w0/test/structs.w
+++ b/w0/test/structs.w
@@ -10,6 +10,6 @@ func distance(p: Point): i32 {
 }
 
 func main(): i32 {
-    var p: Point = {x: 10, y: 30};
+    var p = new Point {x: 10, y: 30};
     return distance(p);
 }

--- a/w0/test/traits_bounds.w
+++ b/w0/test/traits_bounds.w
@@ -17,7 +17,7 @@ struct Box<T: HasValue> {
 }
 
 func main(): i32 {
-    var w: Wrapper = {v: 42};
-    var b: Box<Wrapper> = {item: w};
+    var w = new Wrapper {v: 42};
+    var b = new Box<Wrapper> {item: w};
     return w.value();
 }

--- a/w0/test/visibility.w
+++ b/w0/test/visibility.w
@@ -46,10 +46,10 @@ public func (Point) magnitude_squared(): i64 {
 }
 
 func main(): i32 {
-    var p: Point = { x: 3, y: 4 };
+    var p = new Point { x: 3, y: 4 };
     var mag = p.magnitude_squared();
 
-    var data: InternalData = { value: 42 };
+    var data = new InternalData { value: 42 };
 
     var c: Color = Color::Red;
     var s: Status = Status::Done;


### PR DESCRIPTION
## Summary
- Remove the old `var x: Type = {...}` struct initialization syntax which used raw `malloc()` and wasn't RC-tracked (leaked memory)
- All struct creation now goes through `new Type {...}` which is properly RC-managed
- Update parser, checker, codegen, grammar docs, and 11 test files

## Test plan
- [x] `make` builds successfully
- [x] `make test` — all 85/85 tests pass (48 valid, 27 error, 10 RC runtime)
- [x] Error tests (`error_struct_init_missing_field`, `error_immutable_method`, `error_trait_bound`) still trigger expected errors with `new` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)