### PR TITLE
feat: add type aliases with generic support

### DIFF
--- a/features/type-aliases.md
+++ b/features/type-aliases.md
@@ -1,6 +1,8 @@
 # Type Aliases
 
-Named aliases for complex or semantic types.
+**Status: Implemented** (PR #55, `feature/type_aliases` branch)
+
+Named aliases for complex or semantic types. Aliases are purely compile-time — they resolve to the underlying type during type checking and produce no C code.
 
 ## Proposed Syntax
 
@@ -263,32 +265,17 @@ newtype_decl = "newtype" IDENTIFIER type_params? "=" type ";"
 
 ## Open Questions
 
-1. **Keyword choice?**
-   - `type` (Rust, TypeScript, Haskell)
-   - `alias` (Swift proposal)
-   - `typedef` (C, C++)
+1. **Keyword choice?** — Resolved: `type` (matches Rust, TypeScript, Haskell)
 
-2. **Support newtypes?**
-   - Separate `newtype` keyword?
-   - Use single-field structs?
-   - `distinct` modifier?
+2. **Support newtypes?** — Deferred: out of scope for initial implementation
 
-3. **Where can aliases appear?**
-   - Top-level only?
-   - Inside functions (local type aliases)?
-   - Inside structs?
+3. **Where can aliases appear?** — Resolved: top-level only (in module declarations)
 
-4. **Generic alias bounds?**
-   - `type Sortable<T: Ord> = Vec<T>`
-   - Propagate bounds or require at use site?
+4. **Generic alias bounds?** — Resolved: supported, bounds are checked at the alias definition site via `<T: Trait>` syntax
 
-5. **Associated type aliases?**
-   - Inside traits: `type Item;`
-   - Inside impls: `type Item = i64;`
+5. **Associated type aliases?** — Deferred: not yet implemented
 
-6. **Visibility of underlying type?**
-   - Can users see that `UserId = i64`?
-   - Or is it opaque outside the module?
+6. **Visibility of underlying type?** — Resolved: aliases are fully transparent; `public type` exports the alias
 
 ## Examples
 
@@ -333,6 +320,24 @@ type Box<T> = struct { value: T };
 type Lazy<T> = func(): T;
 type Cache<K, V> = HashMap<K, Lazy<V>>;
 ```
+
+## Implemented Scope
+
+- **Use case 1**: Semantic naming (`type UserId = i64;`)
+- **Use case 2**: Simplifying complex types (`type Pos = Point;`)
+- **Use case 3**: Generic partial application (`type IntBox = Box<i64>;`, `type StringPair<V> = Pair<string, V>;`)
+- Cycle detection via depth counter (max 16)
+- `public`/`private` visibility
+- Codegen resolves aliases to underlying types (no alias names in generated C)
+
+### Not Yet Implemented
+
+- Use case 4: Platform abstraction (requires conditional compilation)
+- Newtypes
+- Local type aliases (inside functions)
+- Associated type aliases (inside traits/impls)
+- Function type aliases (`type Handler = func(Request): Response;` — requires function types)
+- Recursive type aliases through indirection
 
 ## Related Features
 

--- a/grammar.md
+++ b/grammar.md
@@ -22,6 +22,7 @@ This document describes the grammar of the Whist language in BNF (Backus-Naur Fo
                | [ 'public' | 'private' ] <struct-decl>
                | [ 'public' | 'private' ] <enum-decl>
                | [ 'public' | 'private' ] <trait-decl>
+               | [ 'public' | 'private' ] <type-alias>
                | [ 'public' | 'private' ] <var-decl>
                | <impl-decl>
                | <extern-module>
@@ -111,6 +112,21 @@ Traits define a set of required method signatures that types can implement. Trai
 ```
 
 An `impl` block provides concrete method implementations for a trait on a specific type. Methods inside `impl` blocks do not specify a receiver — it is inferred from the `for Type` clause. Use `const func` for immutable-receiver methods. For generic target types, specify the type parameters on the impl header (e.g., `impl Drop for Box<T>`). All trait methods must be implemented.
+
+### Type Alias
+
+```bnf
+<type-alias> ::= 'type' <identifier> [ '<' <type-param-list> '>' ] '=' <type> ';'
+```
+
+Type aliases create alternative names for existing types. They are purely compile-time — aliases resolve to the underlying type during type checking and produce no C code.
+
+- **Simple alias:** `type UserId = i64;` — semantic naming for primitive types
+- **Struct alias:** `type Pos = Point;` — alternative name for a struct type
+- **Generic instantiation alias:** `type IntBox = Box<i64>;` — alias for a concrete generic instantiation
+- **Generic partial application:** `type StringPair<V> = Pair<string, V>;` — alias with its own type parameters that fills in some arguments of a generic type
+
+Aliases are fully interchangeable with the underlying type: `var id: UserId = 42;` is equivalent to `var id: i64 = 42;`.
 
 ### Variable Declaration
 
@@ -310,7 +326,7 @@ break    const    continue    defer     else      enum
 extern   false    for         foreach   func      if
 impl     import   in          new       null      public
 private  return   self        struct    trait     true
-var      while
+type     var      while
 ```
 
 ### Identifiers

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -258,6 +258,16 @@ void node_free(Node* node) {
         free(node->as.impl_decl.type_args.nodes);
         nodelist_free(&node->as.impl_decl.methods);
         break;
+    case NODE_TYPE_ALIAS:
+        free(node->as.type_alias.name);
+        node_free(node->as.type_alias.target_type);
+        for (int i = 0; i < node->as.type_alias.type_param_count; i++) {
+            free(node->as.type_alias.type_params[i]);
+            free(node->as.type_alias.type_param_bounds[i]);
+        }
+        free(node->as.type_alias.type_params);
+        free(node->as.type_alias.type_param_bounds);
+        break;
     case NODE_EXTERN_MODULE:
         nodelist_free(&node->as.extern_module.decls);
         free(node->as.extern_module.module_name);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -76,6 +76,7 @@ typedef enum {
     NODE_ENUM_VARIANT,
     NODE_TRAIT_DECL,
     NODE_IMPL_DECL,
+    NODE_TYPE_ALIAS,
 
     NODE_EXTERN_MODULE,
     NODE_MODULE,
@@ -411,6 +412,18 @@ struct Node {
             NodeList methods;   // List of func_decl nodes (with bodies and receivers)
             char*    source_module;
         } impl_decl;
+
+        // Type alias: type Name = TargetType; or type Name<T> = GenericType<T>;
+        struct {
+            int    is_public;
+            char*  name;
+            int    name_length;
+            Node*  target_type; // The RHS type expression
+            char*  source_module;
+            char** type_params;       // Generic params: ["T", "V"]
+            char** type_param_bounds; // Trait bounds (parallel array)
+            int    type_param_count;
+        } type_alias;
 
         struct {
             char*    module_name;

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -55,6 +55,7 @@ static void register_generic_def(Checker* checker, const char* name, char** type
     }
     def->type_param_count = type_param_count;
     def->decl             = decl;
+    def->is_type_alias    = 0;
     def->methods          = NULL;
     def->method_count     = 0;
     def->method_capacity  = 0;
@@ -193,6 +194,7 @@ void checker_init(Checker* checker) {
     checker->trait_impls         = NULL;
     checker->trait_impl_count    = 0;
     checker->trait_impl_capacity = 0;
+    checker->alias_depth         = 0;
     checker->enum_target_hint    = NULL;
     types_init();
 }
@@ -772,6 +774,38 @@ static Type* resolve_type(Checker* checker, Node* type_node) {
                     return type_error;
                 }
             }
+        }
+
+        // Handle generic type alias: substitute type params and resolve target
+        if (def->is_type_alias) {
+            checker->alias_depth++;
+            if (checker->alias_depth > 16) {
+                check_error(checker, type_node->line, type_node->column,
+                            "Recursive type alias '%s'", base_name);
+                checker->alias_depth--;
+                free(resolved_args);
+                return type_error;
+            }
+
+            // Set up substitution context
+            char** old_params = checker->current_type_params;
+            Type** old_args   = checker->current_type_args;
+            int    old_count  = checker->current_type_param_count;
+
+            checker->current_type_params      = def->type_params;
+            checker->current_type_args        = resolved_args;
+            checker->current_type_param_count = def->type_param_count;
+
+            Type* result = resolve_type(checker, def->decl->as.type_alias.target_type);
+
+            // Restore context
+            checker->current_type_params      = old_params;
+            checker->current_type_args        = old_args;
+            checker->current_type_param_count = old_count;
+
+            checker->alias_depth--;
+            free(resolved_args);
+            return result;
         }
 
         // Generate mangled name
@@ -2516,6 +2550,45 @@ static void check_decl(Checker* checker, Node* node) {
         break;
     }
 
+    case NODE_TYPE_ALIAS: {
+        const char* name = node->as.type_alias.name;
+
+        // Check for redefinition
+        if (checker_lookup(checker, name)) {
+            check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+            return;
+        }
+
+        // Generic type alias: register as a generic def template
+        if (node->as.type_alias.type_param_count > 0) {
+            register_generic_def(checker, name, node->as.type_alias.type_params,
+                                 node->as.type_alias.type_param_bounds,
+                                 node->as.type_alias.type_param_count, node);
+            // Mark as type alias so resolve_type can handle it differently
+            GenericDef* def    = lookup_generic_def(checker, name);
+            def->is_type_alias = 1;
+            return;
+        }
+
+        // Non-generic type alias: resolve the target type and define the symbol
+        checker->alias_depth++;
+        if (checker->alias_depth > 16) {
+            check_error(checker, node->line, node->column, "Recursive type alias '%s'", name);
+            checker->alias_depth--;
+            return;
+        }
+        Type* resolved = resolve_type(checker, node->as.type_alias.target_type);
+        checker->alias_depth--;
+
+        if (resolved == type_error) {
+            return;
+        }
+
+        checker_define(checker, name, SYM_TYPE, resolved, 0, node->as.type_alias.is_public,
+                       checker->current_module);
+        break;
+    }
+
     case NODE_IMPL_DECL: {
         const char* trait_name    = node->as.impl_decl.trait_name;
         const char* type_name_str = node->as.impl_decl.type_name;
@@ -2688,7 +2761,7 @@ int checker_check(Checker* checker, Node* ast) {
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             if (decl->type == NODE_STRUCT_DECL || decl->type == NODE_ENUM_DECL ||
-                decl->type == NODE_TRAIT_DECL) {
+                decl->type == NODE_TRAIT_DECL || decl->type == NODE_TYPE_ALIAS) {
                 check_decl(checker, decl);
             }
         }
@@ -2708,7 +2781,7 @@ int checker_check(Checker* checker, Node* ast) {
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             if (decl->type != NODE_STRUCT_DECL && decl->type != NODE_ENUM_DECL &&
-                decl->type != NODE_TRAIT_DECL) {
+                decl->type != NODE_TRAIT_DECL && decl->type != NODE_TYPE_ALIAS) {
                 check_decl(checker, decl);
             }
         }
@@ -2725,7 +2798,7 @@ int checker_check(Checker* checker, Node* ast) {
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             if (decl->type != NODE_STRUCT_DECL && decl->type != NODE_ENUM_DECL &&
-                decl->type != NODE_TRAIT_DECL) {
+                decl->type != NODE_TRAIT_DECL && decl->type != NODE_TYPE_ALIAS) {
                 check_decl(checker, decl);
             }
         }

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -44,7 +44,8 @@ typedef struct {
     char** type_params;       // ["T"] or ["K", "V"]
     char** type_param_bounds; // Trait bounds (NULL entries = unbounded)
     int    type_param_count;
-    Node*  decl; // Original AST node for field type resolution
+    Node*  decl;          // Original AST node for field type resolution
+    int    is_type_alias; // 1 if this is a generic type alias, 0 for struct/enum
     // Methods on the generic struct
     Node** methods; // Array of NODE_FUNC_DECL
     int    method_count;
@@ -109,6 +110,9 @@ struct Checker {
     TraitImpl* trait_impls;
     int        trait_impl_count;
     int        trait_impl_capacity;
+
+    // Type alias cycle detection
+    int alias_depth;
 
     // Hint for generic enum type inference (set by var_decl when declared type is known)
     Type* enum_target_hint;

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -482,19 +482,34 @@ void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, i
     gen->enum_name_count        = 0;
     gen->enum_name_capacity     = 0;
     gen->enum_has_rc_fields     = NULL;
+    gen->alias_names            = NULL;
+    gen->alias_targets          = NULL;
+    gen->alias_count            = 0;
+    gen->alias_capacity         = 0;
 }
 
 void codegen_emit(CodeGen* gen, Node* ast) {
     if (!ast || ast->type != NODE_PROGRAM)
         return;
 
-    // First pass: collect all tuple types
+    // First pass: collect all tuple types and type aliases
     for (int m = 0; m < ast->as.program.modules.count; m++) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
             continue;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
-            collect_tuple_types_from_decl(gen, mod->as.module.decls.nodes[i]);
+            Node* decl = mod->as.module.decls.nodes[i];
+            collect_tuple_types_from_decl(gen, decl);
+            // Collect non-generic type aliases for codegen resolution
+            if (decl->type == NODE_TYPE_ALIAS && decl->as.type_alias.type_param_count == 0) {
+                VEC_GROW(gen->alias_names, gen->alias_count, gen->alias_capacity);
+                // Grow alias_targets in parallel (realloc to match capacity)
+                gen->alias_targets =
+                    xrealloc(gen->alias_targets, gen->alias_capacity * sizeof(Node*));
+                gen->alias_names[gen->alias_count]   = decl->as.type_alias.name;
+                gen->alias_targets[gen->alias_count] = decl->as.type_alias.target_type;
+                gen->alias_count++;
+            }
         }
     }
 

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -55,6 +55,11 @@ typedef struct {
     int    enum_name_count;
     int    enum_name_capacity;
     int*   enum_has_rc_fields; // Parallel to enum_names
+    // Type alias tracking (alias name -> target type node)
+    char** alias_names;
+    Node** alias_targets;
+    int    alias_count;
+    int    alias_capacity;
 } CodeGen;
 
 void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, int generic_count,

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -161,10 +161,24 @@ int enum_has_rc_fields(CodeGen* gen, const char* name) {
     return gen->enum_has_rc_fields[idx];
 }
 
+// Resolve a type node through aliases. If the node is a NODE_IDENT
+// that names a type alias, return the alias target node instead.
+static Node* resolve_alias(CodeGen* gen, Node* type_node) {
+    if (!type_node || type_node->type != NODE_IDENT)
+        return type_node;
+    for (int i = 0; i < gen->alias_count; i++) {
+        if (strcmp(gen->alias_names[i], type_node->as.ident.name) == 0) {
+            return gen->alias_targets[i];
+        }
+    }
+    return type_node;
+}
+
 // Check if a type node represents a struct (user-defined) type
 static int is_struct_type(CodeGen* gen, Node* type_node) {
     if (!type_node)
         return 0;
+    type_node = resolve_alias(gen, type_node);
     // Generic types (Box<i64>) are always struct types, except Span<T> and generic enums
     if (type_node->type == NODE_GENERIC_TYPE) {
         if (strcmp(type_node->as.generic_type.base_name, "Span") == 0) {
@@ -188,6 +202,7 @@ static int is_struct_type(CodeGen* gen, Node* type_node) {
 int type_node_has_rc(CodeGen* gen, Node* type_node) {
     if (!type_node)
         return 0;
+    type_node = resolve_alias(gen, type_node);
     if (type_node->type == NODE_GENERIC_TYPE) {
         if (strcmp(type_node->as.generic_type.base_name, "Span") == 0)
             return 0;
@@ -233,6 +248,7 @@ int type_node_has_rc(CodeGen* gen, Node* type_node) {
 const char* resolve_enum_name(CodeGen* gen, Node* type_node) {
     if (!type_node)
         return NULL;
+    type_node = resolve_alias(gen, type_node);
     if (type_node->type == NODE_GENERIC_TYPE) {
         char* mangled = build_mangled_name_from_generic_node(gen, type_node);
         if (is_enum_type_name(gen, mangled)) {
@@ -395,8 +411,19 @@ void emit_type(CodeGen* gen, Node* type_node) {
             // Enum type - value type, no pointer
             emit(gen, "%s", name);
         } else {
-            // User-defined struct type - emit as pointer (struct references)
-            emit(gen, "%s*", name);
+            // Check if this is a type alias — resolve to target type
+            int alias_found = 0;
+            for (int i = 0; i < gen->alias_count; i++) {
+                if (strcmp(gen->alias_names[i], name) == 0) {
+                    emit_type(gen, gen->alias_targets[i]);
+                    alias_found = 1;
+                    break;
+                }
+            }
+            if (!alias_found) {
+                // User-defined struct type - emit as pointer (struct references)
+                emit(gen, "%s*", name);
+            }
         }
         break;
     }
@@ -1764,6 +1791,10 @@ void emit_decl(CodeGen* gen, Node* node) {
 
     case NODE_TRAIT_DECL:
         // Traits produce no C code - they are purely a type-checking concept
+        break;
+
+    case NODE_TYPE_ALIAS:
+        // Type aliases produce no C code - they are resolved during type checking
         break;
 
     case NODE_IMPL_DECL:

--- a/w0/lexer.c
+++ b/w0/lexer.c
@@ -128,8 +128,8 @@ static const Keyword keywords[] = {
     {"public", 6, TOK_PUBLIC},   {"private", 7, TOK_PRIVATE},
     {"return", 6, TOK_RETURN},   {"self", 4, TOK_SELF},
     {"struct", 6, TOK_STRUCT},   {"trait", 5, TOK_TRAIT},
-    {"true", 4, TOK_TRUE},       {"var", 3, TOK_VAR},
-    {"while", 5, TOK_WHILE},
+    {"true", 4, TOK_TRUE},       {"type", 4, TOK_TYPE},
+    {"var", 3, TOK_VAR},         {"while", 5, TOK_WHILE},
 };
 
 static const size_t keyword_count = sizeof(keywords) / sizeof(keywords[0]);
@@ -389,6 +389,7 @@ static const char* token_names[] = {
     [TOK_STRUCT]      = "STRUCT",
     [TOK_ENUM]        = "ENUM",
     [TOK_TRAIT]       = "TRAIT",
+    [TOK_TYPE]        = "TYPE",
     [TOK_IMPL]        = "IMPL",
     [TOK_FUNC]        = "FUNC",
     [TOK_VAR]         = "VAR",

--- a/w0/lexer.h
+++ b/w0/lexer.h
@@ -26,6 +26,7 @@ typedef enum {
     TOK_STRUCT,
     TOK_ENUM,
     TOK_TRAIT,
+    TOK_TYPE,
     TOK_IMPL,
     TOK_FUNC,
     TOK_VAR,

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -114,6 +114,7 @@ void synchronize(Parser* parser) {
         case TOK_STRUCT:
         case TOK_ENUM:
         case TOK_TRAIT:
+        case TOK_TYPE:
         case TOK_IMPL:
         case TOK_VAR:
         case TOK_CONST:
@@ -203,7 +204,7 @@ static Node* parse_type(Parser* parser) {
         consume_token(parser, TOK_RBRACKET, "Expected ']' in array type");
         Node* elem = parse_type(parser);
 
-        Node* node = node_new(NODE_ARRAY_TYPE, token.line, token.column);
+        Node* node                    = node_new(NODE_ARRAY_TYPE, token.line, token.column);
         node->as.array_type.elem_type = elem;
         node->as.array_type.size      = size;
         return node;
@@ -215,7 +216,7 @@ static Node* parse_type(Parser* parser) {
         if (check_token(parser, TOK_LT)) {
             advance_token(parser); // consume '<'
 
-            Node* node = node_new(NODE_GENERIC_TYPE, token.line, token.column);
+            Node* node                      = node_new(NODE_GENERIC_TYPE, token.line, token.column);
             node->as.generic_type.base_name = copy_token_string(&token);
             node->as.generic_type.base_name_length = token.length;
             nodelist_init(&node->as.generic_type.type_args);
@@ -247,8 +248,8 @@ static Node* parse_type(Parser* parser) {
         }
 
         // Regular named type (not generic)
-        Node* node = node_new(NODE_IDENT, token.line, token.column);
-        node->as.ident.name = copy_token_string(&token);
+        Node* node            = node_new(NODE_IDENT, token.line, token.column);
+        node->as.ident.name   = copy_token_string(&token);
         node->as.ident.length = token.length;
         return node;
     }
@@ -272,7 +273,7 @@ static Node* parse_struct_init(Parser* parser) {
             consume_token(parser, TOK_IDENT, "Expected field name in struct initializer");
 
             Node* field = node_new(NODE_FIELD_INIT, field_name.line, field_name.column);
-            field->as.field_init.name = copy_token_string(&field_name);
+            field->as.field_init.name        = copy_token_string(&field_name);
             field->as.field_init.name_length = field_name.length;
 
             consume_token(parser, TOK_COLON, "Expected ':' after field name");
@@ -329,7 +330,7 @@ static Node* parse_primary_expression(Parser* parser) {
     }
 
     if (match_token(parser, TOK_FLOAT)) {
-        Node* node = node_new(NODE_FLOAT_LIT, token.line, token.column);
+        Node* node               = node_new(NODE_FLOAT_LIT, token.line, token.column);
         node->as.float_lit.value = strtod(token.start, NULL);
         return node;
     }
@@ -368,7 +369,7 @@ static Node* parse_primary_expression(Parser* parser) {
     }
 
     if (match_token(parser, TOK_TRUE) || match_token(parser, TOK_FALSE)) {
-        Node* node = node_new(NODE_BOOL_LIT, token.line, token.column);
+        Node* node              = node_new(NODE_BOOL_LIT, token.line, token.column);
         node->as.bool_lit.value = (token.type == TOK_TRUE);
         return node;
     }
@@ -387,9 +388,9 @@ static Node* parse_primary_expression(Parser* parser) {
             consume_token(parser, TOK_IDENT, "Expected enum value name after '::'");
 
             Node* node = node_new(NODE_ENUM_VALUE, enum_name.line, enum_name.column);
-            node->as.enum_value.enum_name = copy_token_string(&enum_name);
-            node->as.enum_value.enum_name_length = enum_name.length;
-            node->as.enum_value.value_name       = copy_token_string(&value_name);
+            node->as.enum_value.enum_name         = copy_token_string(&enum_name);
+            node->as.enum_value.enum_name_length  = enum_name.length;
+            node->as.enum_value.value_name        = copy_token_string(&value_name);
             node->as.enum_value.value_name_length = value_name.length;
             nodelist_init(&node->as.enum_value.args);
 
@@ -410,15 +411,15 @@ static Node* parse_primary_expression(Parser* parser) {
             return node;
         }
 
-        Node* node = node_new(NODE_IDENT, token.line, token.column);
-        node->as.ident.name = copy_token_string(&token);
+        Node* node            = node_new(NODE_IDENT, token.line, token.column);
+        node->as.ident.name   = copy_token_string(&token);
         node->as.ident.length = token.length;
         return node;
     }
 
     // Handle 'self' keyword as an identifier
     if (match_token(parser, TOK_SELF)) {
-        Node* node = node_new(NODE_IDENT, token.line, token.column);
+        Node* node            = node_new(NODE_IDENT, token.line, token.column);
         node->as.ident.name   = xstrdup("self");
         node->as.ident.length = 4;
         return node;
@@ -477,7 +478,7 @@ static Node* parse_primary_expression(Parser* parser) {
             node_free(type_node);
             return NULL;
         }
-        Node* node = node_new(NODE_NEW_EXPR, new_token.line, new_token.column);
+        Node* node                      = node_new(NODE_NEW_EXPR, new_token.line, new_token.column);
         node->as.new_expr.type_node     = type_node;
         node->as.new_expr.init          = init;
         node->as.new_expr.resolved_type = NULL;
@@ -535,7 +536,7 @@ static Node* parse_postfix(Parser* parser) {
     for (;;) {
         if (match_token(parser, TOK_LPAREN)) {
             // Function call
-            Node* call = node_new(NODE_CALL, expr->line, expr->column);
+            Node* call         = node_new(NODE_CALL, expr->line, expr->column);
             call->as.call.func = expr;
             nodelist_init(&call->as.call.args);
 
@@ -559,7 +560,7 @@ static Node* parse_postfix(Parser* parser) {
                 if (!check_token(parser, TOK_RBRACKET)) {
                     end = parse_expression(parser);
                 }
-                Node* slice = node_new(NODE_SLICE, expr->line, expr->column);
+                Node* slice            = node_new(NODE_SLICE, expr->line, expr->column);
                 slice->as.slice.object = expr;
                 slice->as.slice.start  = NULL;
                 slice->as.slice.end    = end;
@@ -574,7 +575,7 @@ static Node* parse_postfix(Parser* parser) {
                     if (!check_token(parser, TOK_RBRACKET)) {
                         end = parse_expression(parser);
                     }
-                    Node* slice = node_new(NODE_SLICE, expr->line, expr->column);
+                    Node* slice            = node_new(NODE_SLICE, expr->line, expr->column);
                     slice->as.slice.object = expr;
                     slice->as.slice.start  = first;
                     slice->as.slice.end    = end;
@@ -582,7 +583,7 @@ static Node* parse_postfix(Parser* parser) {
                     expr = slice;
                 } else {
                     // Regular index [expr]
-                    Node* index = node_new(NODE_INDEX, expr->line, expr->column);
+                    Node* index            = node_new(NODE_INDEX, expr->line, expr->column);
                     index->as.index.object = expr;
                     index->as.index.index  = first;
                     consume_token(parser, TOK_RBRACKET, "Expected ']'");
@@ -593,7 +594,7 @@ static Node* parse_postfix(Parser* parser) {
             // Member access
             Token name = parser->current;
             consume_token(parser, TOK_IDENT, "Expected member name after '.'");
-            Node* member = node_new(NODE_MEMBER, expr->line, expr->column);
+            Node* member             = node_new(NODE_MEMBER, expr->line, expr->column);
             member->as.member.object = expr;
             member->as.member.name   = copy_token_string(&name);
             member->as.member.length = name.length;
@@ -610,9 +611,9 @@ static Node* parse_postfix(Parser* parser) {
 static Node* parse_unary(Parser* parser) {
     if (match_token(parser, TOK_BANG) || match_token(parser, TOK_MINUS) ||
         match_token(parser, TOK_TILDE)) {
-        Token op      = parser->previous;
-        Node* operand = parse_unary(parser);
-        Node* node    = node_new(NODE_UNARY, op.line, op.column);
+        Token op               = parser->previous;
+        Node* operand          = parse_unary(parser);
+        Node* node             = node_new(NODE_UNARY, op.line, op.column);
         node->as.unary.op      = op.type;
         node->as.unary.operand = operand;
         return node;
@@ -678,7 +679,7 @@ static Node* parse_binary(Parser* parser, Precedence min_prec) {
         Precedence prec  = get_precedence(op.type);
         Node*      right = parse_binary(parser, prec + 1);
 
-        Node* binary = node_new(NODE_BINARY, op.line, op.column);
+        Node* binary            = node_new(NODE_BINARY, op.line, op.column);
         binary->as.binary.op    = op.type;
         binary->as.binary.left  = left;
         binary->as.binary.right = right;
@@ -718,7 +719,7 @@ static Node* parse_expression(Parser* parser) {
         advance_token(parser);
         Node* value = parse_expression(parser); // Right associative
 
-        Node* assign = node_new(NODE_ASSIGN, op.line, op.column);
+        Node* assign             = node_new(NODE_ASSIGN, op.line, op.column);
         assign->as.assign.op     = op.type;
         assign->as.assign.target = expr;
         assign->as.assign.value  = value;
@@ -771,7 +772,7 @@ static Node* parse_if_stmt(Parser* parser) {
         }
     }
 
-    Node* node = node_new(NODE_IF, token.line, token.column);
+    Node* node                  = node_new(NODE_IF, token.line, token.column);
     node->as.if_stmt.cond       = cond;
     node->as.if_stmt.then_block = then_block;
     node->as.if_stmt.else_block = else_block;
@@ -787,7 +788,7 @@ static Node* parse_while_stmt(Parser* parser) {
     consume_token(parser, TOK_LBRACE, "Expected '{' after while condition");
     Node* body = parse_block(parser);
 
-    Node* node = node_new(NODE_WHILE, token.line, token.column);
+    Node* node               = node_new(NODE_WHILE, token.line, token.column);
     node->as.while_stmt.cond = cond;
     node->as.while_stmt.body = body;
     return node;
@@ -823,7 +824,7 @@ static Node* parse_for_stmt(Parser* parser) {
     consume_token(parser, TOK_LBRACE, "Expected '{' after for clauses");
     Node* body = parse_block(parser);
 
-    Node* node = node_new(NODE_FOR, token.line, token.column);
+    Node* node             = node_new(NODE_FOR, token.line, token.column);
     node->as.for_stmt.init = init;
     node->as.for_stmt.cond = cond;
     node->as.for_stmt.post = post;
@@ -859,7 +860,7 @@ static Node* parse_foreach_stmt(Parser* parser) {
         step = parse_expression(parser);
     } else {
         // Default step is 1
-        step = node_new(NODE_INT_LIT, token.line, token.column);
+        step                   = node_new(NODE_INT_LIT, token.line, token.column);
         step->as.int_lit.value = 1;
     }
 
@@ -867,7 +868,7 @@ static Node* parse_foreach_stmt(Parser* parser) {
     consume_token(parser, TOK_LBRACE, "Expected '{' after foreach clauses");
     Node* body = parse_block(parser);
 
-    Node* node = node_new(NODE_FOREACH, token.line, token.column);
+    Node* node                            = node_new(NODE_FOREACH, token.line, token.column);
     node->as.foreach_stmt.var_name        = var_name;
     node->as.foreach_stmt.var_name_length = var_token.length;
     node->as.foreach_stmt.start           = start;
@@ -886,7 +887,7 @@ static Node* parse_return_stmt(Parser* parser) {
     }
     consume_token(parser, TOK_SEMICOLON, "Expected ';' after return value");
 
-    Node* node = node_new(NODE_RETURN, token.line, token.column);
+    Node* node                 = node_new(NODE_RETURN, token.line, token.column);
     node->as.return_stmt.value = value;
     return node;
 }
@@ -897,7 +898,7 @@ static Node* parse_defer_stmt(Parser* parser) {
     // Parse the deferred statement (typically an expression statement like a function call)
     Node* stmt = parse_statement(parser);
 
-    Node* node = node_new(NODE_DEFER, token.line, token.column);
+    Node* node               = node_new(NODE_DEFER, token.line, token.column);
     node->as.defer_stmt.stmt = stmt;
     return node;
 }
@@ -1035,8 +1036,8 @@ static Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
             return NULL;
         }
 
-        Node* node = node_new(NODE_VAR_DECL, start.line, start.column);
-        var_decl_node* vdn = &node->as.var_decl;
+        Node*          node = node_new(NODE_VAR_DECL, start.line, start.column);
+        var_decl_node* vdn  = &node->as.var_decl;
 
         vdn->name             = NULL; // NULL indicates destructuring
         vdn->name_length      = 0;
@@ -1067,10 +1068,10 @@ static Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
     Token name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected variable name");
 
-    Node* node = node_new(NODE_VAR_DECL, name.line, name.column);
-    var_decl_node* vdn = &node->as.var_decl;
+    Node*          node = node_new(NODE_VAR_DECL, name.line, name.column);
+    var_decl_node* vdn  = &node->as.var_decl;
 
-    vdn->name = copy_token_string(&name);
+    vdn->name             = copy_token_string(&name);
     vdn->is_public        = is_public;
     vdn->name_length      = name.length;
     vdn->is_const         = is_const;
@@ -1112,7 +1113,7 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
         // Expect struct type name
         Token recv_type = parser->current;
         consume_token(parser, TOK_IDENT, "Expected receiver type name");
-        receiver_type = copy_token_string(&recv_type);
+        receiver_type     = copy_token_string(&recv_type);
         receiver_type_len = recv_type.length;
 
         // Check for generic type args: Box<T> or Pair<K, V> or Pair<i32, Box<T>>
@@ -1136,8 +1137,8 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
     Token name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected function name");
 
-    Node* node = node_new(NODE_FUNC_DECL, name.line, name.column);
-    func_decl_node* fdn = &node->as.func_decl;
+    Node*           node = node_new(NODE_FUNC_DECL, name.line, name.column);
+    func_decl_node* fdn  = &node->as.func_decl;
 
     fdn->is_public          = is_public;
     fdn->is_extern          = 0;
@@ -1146,8 +1147,8 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
     fdn->receiver_is_const  = receiver_is_const;
     fdn->receiver_type_args = receiver_type_args;
     fdn->name               = copy_token_string(&name);
-    fdn->name_length = name.length;
-    fdn->is_varargs  = 0;
+    fdn->name_length        = name.length;
+    fdn->is_varargs         = 0;
     nodelist_init(&fdn->params);
 
     consume_token(parser, TOK_LPAREN, "Expected '(' after function name");
@@ -1176,7 +1177,7 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
                 Token param_name = parser->current;
                 consume_token(parser, TOK_IDENT, "Expected parameter name");
 
-                Node* param = node_new(NODE_PARAM, param_name.line, param_name.column);
+                Node* param          = node_new(NODE_PARAM, param_name.line, param_name.column);
                 param->as.param.name = copy_token_string(&param_name);
                 param->as.param.name_length = param_name.length;
                 param->as.param.type        = NULL;
@@ -1229,9 +1230,9 @@ static Node* parse_struct_decl(Parser* parser, int is_public) {
     Token name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected struct name");
 
-    Node* node = node_new(NODE_STRUCT_DECL, name.line, name.column);
-    node->as.struct_decl.is_public = is_public;
-    node->as.struct_decl.name      = copy_token_string(&name);
+    Node* node                       = node_new(NODE_STRUCT_DECL, name.line, name.column);
+    node->as.struct_decl.is_public   = is_public;
+    node->as.struct_decl.name        = copy_token_string(&name);
     node->as.struct_decl.name_length = name.length;
     nodelist_init(&node->as.struct_decl.fields);
 
@@ -1285,8 +1286,8 @@ static Node* parse_struct_decl(Parser* parser, int is_public) {
         Token field_name = parser->current;
         consume_token(parser, TOK_IDENT, "Expected field name");
 
-        Node* field = node_new(NODE_FIELD, field_name.line, field_name.column);
-        field->as.field.name = copy_token_string(&field_name);
+        Node* field                 = node_new(NODE_FIELD, field_name.line, field_name.column);
+        field->as.field.name        = copy_token_string(&field_name);
         field->as.field.name_length = field_name.length;
 
         consume_token(parser, TOK_COLON, "Expected ':' after field name");
@@ -1309,9 +1310,9 @@ static Node* parse_trait_decl(Parser* parser, int is_public) {
     Token name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected trait name");
 
-    Node* node = node_new(NODE_TRAIT_DECL, name.line, name.column);
-    node->as.trait_decl.is_public = is_public;
-    node->as.trait_decl.name      = copy_token_string(&name);
+    Node* node                      = node_new(NODE_TRAIT_DECL, name.line, name.column);
+    node->as.trait_decl.is_public   = is_public;
+    node->as.trait_decl.name        = copy_token_string(&name);
     node->as.trait_decl.name_length = name.length;
     nodelist_init(&node->as.trait_decl.methods);
 
@@ -1349,11 +1350,11 @@ static Node* parse_impl_decl(Parser* parser) {
     Token type_name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected type name after 'for'");
 
-    Node* node = node_new(NODE_IMPL_DECL, trait_name.line, trait_name.column);
+    Node* node                    = node_new(NODE_IMPL_DECL, trait_name.line, trait_name.column);
     node->as.impl_decl.trait_name = copy_token_string(&trait_name);
     node->as.impl_decl.trait_name_length = trait_name.length;
     node->as.impl_decl.type_name         = copy_token_string(&type_name);
-    node->as.impl_decl.type_name_length = type_name.length;
+    node->as.impl_decl.type_name_length  = type_name.length;
     nodelist_init(&node->as.impl_decl.type_args);
     nodelist_init(&node->as.impl_decl.methods);
 
@@ -1414,9 +1415,9 @@ static Node* parse_enum_decl(Parser* parser, int is_public) {
     Token name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected enum name");
 
-    Node* node = node_new(NODE_ENUM_DECL, name.line, name.column);
-    node->as.enum_decl.is_public = is_public;
-    node->as.enum_decl.name      = copy_token_string(&name);
+    Node* node                     = node_new(NODE_ENUM_DECL, name.line, name.column);
+    node->as.enum_decl.is_public   = is_public;
+    node->as.enum_decl.name        = copy_token_string(&name);
     node->as.enum_decl.name_length = name.length;
     nodelist_init(&node->as.enum_decl.values);
 
@@ -1467,7 +1468,7 @@ static Node* parse_enum_decl(Parser* parser, int is_public) {
         consume_token(parser, TOK_IDENT, "Expected enum value name");
 
         Node* value = node_new(NODE_ENUM_VARIANT, value_name.line, value_name.column);
-        value->as.enum_variant.name = copy_token_string(&value_name);
+        value->as.enum_variant.name        = copy_token_string(&value_name);
         value->as.enum_variant.name_length = value_name.length;
         nodelist_init(&value->as.enum_variant.types);
 
@@ -1498,12 +1499,68 @@ static Node* parse_enum_decl(Parser* parser, int is_public) {
     return node;
 }
 
+static Node* parse_type_alias(Parser* parser, int is_public) {
+    Token name = parser->current;
+    consume_token(parser, TOK_IDENT, "Expected type alias name");
+
+    Node* node                      = node_new(NODE_TYPE_ALIAS, name.line, name.column);
+    node->as.type_alias.is_public   = is_public;
+    node->as.type_alias.name        = copy_token_string(&name);
+    node->as.type_alias.name_length = name.length;
+
+    // Parse optional type parameters: type StringMap<V> = ...
+    node->as.type_alias.type_params       = NULL;
+    node->as.type_alias.type_param_bounds = NULL;
+    node->as.type_alias.type_param_count  = 0;
+
+    if (match_token(parser, TOK_LT)) {
+        int capacity                          = 4;
+        node->as.type_alias.type_params       = xmalloc(capacity * sizeof(char*));
+        node->as.type_alias.type_param_bounds = xmalloc(capacity * sizeof(char*));
+
+        do {
+            Token param_name = parser->current;
+            consume_token(parser, TOK_IDENT, "Expected type parameter name");
+
+            if (node->as.type_alias.type_param_count >= capacity) {
+                capacity *= 2;
+                node->as.type_alias.type_params =
+                    xrealloc(node->as.type_alias.type_params, capacity * sizeof(char*));
+                node->as.type_alias.type_param_bounds =
+                    xrealloc(node->as.type_alias.type_param_bounds, capacity * sizeof(char*));
+            }
+
+            node->as.type_alias.type_params[node->as.type_alias.type_param_count] =
+                copy_token_string(&param_name);
+
+            // Check for trait bound: V: TraitName
+            if (match_token(parser, TOK_COLON)) {
+                Token bound_name = parser->current;
+                consume_token(parser, TOK_IDENT, "Expected trait name after ':'");
+                node->as.type_alias.type_param_bounds[node->as.type_alias.type_param_count] =
+                    copy_token_string(&bound_name);
+            } else {
+                node->as.type_alias.type_param_bounds[node->as.type_alias.type_param_count] = NULL;
+            }
+
+            node->as.type_alias.type_param_count++;
+        } while (match_token(parser, TOK_COMMA));
+
+        consume_token(parser, TOK_GT, "Expected '>' after type parameters");
+    }
+
+    consume_token(parser, TOK_EQ, "Expected '=' after type alias name");
+    node->as.type_alias.target_type = parse_type(parser);
+    consume_token(parser, TOK_SEMICOLON, "Expected ';' after type alias");
+    return node;
+}
+
 static Node* parse_extern_decls(Parser* parser, int is_public) {
     Token module_name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected module name string after 'extern'");
 
     Node* node = node_new(NODE_EXTERN_MODULE, module_name.line, module_name.column);
-    node->as.extern_module.module_name = copy_token_string(&module_name);
+    node->as.extern_module.module_name        = copy_token_string(&module_name);
     node->as.extern_module.module_name_length = module_name.length;
     nodelist_init(&node->as.extern_module.decls);
     consume_token(parser, TOK_LBRACE, "Expected '{' after extern module name");
@@ -1852,6 +1909,9 @@ static Node* parse_declaration(Parser* parser) {
     if (match_token(parser, TOK_TRAIT)) {
         return parse_trait_decl(parser, is_public);
     }
+    if (match_token(parser, TOK_TYPE)) {
+        return parse_type_alias(parser, is_public);
+    }
     if (match_token(parser, TOK_IMPL)) {
         return parse_impl_decl(parser);
     }
@@ -1928,7 +1988,7 @@ Node* parser_parse(Parser* parser) {
     nodelist_init(&program->as.program.modules);
 
     // Create main module for the entry file
-    Node* main_module = node_new(NODE_MODULE, 1, 1);
+    Node* main_module                  = node_new(NODE_MODULE, 1, 1);
     main_module->as.module.name        = xstrdup("main");
     main_module->as.module.name_length = 4;
     nodelist_init(&main_module->as.module.decls);

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -412,6 +412,24 @@ void print_ast(Node* node, int depth) {
         }
         break;
 
+    case NODE_TYPE_ALIAS:
+        printf("TypeAlias: %.*s", node->as.type_alias.name_length, node->as.type_alias.name);
+        if (node->as.type_alias.type_param_count > 0) {
+            printf("<");
+            for (int i = 0; i < node->as.type_alias.type_param_count; i++) {
+                if (i > 0)
+                    printf(", ");
+                printf("%s", node->as.type_alias.type_params[i]);
+            }
+            printf(">");
+        }
+        printf("\n");
+        print_visibility(depth + 1, node->as.type_alias.is_public);
+        print_indent(depth + 1);
+        printf("Target:\n");
+        print_ast(node->as.type_alias.target_type, depth + 2);
+        break;
+
     case NODE_IMPL_DECL:
         printf("ImplDecl: %.*s for %.*s", node->as.impl_decl.trait_name_length,
                node->as.impl_decl.trait_name, node->as.impl_decl.type_name_length,

--- a/w0/test/error_type_alias_cycle.w
+++ b/w0/test/error_type_alias_cycle.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Recursive type alias (self-reference)
+// Expected error: Unknown type 'A'
+
+type A = A;
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/error_type_alias_redef.w
+++ b/w0/test/error_type_alias_redef.w
@@ -1,0 +1,9 @@
+// ERROR TEST: Redefinition of type alias
+// Expected error: Redefinition of type
+
+type Foo = i64;
+type Foo = string;
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/type_alias.w
+++ b/w0/test/type_alias.w
@@ -1,0 +1,33 @@
+// Test basic type aliases
+
+type UserId = i64;
+type Score = f64;
+type Name = string;
+type Flag = bool;
+
+struct Point { x: i64, y: i64 }
+type Pos = Point;
+
+func add_ids(a: UserId, b: UserId): UserId {
+    return a + b;
+}
+
+func main(): i32 {
+    var id: UserId = 42;
+    var id2: UserId = 100;
+    var total: UserId = add_ids(id, id2);
+
+    var score: Score = 3.14;
+    var name: Name = "hello";
+    var flag: Flag = true;
+
+    // Alias is interchangeable with the underlying type
+    var raw: i64 = id;
+    var id3: UserId = raw;
+
+    // Struct alias
+    var p: Pos = new Point { x: 1, y: 2 };
+    var q: Point = p;
+
+    return 0;
+}

--- a/w0/test/type_alias_generic.w
+++ b/w0/test/type_alias_generic.w
@@ -1,0 +1,22 @@
+// Test generic type aliases
+
+struct Box<T> { value: T }
+struct Pair<K, V> { key: K, value: V }
+
+// Partial application: fix one type parameter
+type IntBox = Box<i64>;
+type StringPair<V> = Pair<string, V>;
+
+func main(): i32 {
+    // Use non-generic alias of a generic struct
+    var b: IntBox = new Box<i64> { value: 42 };
+
+    // Use generic alias with partial application
+    var p: StringPair<i64> = new Pair<string, i64> { key: "age", value: 30 };
+
+    // The aliased type is fully interchangeable
+    var b2: Box<i64> = b;
+    var p2: Pair<string, i64> = p;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add compile-time type aliases (`type UserId = i64;`) that resolve to the underlying type during type checking and produce no C code
- Support generic type aliases with partial application (`type StringPair<V> = Pair<string, V>;`)
- Cycle detection via depth counter (max 16), `public`/`private` visibility, trait bounds on generic params

## Changes
- **Lexer**: `TOK_TYPE` keyword
- **Parser**: `parse_type_alias()` with generic param support
- **AST**: `NODE_TYPE_ALIAS` node type
- **Checker**: Non-generic aliases resolve and define as `SYM_TYPE`; generic aliases register as `GenericDef` with `is_type_alias=1` and substitute type params during `resolve_type`
- **Codegen**: Alias name → target type resolution so generated C uses underlying types (not alias names)
- **Grammar**: `<type-alias>` rule added
- **Feature doc**: Updated with implementation status

## Test plan
- [x] `test/type_alias.w` — basic aliases (UserId=i64, Score=f64, Pos=Point), interchangeability
- [x] `test/type_alias_generic.w` — generic aliases (IntBox=Box<i64>, StringPair<V>=Pair<string,V>)
- [x] `test/error_type_alias_redef.w` — redefinition error
- [x] `test/error_type_alias_cycle.w` — self-referential cycle error
- [x] All 102/102 tests pass (98 existing + 4 new)
- [x] Both valid test files compile to C and execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)