### PR TITLE
feat: add Vec<T> as a compiler builtin type

### DIFF
--- a/features/vectors.md
+++ b/features/vectors.md
@@ -1,0 +1,324 @@
+# Vec\<T\> — Dynamic Arrays
+
+Compiler-builtin growable array type, similar to how `Span<T>` is handled.
+
+## Summary
+
+`Vec<T>` is a generic, heap-backed, dynamically-sized array. The compiler knows
+about it natively (like `Span<T>`) and emits the struct layout and methods
+directly in the generated C. Vecs are RC-managed via `new` and automatically
+clean up their backing buffer and elements when freed.
+
+## Syntax
+
+```whist
+// Create empty vec
+var nums = new Vec<i64>{};
+
+// Create with initial elements
+var nums = new Vec<i64>{1, 2, 3};
+
+// Push / pop
+nums.push(42);
+var last = nums.pop();       // panics if empty
+
+// Indexing (always bounds-checked)
+var x = nums[0];
+nums[2] = 99;
+
+// Length
+var n = nums.count;          // field, consistent with Span<T>
+
+// Clear
+nums.clear();
+
+// Span interop
+var span: Span<i64> = nums[:];
+```
+
+## Type
+
+`Vec<T>` is a new builtin type (`TYPE_VEC`) alongside `TYPE_ARRAY` and
+`TYPE_SPAN`. It stores an element type, like Span.
+
+Whist-level view:
+```whist
+// Conceptual — not user-declared, compiler-provided
+struct Vec<T> {
+    data: *T,       // backing buffer (plain malloc, not RC)
+    count: i64,     // number of elements
+    capacity: i64,  // allocated slots
+}
+```
+
+## C Representation
+
+Each monomorphized `Vec<T>` produces a C struct:
+
+```c
+// Vec<i64> →
+typedef struct {
+    int64_t* data;
+    int64_t count;
+    int64_t capacity;
+} Vec_i64;
+
+// Vec<Point> → (where Point is a struct)
+typedef struct {
+    Point** data;    // array of pointers (structs are heap-allocated)
+    int64_t count;
+    int64_t capacity;
+} Vec_Point;
+```
+
+Since Vecs are created with `new`, the Vec struct itself is RC-managed:
+
+```c
+// var nums = new Vec<i64>{};
+Vec_i64* nums = (Vec_i64*)__rc_alloc(sizeof(Vec_i64));
+nums->data = NULL;
+nums->count = 0;
+nums->capacity = 0;
+
+// var nums = new Vec<i64>{1, 2, 3};
+Vec_i64* nums = (Vec_i64*)__rc_alloc(sizeof(Vec_i64));
+nums->data = NULL;
+nums->count = 0;
+nums->capacity = 0;
+__Vec_i64_push(nums, 1);
+__Vec_i64_push(nums, 2);
+__Vec_i64_push(nums, 3);
+```
+
+## V1 API
+
+Minimal surface area. Expand in later iterations.
+
+| Operation | Syntax | Description |
+|-----------|--------|-------------|
+| Create empty | `new Vec<T>{}` | RC-allocated, empty |
+| Create with elements | `new Vec<T>{a, b, c}` | RC-allocated, pushes each |
+| Push | `v.push(value)` | Append element, grow if needed |
+| Pop | `v.pop()` | Remove and return last element, panic if empty |
+| Index read | `v[i]` | Bounds-checked, panic on out-of-range |
+| Index write | `v[i] = x` | Bounds-checked, panic on out-of-range |
+| Length | `v.count` | Field access (like Span) |
+| Clear | `v.clear()` | Remove all elements, cleanup RC if needed |
+| Span | `v[:]` / `v[a:b]` | Produce `Span<T>` view |
+
+### Methods not in V1 (future)
+
+- `pop()` returning `Option<T>` instead of panicking
+- `insert(index, value)`, `remove(index)`, `swap_remove(index)`
+- `reserve(additional)`, `shrink_to_fit()`
+- `first()`, `last()` returning `Option<T>`
+- `contains(value)`, `sort()`, iteration, functional methods
+- `Vec.with_capacity(n)` (needs associated functions)
+
+## Generated C — Method Implementations
+
+The compiler emits these as static functions per monomorphization:
+
+### Push
+
+```c
+void __Vec_i64_push(Vec_i64* self, int64_t value) {
+    if (self->count == self->capacity) {
+        int64_t new_cap = self->capacity == 0 ? 4 : self->capacity * 2;
+        self->data = realloc(self->data, new_cap * sizeof(int64_t));
+        self->capacity = new_cap;
+    }
+    self->data[self->count] = value;
+    self->count++;
+}
+```
+
+### Pop
+
+```c
+int64_t __Vec_i64_pop(Vec_i64* self) {
+    if (self->count == 0) {
+        fprintf(stderr, "panic: pop from empty Vec\n");
+        exit(1);
+    }
+    self->count--;
+    return self->data[self->count];
+}
+```
+
+### Index (read)
+
+```c
+int64_t __Vec_i64_get(Vec_i64* self, int64_t index) {
+    if (index < 0 || index >= self->count) {
+        fprintf(stderr, "panic: Vec index %lld out of range (count=%lld)\n",
+                index, self->count);
+        exit(1);
+    }
+    return self->data[index];
+}
+```
+
+### Index (write)
+
+```c
+void __Vec_i64_set(Vec_i64* self, int64_t index, int64_t value) {
+    if (index < 0 || index >= self->count) {
+        fprintf(stderr, "panic: Vec index %lld out of range (count=%lld)\n",
+                index, self->count);
+        exit(1);
+    }
+    self->data[index] = value;
+}
+```
+
+### Clear
+
+```c
+void __Vec_i64_clear(Vec_i64* self) {
+    // For RC element types: __rc_dec each element first
+    self->count = 0;
+    // Note: does not free or shrink the backing buffer
+}
+```
+
+### Drop (compiler-generated `__rc_dec_Vec_T`)
+
+```c
+void __rc_dec_Vec_i64(Vec_i64* self) {
+    __RcHeader* header = (__RcHeader*)self - 1;
+    header->refcount--;
+    if (header->refcount == 0) {
+        // For RC element types: __rc_dec each element
+        free(self->data);
+        free(header);
+    }
+}
+```
+
+For `Vec<Point>` where Point is RC-managed:
+
+```c
+void __rc_dec_Vec_Point(Vec_Point* self) {
+    __RcHeader* header = (__RcHeader*)self - 1;
+    header->refcount--;
+    if (header->refcount == 0) {
+        for (int64_t i = 0; i < self->count; i++) {
+            __rc_dec_Point(self->data[i]);  // or __rc_dec depending on type
+        }
+        free(self->data);
+        free(header);
+    }
+}
+```
+
+## RC Integration
+
+- `new Vec<T>{}` → RC-allocated Vec struct (refcount=1)
+- Assigning a Vec to another variable → `__rc_inc` (shared reference to same Vec)
+- Scope exit → `__rc_dec_Vec_T` (decrements, frees if zero)
+- Element cleanup on free: if `T` is RC-managed, dec each element
+- Clear also decs RC elements before resetting count
+
+The Vec's backing `data` buffer is **not** RC-managed — it's plain
+`malloc`/`realloc`/`free`, owned exclusively by the Vec.
+
+## Span Interop
+
+Slicing a Vec produces a `Span<T>`, reusing the existing slice infrastructure:
+
+```c
+// nums[:]
+(Span_i64){ .data = nums->data, .count = nums->count }
+
+// nums[1:3]
+(Span_i64){ .data = nums->data + 1, .count = 2 }
+```
+
+The Span borrows the Vec's buffer — it is only valid while the Vec is alive.
+No lifetime enforcement in V1 (same as Span on arrays today).
+
+## Compiler Changes
+
+### types.h / types.c
+
+- Add `TYPE_VEC` to the type enum
+- Vec stores element type (like Span): `type->as.vec.elem_type`
+- `type_mangle_generic` support: `Vec<i64>` → `Vec_i64`
+- `type_equals` / `type_assignable` for Vec types
+
+### lexer
+
+- No changes needed — `Vec` is parsed as an identifier
+
+### parser
+
+- Recognize `Vec<T>` in type position (similar to `Span<T>`)
+- Parse `new Vec<T>{...}` — the `{...}` contains expressions (elements),
+  not field assignments
+- Parse `v.push(expr)`, `v.pop()`, `v.clear()` as method calls
+- `v.count` as field access
+- `v[i]` / `v[i] = x` already handled by index syntax
+- `v[:]` / `v[a:b]` already handled by slice syntax
+
+### checker
+
+- Type-check `new Vec<T>{elems}`: each element must be assignable to `T`
+- Type-check method calls: `push` takes `T`, `pop` returns `T`
+- `v.count` resolves to `i64`
+- Index operations: result type is `T`
+- Slice operations: result type is `Span<T>`
+- Set `has_rc_fields` if `T` is an RC type
+
+### codegen
+
+- Emit `Vec_T` typedef for each monomorphized Vec type
+- Emit method functions (`__Vec_T_push`, `__Vec_T_pop`, etc.)
+- Emit `__rc_dec_Vec_T` with element cleanup
+- For `new Vec<T>{}`: emit `__rc_alloc` + zero-init
+- For `new Vec<T>{a,b,c}`: emit alloc + push calls
+- For `v.push(x)`: emit `__Vec_T_push(v, x)`
+- For `v[i]`: emit `__Vec_T_get(v, i)`
+- For `v[i] = x`: emit `__Vec_T_set(v, i, x)`
+- For `v.pop()`: emit `__Vec_T_pop(v)`
+- For `v.clear()`: emit `__Vec_T_clear(v)`
+- For `v.count`: emit `v->count`
+- For `v[:]`: emit Span construction (reuse existing slice codegen)
+
+## Growth Strategy
+
+- Initial capacity: 0 (no allocation until first push)
+- Growth factor: 2x
+- `realloc` for resizing
+
+## Test Plan
+
+```
+test/vec_basic.w          — create, push, index read, count
+test/vec_pop.w            — pop, panic on empty
+test/vec_init.w           — new Vec<T>{1, 2, 3} initializer
+test/vec_bounds.w         — index out-of-range panic (error test)
+test/vec_clear.w          — clear, re-push
+test/vec_span.w           — slice to Span<T>
+test/vec_rc.w             — Vec<StructType> element cleanup
+test/vec_index_write.w    — v[i] = x assignment
+test/vec_generic.w        — Vec with different element types
+```
+
+## Open Questions / Future Work
+
+1. **Passing Vec to functions** — by reference (RC inc/dec) works today.
+   Passing by value (copy/clone) is not supported in V1.
+2. **Vec of Vec** — `Vec<Vec<i64>>` should work since inner Vec is RC-managed.
+   Needs testing.
+3. **Equality** — `v1 == v2` for element-wise comparison. Not in V1.
+4. **Iteration** — `foreach x in v { ... }`. Needs iterator protocol. Not in V1.
+5. **Associated functions** — `Vec.new()`, `Vec.with_capacity()` would be
+   cleaner but needs new language feature. Using `new Vec<T>{}` for now.
+6. **Capacity control** — no way to pre-allocate in V1.
+
+## Related Features
+
+- [Memory Management](memory-management.md) — RC allocation model
+- [Stdlib Collections](stdlib-collections.md) — aspirational full API
+- [Traits](traits.md) — Drop trait for cleanup

--- a/grammar.md
+++ b/grammar.md
@@ -162,12 +162,25 @@ Aliases are fully interchangeable with the underlying type: `var id: UserId = 42
 
 **Tuple types:** `(T1, T2)` or `(T1, T2, T3, ...)` represent fixed-size heterogeneous collections. Tuples must have at least two elements.
 
-**Span types:** `Span<T>` is a builtin generic type representing an immutable view into contiguous memory (array or another span). Spans have:
+**Span types:** `Span<T>` is a builtin generic type representing an immutable view into contiguous memory (array, span, or vec). Spans have:
 - `span.count` — number of elements (read-only)
 - `span[i]` — bounds-checked element access (panics if out of bounds)
 - `span.data` — private (compile error if accessed directly)
 
 Create spans using slice syntax: `var s: Span<i64> = arr[:];`
+
+**Vec types:** `Vec<T>` is a builtin generic type representing a dynamically-growable array. Vecs are RC-managed (created with `new`) and have:
+- `vec.count` — number of elements (read-only, `i64`)
+- `vec.capacity` — current capacity (read-only, `i64`)
+- `vec[i]` — bounds-checked element access (panics if out of bounds)
+- `vec[i] = x` — bounds-checked element write
+- `vec.push(x)` — append an element
+- `vec.pop()` — remove and return the last element (panics if empty)
+- `vec.clear()` — remove all elements (decrements RC for struct elements)
+- `vec.data` — private (compile error if accessed directly)
+- Slice syntax produces a `Span<T>`: `vec[:]`, `vec[1:3]`, `vec[2:]`
+
+Create vecs: `var v = new Vec<i64>{};` or `var v = new Vec<i64>{1, 2, 3};`
 
 ---
 
@@ -290,7 +303,10 @@ Create spans using slice syntax: `var s: Span<i64> = arr[:];`
                 | <tuple-literal>
                 | <array-literal>
 
-<new-expr> ::= 'new' <type> '{' [ <field-init-list> ] '}'
+<new-expr> ::= 'new' <type> '{' [ <init-list> ] '}'
+
+<init-list> ::= <field-init-list>
+             | <element-list>
 
 <enum-value-access> ::= <identifier> '::' <identifier>
 
@@ -300,6 +316,8 @@ Create spans using slice syntax: `var s: Span<i64> = arr[:];`
 
 <field-init> ::= <identifier> ':' <expression>
 
+<element-list> ::= <expression> { ',' <expression> } [ ',' ]
+
 <tuple-literal> ::= '(' <expression> ',' <expression> { ',' <expression> } ')'
 ```
 
@@ -307,9 +325,9 @@ Create spans using slice syntax: `var s: Span<i64> = arr[:];`
 
 **Array literals:** `[1, 2, 3, 4, 5]` creates an array. The element type is inferred from the first element. All elements must have compatible types. Trailing commas are allowed.
 
-**New expressions:** `new Point { x: 1, y: 2 }` heap-allocates a struct with reference counting. The returned pointer is automatically freed when its reference count drops to zero. Copies of RC pointers (`var q = p`) increment the reference count. RC variables are automatically decremented when they go out of scope.
+**New expressions:** `new Point { x: 1, y: 2 }` heap-allocates a struct with reference counting. `new Vec<i64>{1, 2, 3}` heap-allocates a Vec with initial elements (or `new Vec<i64>{}` for empty). The returned pointer is automatically freed when its reference count drops to zero. Copies of RC pointers (`var q = p`) increment the reference count. RC variables are automatically decremented when they go out of scope.
 
-**Slice expressions:** `arr[start:end]` creates a `Span<T>` view into an array or span. Both bounds are optional:
+**Slice expressions:** `arr[start:end]` creates a `Span<T>` view into an array, span, or vec. Both bounds are optional:
 - `arr[:]` — full span (all elements)
 - `arr[1:]` — from index 1 to end
 - `arr[:3]` — from start to index 3 (exclusive)

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -201,6 +201,7 @@ struct Node {
             Node* index;
             int   is_tuple_index; // Set by checker if indexing a tuple
             int   is_span_index;  // Set by checker if indexing a span
+            int   is_vec_index;   // Set by checker if indexing a vec
         } index;
 
         // Slice expression: arr[start:end]
@@ -210,6 +211,7 @@ struct Node {
             Node* end;           // End index (NULL if omitted)
             Type* resolved_type; // Set by checker
             int   is_array;      // Set by checker: 1 if slicing array, 0 if slicing span
+            int   is_vec;        // Set by checker: 1 if slicing a vec
         } slice;
 
         // Member access: obj.member

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -108,6 +108,26 @@ static void register_span_instance(Checker* checker, const char* mangled_name, T
     inst->type         = span_type;
 }
 
+// Look up an already-instantiated vec type by mangled name
+static VecInstance* lookup_vec_instance(Checker* checker, const char* mangled_name) {
+    for (int i = 0; i < checker->vec_instance_count; i++) {
+        if (strcmp(checker->vec_instances[i].mangled_name, mangled_name) == 0) {
+            return &checker->vec_instances[i];
+        }
+    }
+    return NULL;
+}
+
+// Register an instantiated vec type
+static void register_vec_instance(Checker* checker, const char* mangled_name, Type* elem_type,
+                                  Type* vec_type) {
+    VEC_GROW(checker->vec_instances, checker->vec_instance_count, checker->vec_instance_capacity);
+    VecInstance* inst  = &checker->vec_instances[checker->vec_instance_count++];
+    inst->mangled_name = xstrdup(mangled_name);
+    inst->elem_type    = elem_type;
+    inst->type         = vec_type;
+}
+
 // Register an instantiated generic struct
 static void register_generic_instance(Checker* checker, const char* mangled_name,
                                       const char* base_name, Type* type, Type** type_args,
@@ -190,6 +210,10 @@ void checker_init(Checker* checker) {
     checker->span_instances         = NULL;
     checker->span_instance_count    = 0;
     checker->span_instance_capacity = 0;
+    // Vec support
+    checker->vec_instances         = NULL;
+    checker->vec_instance_count    = 0;
+    checker->vec_instance_capacity = 0;
     // Trait support
     checker->trait_impls         = NULL;
     checker->trait_impl_count    = 0;
@@ -262,6 +286,11 @@ void checker_free(Checker* checker) {
         free(checker->span_instances[i].mangled_name);
     }
     free(checker->span_instances);
+    // Free vec instances
+    for (int i = 0; i < checker->vec_instance_count; i++) {
+        free(checker->vec_instances[i].mangled_name);
+    }
+    free(checker->vec_instances);
     // Free trait implementations
     for (int i = 0; i < checker->trait_impl_count; i++) {
         free(checker->trait_impls[i].trait_name);
@@ -688,6 +717,47 @@ static Type* resolve_type(Checker* checker, Node* type_node) {
         // Generic type instantiation: Box<i64>, Pair<K, V>, Span<T>
         const char* base_name = type_node->as.generic_type.base_name;
         int         arg_count = type_node->as.generic_type.type_args.count;
+
+        // Handle builtin Vec<T> type
+        if (strcmp(base_name, "Vec") == 0) {
+            if (arg_count != 1) {
+                check_error(checker, type_node->line, type_node->column,
+                            "Vec requires exactly 1 type argument, got %d", arg_count);
+                return type_error;
+            }
+
+            // Resolve element type
+            Type* elem_type = resolve_type(checker, type_node->as.generic_type.type_args.nodes[0]);
+            if (elem_type == type_error) {
+                return type_error;
+            }
+
+            // Generate mangled name for the vec instance
+            char mangled[256];
+            snprintf(mangled, sizeof(mangled), "Vec_%s", type_name(elem_type));
+
+            // Check if already instantiated
+            VecInstance* existing = lookup_vec_instance(checker, mangled);
+            if (existing) {
+                return existing->type;
+            }
+
+            // Create the vec type
+            Type* vec_type = type_vec(elem_type);
+
+            // Register for codegen
+            register_vec_instance(checker, mangled, elem_type, vec_type);
+
+            // Also ensure a Span instance for the same element type exists (for slicing)
+            char span_mangled[256];
+            snprintf(span_mangled, sizeof(span_mangled), "Span_%s", type_name(elem_type));
+            if (!lookup_span_instance(checker, span_mangled)) {
+                Type* span_type = type_span(elem_type);
+                register_span_instance(checker, span_mangled, elem_type, span_type);
+            }
+
+            return vec_type;
+        }
 
         // Handle builtin Span<T> type
         if (strcmp(base_name, "Span") == 0) {
@@ -1149,6 +1219,15 @@ static Type* check_index_expr(Checker* checker, Node* node) {
         node->as.index.is_span_index = 1;
         return object->as.span.elem;
     }
+    if (object->kind == TYPE_VEC) {
+        if (!type_is_integer(index)) {
+            check_error(checker, node->line, node->column, "Vec index must be an integer, got '%s'",
+                        type_name(index));
+            return type_error;
+        }
+        node->as.index.is_vec_index = 1;
+        return object->as.vec.elem;
+    }
     if (object->kind == TYPE_STRING) {
         if (!type_is_integer(index)) {
             check_error(checker, node->line, node->column,
@@ -1192,6 +1271,9 @@ static Type* check_slice_expr(Checker* checker, Node* node) {
     } else if (object->kind == TYPE_SPAN) {
         elem_type               = object->as.span.elem;
         node->as.slice.is_array = 0;
+    } else if (object->kind == TYPE_VEC) {
+        elem_type             = object->as.vec.elem;
+        node->as.slice.is_vec = 1;
     } else {
         check_error(checker, node->line, node->column, "Cannot slice type '%s'", type_name(object));
         return type_error;
@@ -1263,6 +1345,46 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         }
         check_error(checker, node->line, node->column, "Enum '%s' has no member '%s'",
                     object->as.enm.name, member_name);
+        return type_error;
+    }
+
+    // Handle Vec member access
+    if (object->kind == TYPE_VEC) {
+        const char* member_name = node->as.member.name;
+        node->as.member.is_ref  = 1; // Vec is a pointer (RC-managed)
+        Type* elem_type         = object->as.vec.elem;
+
+        if (strcmp(member_name, "count") == 0) {
+            return type_int64;
+        }
+        if (strcmp(member_name, "capacity") == 0) {
+            return type_int64;
+        }
+        if (strcmp(member_name, "data") == 0) {
+            check_error(checker, node->line, node->column,
+                        "Vec 'data' field is private; use indexing");
+            return type_error;
+        }
+        // Methods: push, pop, clear
+        if (strcmp(member_name, "push") == 0 || strcmp(member_name, "pop") == 0 ||
+            strcmp(member_name, "clear") == 0) {
+            // Build mangled vec name for method dispatch
+            char mangled[256];
+            snprintf(mangled, sizeof(mangled), "__Vec_%s", type_name(elem_type));
+            node->as.member.struct_name = xstrdup(mangled);
+
+            if (strcmp(member_name, "push") == 0) {
+                Type** params = xmalloc(1 * sizeof(Type*));
+                params[0]     = elem_type;
+                return type_func(params, 1, type_void, 0);
+            }
+            if (strcmp(member_name, "pop") == 0) {
+                return type_func(NULL, 0, elem_type, 0);
+            }
+            // clear
+            return type_func(NULL, 0, type_void, 0);
+        }
+        check_error(checker, node->line, node->column, "Vec has no member '%s'", member_name);
         return type_error;
     }
 
@@ -1675,19 +1797,37 @@ static Type* check_expression(Checker* checker, Node* node) {
         return check_assign_expr(checker, node);
 
     case NODE_NEW_EXPR: {
-        Type* struct_type = resolve_type(checker, node->as.new_expr.type_node);
-        if (struct_type == type_error)
+        Type* resolved = resolve_type(checker, node->as.new_expr.type_node);
+        if (resolved == type_error)
             return type_error;
-        if (struct_type->kind != TYPE_STRUCT) {
+        if (resolved->kind == TYPE_VEC) {
+            // new Vec<T>{} or new Vec<T>{1, 2, 3}
+            Type* elem_type = resolved->as.vec.elem;
+            Node* init      = node->as.new_expr.init;
+            // Check each element expression against the element type
+            for (int i = 0; i < init->as.struct_init.fields.count; i++) {
+                Node* field = init->as.struct_init.fields.nodes[i];
+                if (field->type != NODE_FIELD_INIT)
+                    continue;
+                Type* val_type = check_expression(checker, field->as.field_init.value);
+                if (val_type->kind != TYPE_ERROR && !type_assignable(elem_type, val_type)) {
+                    check_error_type(checker, field->line, field->column, "Vec element", elem_type,
+                                     val_type);
+                }
+            }
+            node->as.new_expr.resolved_type = resolved;
+            return resolved;
+        }
+        if (resolved->kind != TYPE_STRUCT) {
             check_error(checker, node->line, node->column, "'new' requires a struct type, got '%s'",
-                        type_name(struct_type));
+                        type_name(resolved));
             return type_error;
         }
-        Type* init_type = check_struct_init(checker, node->as.new_expr.init, struct_type);
+        Type* init_type = check_struct_init(checker, node->as.new_expr.init, resolved);
         if (init_type == type_error)
             return type_error;
-        node->as.new_expr.resolved_type = struct_type;
-        return struct_type;
+        node->as.new_expr.resolved_type = resolved;
+        return resolved;
     }
 
     case NODE_STRUCT_INIT:

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -68,6 +68,13 @@ typedef struct {
     Type* type;         // The TYPE_SPAN instance
 } SpanInstance;
 
+// Instantiated vec type
+typedef struct {
+    char* mangled_name; // "Vec_i64"
+    Type* elem_type;    // The element type
+    Type* type;         // The TYPE_VEC instance
+} VecInstance;
+
 struct Checker {
     Scope* scope;
     Type*  current_func_return; // Return type of current function
@@ -105,6 +112,11 @@ struct Checker {
     SpanInstance* span_instances;
     int           span_instance_count;
     int           span_instance_capacity;
+
+    // Instantiated vec types
+    VecInstance* vec_instances;
+    int          vec_instance_count;
+    int          vec_instance_capacity;
 
     // Trait implementations
     TraitImpl* trait_impls;

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -453,8 +453,8 @@ static void collect_tuple_types_from_decl(CodeGen* gen, Node* decl) {
 }
 
 void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, int generic_count,
-                  SpanInstance* span_instances, int span_count, TraitImpl* trait_impls,
-                  int trait_impl_count, int rc_debug) {
+                  SpanInstance* span_instances, int span_count, VecInstance* vec_instances,
+                  int vec_count, TraitImpl* trait_impls, int trait_impl_count, int rc_debug) {
     gen->out                    = out;
     gen->indent                 = 0;
     gen->temp_count             = 0;
@@ -476,6 +476,8 @@ void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, i
     gen->generic_instance_count = generic_count;
     gen->span_instances         = span_instances;
     gen->span_instance_count    = span_count;
+    gen->vec_instances          = vec_instances;
+    gen->vec_instance_count     = vec_count;
     gen->trait_impls            = trait_impls;
     gen->trait_impl_count       = trait_impl_count;
     gen->enum_names             = NULL;
@@ -580,15 +582,17 @@ void codegen_emit(CodeGen* gen, Node* ast) {
         emit(gen, "}\n\n");
     }
 
-    // Emit span struct typedefs
-    for (int i = 0; i < gen->span_instance_count; i++) {
-        SpanInstance* inst = &gen->span_instances[i];
-        emit(gen, "typedef struct {\n");
-        emit(gen, "    const ");
-        emit_resolved_type(gen, inst->elem_type);
-        emit(gen, "* data;\n");
-        emit(gen, "    uint64_t count;\n");
-        emit(gen, "} __Span_%s;\n\n", type_name(inst->elem_type));
+    // Emit Vec bounds check helper (only if we have vec instances)
+    if (gen->vec_instance_count > 0) {
+        emit(gen, "static inline void __w0_vec_check(int64_t count, int64_t idx, int line, int "
+                  "col) {\n");
+        emit(gen, "    if (idx < 0 || idx >= count) {\n");
+        emit(gen, "        fprintf(stderr, \"Panic: Vec index %%lld out of bounds (count=%%lld) "
+                  "at %%d:%%d\\n\",\n");
+        emit(gen, "                (long long)idx, (long long)count, line, col);\n");
+        emit(gen, "        exit(1);\n");
+        emit(gen, "    }\n");
+        emit(gen, "}\n\n");
     }
 
     // Emit tuple typedefs
@@ -701,6 +705,32 @@ void codegen_emit(CodeGen* gen, Node* ast) {
              gen->generic_instances[i].mangled_name);
     }
     emit(gen, "\n");
+
+    // Emit span struct typedefs (after struct forward declarations)
+    for (int i = 0; i < gen->span_instance_count; i++) {
+        SpanInstance* inst = &gen->span_instances[i];
+        emit(gen, "typedef struct {\n");
+        emit(gen, "    const ");
+        emit_resolved_type(gen, inst->elem_type);
+        emit(gen, "* data;\n");
+        emit(gen, "    uint64_t count;\n");
+        emit(gen, "} __Span_%s;\n\n", type_name(inst->elem_type));
+    }
+
+    // Emit Vec struct typedefs (after struct forward declarations)
+    for (int i = 0; i < gen->vec_instance_count; i++) {
+        VecInstance* inst       = &gen->vec_instances[i];
+        Type*        elem_type  = inst->elem_type;
+        const char*  elem_tname = type_name(elem_type);
+
+        emit(gen, "typedef struct {\n");
+        emit(gen, "    ");
+        emit_resolved_type(gen, elem_type);
+        emit(gen, "* data;\n");
+        emit(gen, "    int64_t count;\n");
+        emit(gen, "    int64_t capacity;\n");
+        emit(gen, "} __Vec_%s;\n\n", elem_tname);
+    }
 
     // Emit enum typedefs (after struct forward declarations)
     for (int m = 0; m < ast->as.program.modules.count; m++) {
@@ -1353,6 +1383,96 @@ void codegen_emit(CodeGen* gen, Node* ast) {
         }
     }
     emit(gen, "\n");
+
+    // Emit Vec method functions (after struct __rc_dec forward declarations)
+    for (int i = 0; i < gen->vec_instance_count; i++) {
+        VecInstance* inst        = &gen->vec_instances[i];
+        Type*        elem_type   = inst->elem_type;
+        const char*  elem_tname  = type_name(elem_type);
+        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
+
+        // Push
+        emit(gen, "static inline void __Vec_%s_push(__Vec_%s* self, ", elem_tname, elem_tname);
+        emit_resolved_type(gen, elem_type);
+        emit(gen, " value) {\n");
+        emit(gen, "    if (self->count == self->capacity) {\n");
+        emit(gen, "        int64_t new_cap = self->capacity == 0 ? 4 : self->capacity * 2;\n");
+        emit(gen, "        self->data = realloc(self->data, new_cap * sizeof(");
+        emit_resolved_type(gen, elem_type);
+        emit(gen, "));\n");
+        emit(gen, "        self->capacity = new_cap;\n");
+        emit(gen, "    }\n");
+        emit(gen, "    self->data[self->count] = value;\n");
+        emit(gen, "    self->count++;\n");
+        emit(gen, "}\n\n");
+
+        // Pop
+        emit(gen, "static inline ");
+        emit_resolved_type(gen, elem_type);
+        emit(gen, " __Vec_%s_pop(__Vec_%s* self) {\n", elem_tname, elem_tname);
+        emit(gen, "    if (self->count == 0) {\n");
+        emit(gen, "        fprintf(stderr, \"Panic: pop from empty Vec\\n\");\n");
+        emit(gen, "        exit(1);\n");
+        emit(gen, "    }\n");
+        emit(gen, "    self->count--;\n");
+        emit(gen, "    return self->data[self->count];\n");
+        emit(gen, "}\n\n");
+
+        // Clear
+        emit(gen, "static inline void __Vec_%s_clear(__Vec_%s* self) {\n", elem_tname, elem_tname);
+        if (elem_is_ptr) {
+            emit(gen, "    for (int64_t i = 0; i < self->count; i++) {\n");
+            if (elem_type->kind == TYPE_VEC) {
+                emit(gen, "        __rc_dec_Vec_%s(self->data[i]);\n",
+                     type_name(elem_type->as.vec.elem));
+            } else if (elem_type->kind == TYPE_STRUCT &&
+                       (elem_type->as.struc.has_drop || elem_type->as.struc.has_rc_fields)) {
+                emit(gen, "        __rc_dec_%s(self->data[i]);\n", elem_type->as.struc.name);
+            } else {
+                emit(gen, "        __rc_dec(self->data[i]);\n");
+            }
+            emit(gen, "    }\n");
+        }
+        emit(gen, "    self->count = 0;\n");
+        emit(gen, "}\n\n");
+    }
+
+    // Emit __rc_dec_Vec_* forward declarations
+    for (int i = 0; i < gen->vec_instance_count; i++) {
+        VecInstance* inst       = &gen->vec_instances[i];
+        const char*  elem_tname = type_name(inst->elem_type);
+        emit(gen, "static inline void __rc_dec_Vec_%s(__Vec_%s* ptr);\n", elem_tname, elem_tname);
+    }
+
+    // Emit __rc_dec_Vec_* definitions
+    for (int i = 0; i < gen->vec_instance_count; i++) {
+        VecInstance* inst        = &gen->vec_instances[i];
+        Type*        elem_type   = inst->elem_type;
+        const char*  elem_tname  = type_name(elem_type);
+        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
+
+        emit(gen, "static inline void __rc_dec_Vec_%s(__Vec_%s* ptr) {\n", elem_tname, elem_tname);
+        emit(gen, "    if (!ptr) return;\n");
+        emit(gen, "    __RcHeader* h = (__RcHeader*)ptr - 1;\n");
+        emit(gen, "    if (--h->refcount == 0) {\n");
+        if (elem_is_ptr) {
+            emit(gen, "        for (int64_t i = 0; i < ptr->count; i++) {\n");
+            if (elem_type->kind == TYPE_VEC) {
+                emit(gen, "            __rc_dec_Vec_%s(ptr->data[i]);\n",
+                     type_name(elem_type->as.vec.elem));
+            } else if (elem_type->kind == TYPE_STRUCT &&
+                       (elem_type->as.struc.has_drop || elem_type->as.struc.has_rc_fields)) {
+                emit(gen, "            __rc_dec_%s(ptr->data[i]);\n", elem_type->as.struc.name);
+            } else {
+                emit(gen, "            __rc_dec(ptr->data[i]);\n");
+            }
+            emit(gen, "        }\n");
+        }
+        emit(gen, "        free(ptr->data);\n");
+        emit(gen, "        free(h);\n");
+        emit(gen, "    }\n");
+        emit(gen, "}\n\n");
+    }
 
     // Emit type-specific __rc_dec_TypeName functions for structs with Drop or RC fields
     // Non-generic structs: scan modules for struct decls with resolved types

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -47,6 +47,9 @@ typedef struct {
     // Span instances from checker (not owned, do not free)
     SpanInstance* span_instances;
     int           span_instance_count;
+    // Vec instances from checker (not owned, do not free)
+    VecInstance* vec_instances;
+    int          vec_instance_count;
     // Trait implementations from checker (not owned, do not free)
     TraitImpl* trait_impls;
     int        trait_impl_count;
@@ -63,8 +66,8 @@ typedef struct {
 } CodeGen;
 
 void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, int generic_count,
-                  SpanInstance* span_instances, int span_count, TraitImpl* trait_impls,
-                  int trait_impl_count, int rc_debug);
+                  SpanInstance* span_instances, int span_count, VecInstance* vec_instances,
+                  int vec_count, TraitImpl* trait_impls, int trait_impl_count, int rc_debug);
 void codegen_emit(CodeGen* gen, Node* ast);
 
 #endif

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -51,6 +51,13 @@ static const char* get_dec_func_for_type(Type* t) {
         snprintf(buf, len, "__rc_dec_%s", t->as.enm.name);
         return buf;
     }
+    if (t && t->kind == TYPE_VEC) {
+        const char* elem_tname = type_name(t->as.vec.elem);
+        size_t      len        = strlen("__rc_dec_Vec_") + strlen(elem_tname) + 1;
+        char*       buf        = xmalloc(len);
+        snprintf(buf, len, "__rc_dec_Vec_%s", elem_tname);
+        return buf;
+    }
     return xstrdup("__rc_dec");
 }
 
@@ -179,9 +186,12 @@ static int is_struct_type(CodeGen* gen, Node* type_node) {
     if (!type_node)
         return 0;
     type_node = resolve_alias(gen, type_node);
-    // Generic types (Box<i64>) are always struct types, except Span<T> and generic enums
+    // Generic types (Box<i64>) are always struct types, except Span<T>, Vec<T>, and generic enums
     if (type_node->type == NODE_GENERIC_TYPE) {
         if (strcmp(type_node->as.generic_type.base_name, "Span") == 0) {
+            return 0;
+        }
+        if (strcmp(type_node->as.generic_type.base_name, "Vec") == 0) {
             return 0;
         }
         // Check if the mangled name is a registered enum
@@ -206,6 +216,8 @@ int type_node_has_rc(CodeGen* gen, Node* type_node) {
     if (type_node->type == NODE_GENERIC_TYPE) {
         if (strcmp(type_node->as.generic_type.base_name, "Span") == 0)
             return 0;
+        if (strcmp(type_node->as.generic_type.base_name, "Vec") == 0)
+            return 1; // Vec is always RC-managed
         // Check if this is a generic enum
         char* mangled = build_mangled_name_from_generic_node(gen, type_node);
         if (is_enum_type_name(gen, mangled)) {
@@ -472,6 +484,31 @@ void emit_type(CodeGen* gen, Node* type_node) {
 
         // Special case: Span<T> is a value type, not a pointer
         int is_span = (strcmp(base, "Span") == 0);
+        int is_vec  = (strcmp(base, "Vec") == 0);
+
+        if (is_vec) {
+            emit(gen, "__Vec_");
+            Node* arg = type_node->as.generic_type.type_args.nodes[0];
+            if (arg->type == NODE_IDENT) {
+                const char* arg_name    = arg->as.ident.name;
+                int         substituted = 0;
+                if (gen->subst_ctx) {
+                    for (int s = 0; s < gen->subst_ctx->count; s++) {
+                        if (strcmp(gen->subst_ctx->type_params[s], arg_name) == 0) {
+                            Type* subst_type = gen->subst_ctx->type_args[s];
+                            emit(gen, "%s", type_name(subst_type));
+                            substituted = 1;
+                            break;
+                        }
+                    }
+                }
+                if (!substituted) {
+                    emit(gen, "%s", arg_name);
+                }
+            }
+            emit(gen, "*"); // Vec is RC-managed pointer
+            break;
+        }
 
         if (is_span) {
             emit(gen, "__Span_");
@@ -632,6 +669,9 @@ void emit_resolved_type(CodeGen* gen, Type* type) {
         break;
     case TYPE_SPAN:
         emit(gen, "__Span_%s", type_name(type->as.span.elem));
+        break;
+    case TYPE_VEC:
+        emit(gen, "__Vec_%s*", type_name(type->as.vec.elem));
         break;
     case TYPE_ENUM:
         emit(gen, "%s", type->as.enm.name);
@@ -952,7 +992,18 @@ static void emit_expr(CodeGen* gen, Node* node) {
     }
 
     case NODE_INDEX:
-        if (node->as.index.is_span_index) {
+        if (node->as.index.is_vec_index) {
+            // Bounds-checked vec access
+            emit(gen, "(__w0_vec_check(");
+            emit_expr(gen, node->as.index.object);
+            emit(gen, "->count, ");
+            emit_expr(gen, node->as.index.index);
+            emit(gen, ", %d, %d), ", node->line, node->column);
+            emit_expr(gen, node->as.index.object);
+            emit(gen, "->data[");
+            emit_expr(gen, node->as.index.index);
+            emit(gen, "])");
+        } else if (node->as.index.is_span_index) {
             // Bounds-checked span access
             emit(gen, "(__w0_span_check(");
             emit_expr(gen, node->as.index.object);
@@ -984,7 +1035,16 @@ static void emit_expr(CodeGen* gen, Node* node) {
         // Emit compound literal
         emit(gen, "((__Span_%s){ .data = ", type_name(elem_type));
 
-        if (node->as.slice.is_array) {
+        if (node->as.slice.is_vec) {
+            // Vec slicing: .data = vec->data + start
+            emit_expr(gen, node->as.slice.object);
+            emit(gen, "->data + ");
+            if (node->as.slice.start) {
+                emit_expr(gen, node->as.slice.start);
+            } else {
+                emit(gen, "0");
+            }
+        } else if (node->as.slice.is_array) {
             // Array slicing: .data = &arr[start]
             emit(gen, "&(");
             emit_expr(gen, node->as.slice.object);
@@ -1009,14 +1069,17 @@ static void emit_expr(CodeGen* gen, Node* node) {
         emit(gen, ", .count = ");
 
         // Calculate count: end - start
-        // For omitted end, use array length or span.count
+        // For omitted end, use array length or span/vec.count
         if (node->as.slice.end) {
             emit(gen, "(");
             emit_expr(gen, node->as.slice.end);
             emit(gen, ")");
         } else {
             // Use full length
-            if (node->as.slice.is_array) {
+            if (node->as.slice.is_vec) {
+                emit_expr(gen, node->as.slice.object);
+                emit(gen, "->count");
+            } else if (node->as.slice.is_array) {
                 emit(gen, "(sizeof(");
                 emit_expr(gen, node->as.slice.object);
                 emit(gen, ")/sizeof((");
@@ -1099,29 +1162,50 @@ static void emit_expr(CodeGen* gen, Node* node) {
         break;
 
     case NODE_NEW_EXPR: {
-        // new Type { fields } as inline expression using GCC statement expression
-        Type*       stype = node->as.new_expr.resolved_type;
-        const char* tname = stype->as.struc.name;
-        int         tmp   = gen->temp_count++;
-        emit(gen, "({ %s* __rc_tmp%d = (%s*)__rc_alloc(sizeof(%s)); *__rc_tmp%d = (%s)", tname, tmp,
-             tname, tname, tmp, tname);
-        emit_struct_init(gen, node->as.new_expr.init);
-        emit(gen, ";");
-        // Increment refcount for any RC-tracked idents stored in struct fields
-        Node* rc_init = node->as.new_expr.init;
-        for (int i = 0; i < rc_init->as.struct_init.fields.count; i++) {
-            Node* field = rc_init->as.struct_init.fields.nodes[i];
-            if (field && field->type == NODE_FIELD_INIT &&
-                field->as.field_init.value->type == NODE_IDENT &&
-                rc_is_tracked(gen, field->as.field_init.value->as.ident.name)) {
-                const char* vname  = field->as.field_init.value->as.ident.name;
-                Type*       vtype  = rc_get_var_type(gen, vname);
-                const char* inc_fn = get_inc_func_for_type(vtype);
-                emit(gen, " %s(%s);", inc_fn, vname);
-                free((char*)inc_fn);
+        Type* rtype = node->as.new_expr.resolved_type;
+        if (rtype->kind == TYPE_VEC) {
+            // new Vec<T>{elems} as inline expression using GCC statement expression
+            const char* elem_tname = type_name(rtype->as.vec.elem);
+            int         tmp        = gen->temp_count++;
+            emit(gen,
+                 "({ __Vec_%s* __rc_tmp%d = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s)); "
+                 "__rc_tmp%d->data = NULL; __rc_tmp%d->count = 0; __rc_tmp%d->capacity = 0;",
+                 elem_tname, tmp, elem_tname, elem_tname, tmp, tmp, tmp);
+            // Push initial elements
+            Node* init = node->as.new_expr.init;
+            for (int i = 0; i < init->as.struct_init.fields.count; i++) {
+                Node* field = init->as.struct_init.fields.nodes[i];
+                if (field && field->type == NODE_FIELD_INIT) {
+                    emit(gen, " __Vec_%s_push(__rc_tmp%d, ", elem_tname, tmp);
+                    emit_expr(gen, field->as.field_init.value);
+                    emit(gen, ");");
+                }
             }
+            emit(gen, " __rc_tmp%d; })", tmp);
+        } else {
+            // new Type { fields } as inline expression using GCC statement expression
+            const char* tname = rtype->as.struc.name;
+            int         tmp   = gen->temp_count++;
+            emit(gen, "({ %s* __rc_tmp%d = (%s*)__rc_alloc(sizeof(%s)); *__rc_tmp%d = (%s)", tname,
+                 tmp, tname, tname, tmp, tname);
+            emit_struct_init(gen, node->as.new_expr.init);
+            emit(gen, ";");
+            // Increment refcount for any RC-tracked idents stored in struct fields
+            Node* rc_init = node->as.new_expr.init;
+            for (int i = 0; i < rc_init->as.struct_init.fields.count; i++) {
+                Node* field = rc_init->as.struct_init.fields.nodes[i];
+                if (field && field->type == NODE_FIELD_INIT &&
+                    field->as.field_init.value->type == NODE_IDENT &&
+                    rc_is_tracked(gen, field->as.field_init.value->as.ident.name)) {
+                    const char* vname  = field->as.field_init.value->as.ident.name;
+                    Type*       vtype  = rc_get_var_type(gen, vname);
+                    const char* inc_fn = get_inc_func_for_type(vtype);
+                    emit(gen, " %s(%s);", inc_fn, vname);
+                    free((char*)inc_fn);
+                }
+            }
+            emit(gen, " __rc_tmp%d; })", tmp);
         }
-        emit(gen, " __rc_tmp%d; })", tmp);
         break;
     }
 
@@ -1330,6 +1414,25 @@ void emit_stmt(CodeGen* gen, Node* node) {
                 }
             }
         }
+        // Handle Vec index assignment: v[i] = x → bounds check + direct data write
+        if (expr->type == NODE_ASSIGN && expr->as.assign.target->type == NODE_INDEX &&
+            expr->as.assign.target->as.index.is_vec_index) {
+            Node* idx_node = expr->as.assign.target;
+            emit_indent(gen);
+            emit(gen, "__w0_vec_check(");
+            emit_expr(gen, idx_node->as.index.object);
+            emit(gen, "->count, ");
+            emit_expr(gen, idx_node->as.index.index);
+            emit(gen, ", %d, %d);\n", idx_node->line, idx_node->column);
+            emit_indent(gen);
+            emit_expr(gen, idx_node->as.index.object);
+            emit(gen, "->data[");
+            emit_expr(gen, idx_node->as.index.index);
+            emit(gen, "] %s ", assign_op_str(expr->as.assign.op));
+            emit_expr(gen, expr->as.assign.value);
+            emit(gen, ";\n");
+            break;
+        }
         emit_indent(gen);
         emit_expr(gen, expr);
         emit(gen, ";\n");
@@ -1360,11 +1463,36 @@ void emit_stmt(CodeGen* gen, Node* node) {
         // Handle RC-managed variable declarations
         if (node->as.var_decl.is_rc && node->as.var_decl.init) {
             if (node->as.var_decl.init->type == NODE_NEW_EXPR) {
+                Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
+                if (rtype && rtype->kind == TYPE_VEC) {
+                    // var v = new Vec<T>{} or new Vec<T>{1, 2, 3}
+                    const char* elem_tname = type_name(rtype->as.vec.elem);
+                    emit_indent(gen);
+                    emit(gen, "__Vec_%s* %s = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s));\n",
+                         elem_tname, node->as.var_decl.name, elem_tname, elem_tname);
+                    emit_indent(gen);
+                    emit(gen, "%s->data = NULL; %s->count = 0; %s->capacity = 0;\n",
+                         node->as.var_decl.name, node->as.var_decl.name, node->as.var_decl.name);
+                    // Push initial elements
+                    Node* init = node->as.var_decl.init->as.new_expr.init;
+                    for (int i = 0; i < init->as.struct_init.fields.count; i++) {
+                        Node* field = init->as.struct_init.fields.nodes[i];
+                        if (field && field->type == NODE_FIELD_INIT) {
+                            emit_indent(gen);
+                            emit(gen, "__Vec_%s_push(%s, ", elem_tname, node->as.var_decl.name);
+                            emit_expr(gen, field->as.field_init.value);
+                            emit(gen, ");\n");
+                        }
+                    }
+                    char dec_buf[256];
+                    snprintf(dec_buf, sizeof(dec_buf), "__rc_dec_Vec_%s", elem_tname);
+                    rc_push_var(gen, node->as.var_decl.name, dec_buf, rtype);
+                    break;
+                }
                 // var p = new Point { x: 1, y: 2 }
                 // => Point* p = (Point*)__rc_alloc(sizeof(Point));
                 //    *p = (Point){ .x = 1, .y = 2 };
-                Type*       stype = node->as.var_decl.init->as.new_expr.resolved_type;
-                const char* tname = stype->as.struc.name;
+                const char* tname = rtype->as.struc.name;
                 emit_indent(gen);
                 emit(gen, "%s* %s = (%s*)__rc_alloc(sizeof(%s));\n", tname, node->as.var_decl.name,
                      tname, tname);
@@ -1387,8 +1515,8 @@ void emit_stmt(CodeGen* gen, Node* node) {
                         free((char*)inc_fn);
                     }
                 }
-                const char* dec_fn = get_dec_func_for_type(stype);
-                rc_push_var(gen, node->as.var_decl.name, dec_fn, stype);
+                const char* dec_fn = get_dec_func_for_type(rtype);
+                rc_push_var(gen, node->as.var_decl.name, dec_fn, rtype);
                 free((char*)dec_fn);
                 break;
             } else {

--- a/w0/main.c
+++ b/w0/main.c
@@ -59,8 +59,9 @@ static int compile_to_c(const char* source, const char* source_path, const char*
 
     CodeGen gen;
     codegen_init(&gen, out, checker.generic_instances, checker.generic_instance_count,
-                 checker.span_instances, checker.span_instance_count, checker.trait_impls,
-                 checker.trait_impl_count, rc_debug);
+                 checker.span_instances, checker.span_instance_count, checker.vec_instances,
+                 checker.vec_instance_count, checker.trait_impls, checker.trait_impl_count,
+                 rc_debug);
     codegen_emit(&gen, ast);
 
     checker_free(&checker);
@@ -373,7 +374,8 @@ int main(int argc, char** argv) {
                 CodeGen gen;
                 codegen_init(&gen, out, checker.generic_instances, checker.generic_instance_count,
                              checker.span_instances, checker.span_instance_count,
-                             checker.trait_impls, checker.trait_impl_count, rc_debug);
+                             checker.vec_instances, checker.vec_instance_count, checker.trait_impls,
+                             checker.trait_impl_count, rc_debug);
                 codegen_emit(&gen, ast);
                 checker_free(&checker);
 

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -268,26 +268,70 @@ static Node* parse_struct_init(Parser* parser) {
     nodelist_init(&node->as.struct_init.fields);
 
     if (!check_token(parser, TOK_RBRACE)) {
-        for (;;) {
-            Token field_name = parser->current;
-            consume_token(parser, TOK_IDENT, "Expected field name in struct initializer");
-
-            Node* field = node_new(NODE_FIELD_INIT, field_name.line, field_name.column);
-            field->as.field_init.name        = copy_token_string(&field_name);
-            field->as.field_init.name_length = field_name.length;
-
-            consume_token(parser, TOK_COLON, "Expected ':' after field name");
-            field->as.field_init.value = parse_expression(parser);
-
-            nodelist_push(&node->as.struct_init.fields, field);
-
-            if (match_token(parser, TOK_COMMA)) {
-                if (check_token(parser, TOK_RBRACE)) {
-                    break; // trailing comma
-                }
-                continue;
+        // Peek ahead to determine mode: if first token is NOT ident followed by ':',
+        // parse as bare expression list (for Vec element initializers)
+        int is_element_list = 0;
+        if (parser->current.type != TOK_IDENT) {
+            is_element_list = 1;
+        } else {
+            // Peek: if next token after ident is not ':', it's an element list
+            // We need to check if the token after the identifier is ':'
+            // Use a simple lookahead: save state, advance, check, restore
+            Lexer saved_lexer   = parser->lexer;
+            Token saved_current = parser->current;
+            int   saved_error   = parser->had_error;
+            advance_token(parser);
+            if (!check_token(parser, TOK_COLON)) {
+                is_element_list = 1;
             }
-            break;
+            // Restore parser state
+            parser->lexer     = saved_lexer;
+            parser->current   = saved_current;
+            parser->had_error = saved_error;
+        }
+
+        if (is_element_list) {
+            // Parse bare expressions (for Vec initializers like {1, 2, 3})
+            for (;;) {
+                Token elem_token = parser->current;
+                Node* field      = node_new(NODE_FIELD_INIT, elem_token.line, elem_token.column);
+                field->as.field_init.name        = NULL;
+                field->as.field_init.name_length = 0;
+                field->as.field_init.value       = parse_expression(parser);
+
+                nodelist_push(&node->as.struct_init.fields, field);
+
+                if (match_token(parser, TOK_COMMA)) {
+                    if (check_token(parser, TOK_RBRACE)) {
+                        break; // trailing comma
+                    }
+                    continue;
+                }
+                break;
+            }
+        } else {
+            // Parse named fields (standard struct init: {name: expr, ...})
+            for (;;) {
+                Token field_name = parser->current;
+                consume_token(parser, TOK_IDENT, "Expected field name in struct initializer");
+
+                Node* field = node_new(NODE_FIELD_INIT, field_name.line, field_name.column);
+                field->as.field_init.name        = copy_token_string(&field_name);
+                field->as.field_init.name_length = field_name.length;
+
+                consume_token(parser, TOK_COLON, "Expected ':' after field name");
+                field->as.field_init.value = parse_expression(parser);
+
+                nodelist_push(&node->as.struct_init.fields, field);
+
+                if (match_token(parser, TOK_COMMA)) {
+                    if (check_token(parser, TOK_RBRACE)) {
+                        break; // trailing comma
+                    }
+                    continue;
+                }
+                break;
+            }
         }
     }
 

--- a/w0/test/rc_runtime/rc_vec_basic.w
+++ b/w0/test/rc_runtime/rc_vec_basic.w
@@ -1,0 +1,29 @@
+// RC RUNTIME TEST: Vec cleanup frees data and elements
+
+struct Item {
+    value: i64,
+}
+
+func main(): i32 {
+    var items = new Vec<Item>{};
+    items.push(new Item { value: 1 });
+    items.push(new Item { value: 2 });
+    items.push(new Item { value: 3 });
+
+    if (items.count != 3) {
+        return 1;
+    }
+
+    var first: Item = items[0];
+    if (first.value != 1) {
+        return 2;
+    }
+
+    var last: Item = items[2];
+    if (last.value != 3) {
+        return 3;
+    }
+
+    // Vec goes out of scope here — should free Vec + all Item elements
+    return 0;
+}

--- a/w0/test/traits_basic.w
+++ b/w0/test/traits_basic.w
@@ -19,7 +19,7 @@ impl Greetable for Dog {
 }
 
 func main(): i32 {
-    var d: Dog = new Dog {name: "Rex\n"};
+    var d: Dog = new Dog{name: "Rex\n"};
     var s: string = d.greet();
     std.print(s);
     return 0;

--- a/w0/test/vec_basic.w
+++ b/w0/test/vec_basic.w
@@ -1,0 +1,27 @@
+// Test basic Vec operations: create, push, index, count
+
+func main(): i32 {
+    var nums = new Vec<i64>{};
+
+    nums.push(10);
+    nums.push(20);
+    nums.push(30);
+
+    if (nums.count != 3) {
+        return 1;
+    }
+
+    if (nums[0] != 10) {
+        return 2;
+    }
+
+    if (nums[1] != 20) {
+        return 3;
+    }
+
+    if (nums[2] != 30) {
+        return 4;
+    }
+
+    return 0;
+}

--- a/w0/test/vec_bounds.w
+++ b/w0/test/vec_bounds.w
@@ -1,0 +1,8 @@
+// Test Vec bounds checking (runtime panic, not a --check error)
+// This test passes type-checking but panics at runtime with out-of-bounds access
+
+func main(): i32 {
+    var nums = new Vec<i64>{10, 20, 30};
+    var x = nums[5];
+    return 0;
+}

--- a/w0/test/vec_clear.w
+++ b/w0/test/vec_clear.w
@@ -1,0 +1,33 @@
+// Test Vec clear and re-push
+
+func main(): i32 {
+    var nums = new Vec<i64>{1, 2, 3};
+
+    if (nums.count != 3) {
+        return 1;
+    }
+
+    nums.clear();
+
+    if (nums.count != 0) {
+        return 2;
+    }
+
+    // Re-push after clear
+    nums.push(42);
+    nums.push(99);
+
+    if (nums.count != 2) {
+        return 3;
+    }
+
+    if (nums[0] != 42) {
+        return 4;
+    }
+
+    if (nums[1] != 99) {
+        return 5;
+    }
+
+    return 0;
+}

--- a/w0/test/vec_index_write.w
+++ b/w0/test/vec_index_write.w
@@ -1,0 +1,21 @@
+// Test Vec index write: v[i] = x
+
+func main(): i32 {
+    var nums = new Vec<i64>{10, 20, 30};
+
+    nums[1] = 99;
+
+    if (nums[0] != 10) {
+        return 1;
+    }
+
+    if (nums[1] != 99) {
+        return 2;
+    }
+
+    if (nums[2] != 30) {
+        return 3;
+    }
+
+    return 0;
+}

--- a/w0/test/vec_init.w
+++ b/w0/test/vec_init.w
@@ -1,0 +1,33 @@
+// Test Vec initializer syntax: new Vec<T>{1, 2, 3}
+
+func main(): i32 {
+    var nums = new Vec<i64>{1, 2, 3};
+
+    if (nums.count != 3) {
+        return 1;
+    }
+
+    if (nums[0] != 1) {
+        return 2;
+    }
+
+    if (nums[1] != 2) {
+        return 3;
+    }
+
+    if (nums[2] != 3) {
+        return 4;
+    }
+
+    // Push more after init
+    nums.push(4);
+    if (nums.count != 4) {
+        return 5;
+    }
+
+    if (nums[3] != 4) {
+        return 6;
+    }
+
+    return 0;
+}

--- a/w0/test/vec_pop.w
+++ b/w0/test/vec_pop.w
@@ -1,0 +1,30 @@
+// Test Vec pop operation
+
+func main(): i32 {
+    var nums = new Vec<i64>{10, 20, 30};
+
+    var last = nums.pop();
+    if (last != 30) {
+        return 1;
+    }
+
+    if (nums.count != 2) {
+        return 2;
+    }
+
+    var second = nums.pop();
+    if (second != 20) {
+        return 3;
+    }
+
+    var first = nums.pop();
+    if (first != 10) {
+        return 4;
+    }
+
+    if (nums.count != 0) {
+        return 5;
+    }
+
+    return 0;
+}

--- a/w0/test/vec_span.w
+++ b/w0/test/vec_span.w
@@ -1,0 +1,33 @@
+// Test Vec slicing to Span
+
+func sum(s: Span<i64>): i64 {
+    var total: i64 = 0;
+    for (var i: i64 = 0; i < s.count; i += 1) {
+        total = total + s[i];
+    }
+    return total;
+}
+
+func main(): i32 {
+    var nums = new Vec<i64>{10, 20, 30, 40, 50};
+
+    // Full slice
+    var all: Span<i64> = nums[:];
+    if (sum(all) != 150) {
+        return 1;
+    }
+
+    // Partial slice
+    var mid: Span<i64> = nums[1:4];
+    if (sum(mid) != 90) {
+        return 2;
+    }
+
+    // Start-only slice
+    var tail: Span<i64> = nums[3:];
+    if (sum(tail) != 90) {
+        return 3;
+    }
+
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -144,6 +144,12 @@ Type* type_span(Type* elem) {
     return type;
 }
 
+Type* type_vec(Type* elem) {
+    Type* type        = type_new(TYPE_VEC);
+    type->as.vec.elem = elem;
+    return type;
+}
+
 void type_free(Type* type) {
     if (!type)
         return;
@@ -223,6 +229,8 @@ int type_equals(Type* a, Type* b) {
                type_equals(a->as.array.elem, b->as.array.elem);
     case TYPE_SPAN:
         return type_equals(a->as.span.elem, b->as.span.elem);
+    case TYPE_VEC:
+        return type_equals(a->as.vec.elem, b->as.vec.elem);
     case TYPE_STRUCT:
         return strcmp(a->as.struc.name, b->as.struc.name) == 0;
     case TYPE_ENUM:
@@ -304,6 +312,11 @@ int type_assignable(Type* target, Type* value) {
         return 1;
     }
 
+    // null can be assigned to vec references
+    if (target->kind == TYPE_VEC && value->kind == TYPE_NULL) {
+        return 1;
+    }
+
     // null can be assigned to voidptr
     if (target->kind == TYPE_VOIDPTR && value->kind == TYPE_NULL) {
         return 1;
@@ -375,6 +388,11 @@ const char* type_name(Type* type) {
     case TYPE_SPAN: {
         char* buf = next_type_name_buf();
         snprintf(buf, 256, "Span<%s>", type_name(type->as.span.elem));
+        return buf;
+    }
+    case TYPE_VEC: {
+        char* buf = next_type_name_buf();
+        snprintf(buf, 256, "Vec<%s>", type_name(type->as.vec.elem));
         return buf;
     }
     case TYPE_STRUCT:
@@ -496,6 +514,10 @@ static const char* type_mangle_name(Type* type) {
     case TYPE_SPAN:
         snprintf(type_mangle_buf, sizeof(type_mangle_buf), "Span_%s",
                  type_mangle_name(type->as.span.elem));
+        return type_mangle_buf;
+    case TYPE_VEC:
+        snprintf(type_mangle_buf, sizeof(type_mangle_buf), "Vec_%s",
+                 type_mangle_name(type->as.vec.elem));
         return type_mangle_buf;
     case TYPE_STRUCT:
         return type->as.struc.name;

--- a/w0/types.h
+++ b/w0/types.h
@@ -21,6 +21,7 @@ typedef enum {
     TYPE_VOIDPTR,
     TYPE_ARRAY,
     TYPE_SPAN,
+    TYPE_VEC,
     TYPE_STRUCT,
     TYPE_ENUM,
     TYPE_TRAIT,
@@ -56,6 +57,11 @@ struct Type {
         struct {
             Type* elem; // Element type T
         } span;
+
+        // Vec: Vec<T>
+        struct {
+            Type* elem; // Element type T
+        } vec;
 
         // Struct
         struct {
@@ -145,6 +151,7 @@ Type* type_func(Type** params, int param_count, Type* return_type, int is_vararg
 Type* type_tuple(Type** elems, int count);
 Type* type_generic_param(const char* name);
 Type* type_span(Type* elem);
+Type* type_vec(Type* elem);
 
 // Generic type name mangling
 char* type_mangle_generic(const char* base, Type** args, int count);


### PR DESCRIPTION
## Summary

- Add `Vec<T>` as a compiler builtin dynamic array type with RC memory management
- Support push, pop, clear, bounds-checked index read/write, slice to `Span<T>`, and initializer syntax (`new Vec<T>{1, 2, 3}`)
- Automatic element RC cleanup on drop for struct/vec element types
- Parser extended to support bare element lists in `new` expressions
- 8 new tests (7 valid + 1 RC runtime) — all 111 tests pass

## Test plan

- [x] `make` builds with zero warnings
- [x] All 111 tests pass (`make test`): 65 valid, 35 error, 11 RC runtime
- [x] New vec tests cover: basic push/index, initializer, pop, clear, index write, slice to span, bounds checking, RC struct element cleanup
- [x] `make format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)