### PR TITLE
fix: accept all integer types in foreach range expressions

### DIFF
--- a/w0/ast.h
+++ b/w0/ast.h
@@ -331,6 +331,7 @@ struct Node {
             Node* end;
             Node* step;
             Node* body;
+            Type* resolved_type; // Set by checker (loop variable type)
         } foreach_stmt;
 
         // Return statement

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -2320,20 +2320,32 @@ static void check_statement(Checker* checker, Node* node) {
         Type* start_type = check_expression(checker, node->as.foreach_stmt.start);
         Type* end_type   = check_expression(checker, node->as.foreach_stmt.end);
 
-        if (start_type->kind != TYPE_INT64 && start_type->kind != TYPE_ERROR) {
+        if (!type_is_integer(start_type) && start_type->kind != TYPE_ERROR) {
             check_error(checker, node->as.foreach_stmt.start->line,
                         node->as.foreach_stmt.start->column,
                         "Foreach range start must be int, got '%s'", type_name(start_type));
         }
 
-        if (end_type->kind != TYPE_INT64 && end_type->kind != TYPE_ERROR) {
+        if (!type_is_integer(end_type) && end_type->kind != TYPE_ERROR) {
             check_error(checker, node->as.foreach_stmt.end->line, node->as.foreach_stmt.end->column,
                         "Foreach range end must be int, got '%s'", type_name(end_type));
         }
 
-        // Add the loop variable as a const int64 (immutable)
-        Symbol* sym = checker_define(checker, node->as.foreach_stmt.var_name, SYM_VAR, type_int64,
-                                     1, 0, NULL);
+        // Determine loop variable type: prefer end type when start is a default i64 literal
+        Type* loop_type;
+        if (type_is_integer(end_type) &&
+            (start_type->kind == TYPE_INT64 || !type_is_integer(start_type))) {
+            loop_type = end_type;
+        } else if (type_is_integer(start_type)) {
+            loop_type = start_type;
+        } else {
+            loop_type = type_int64;
+        }
+        node->as.foreach_stmt.resolved_type = loop_type;
+
+        // Add the loop variable as a const integer (immutable)
+        Symbol* sym =
+            checker_define(checker, node->as.foreach_stmt.var_name, SYM_VAR, loop_type, 1, 0, NULL);
         if (!sym) {
             check_error(checker, node->line, node->column,
                         "Variable '%s' already declared in this scope",
@@ -2362,7 +2374,7 @@ static void check_statement(Checker* checker, Node* node) {
             if (expected->kind == TYPE_ENUM) {
                 checker->enum_target_hint = expected;
             }
-            Type* actual = check_expression(checker, node->as.return_stmt.value);
+            Type* actual              = check_expression(checker, node->as.return_stmt.value);
             checker->enum_target_hint = old_hint;
             if (!type_assignable(expected, actual)) {
                 check_error_type(checker, node->line, node->column, "Return", expected, actual);
@@ -2965,8 +2977,7 @@ int checker_check(Checker* checker, Node* ast) {
                 check_decl(checker, decl);
             }
             // Generic impl block: impl Drop for Box<T>
-            else if (decl->type == NODE_IMPL_DECL &&
-                     decl->as.impl_decl.type_args.count > 0) {
+            else if (decl->type == NODE_IMPL_DECL && decl->as.impl_decl.type_args.count > 0) {
                 check_decl(checker, decl);
             }
         }
@@ -2993,8 +3004,7 @@ int checker_check(Checker* checker, Node* ast) {
                 decl->as.func_decl.receiver_type_args.count > 0) {
                 continue;
             }
-            if (decl->type == NODE_IMPL_DECL &&
-                decl->as.impl_decl.type_args.count > 0) {
+            if (decl->type == NODE_IMPL_DECL && decl->as.impl_decl.type_args.count > 0) {
                 continue;
             }
             check_decl(checker, decl);
@@ -3021,8 +3031,7 @@ int checker_check(Checker* checker, Node* ast) {
                 decl->as.func_decl.receiver_type_args.count > 0) {
                 continue;
             }
-            if (decl->type == NODE_IMPL_DECL &&
-                decl->as.impl_decl.type_args.count > 0) {
+            if (decl->type == NODE_IMPL_DECL && decl->as.impl_decl.type_args.count > 0) {
                 continue;
             }
             check_decl(checker, decl);

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1684,8 +1684,8 @@ void codegen_emit(CodeGen* gen, Node* ast) {
                     emit(gen, "        __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
                 }
             } else if (ft && ft->kind == TYPE_VEC) {
-                emit(gen, "        __rc_dec_Vec_%s(ptr->%s);\n",
-                     type_name(ft->as.vec.elem), t->as.struc.field_names[f]);
+                emit(gen, "        __rc_dec_Vec_%s(ptr->%s);\n", type_name(ft->as.vec.elem),
+                     t->as.struc.field_names[f]);
             }
         }
         if (gen->rc_debug) {

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -2042,8 +2042,12 @@ void emit_stmt(CodeGen* gen, Node* node) {
 
     case NODE_FOREACH:
         emit_indent(gen);
-        // Generate: for (int64_t var = start; var < end; var += step) {
-        emit(gen, "for (int64_t %s = ", node->as.foreach_stmt.var_name);
+        // Generate: for (<type> var = start; var < end; var += step) {
+        emit(gen, "for (");
+        emit_resolved_type(gen, node->as.foreach_stmt.resolved_type
+                                    ? node->as.foreach_stmt.resolved_type
+                                    : type_int64);
+        emit(gen, " %s = ", node->as.foreach_stmt.var_name);
         emit_expr(gen, node->as.foreach_stmt.start);
         emit(gen, "; %s < ", node->as.foreach_stmt.var_name);
         emit_expr(gen, node->as.foreach_stmt.end);

--- a/w0/test/hash_table.w
+++ b/w0/test/hash_table.w
@@ -37,8 +37,8 @@ struct HashTable<K, V>  {
 func (HashTable<K,V>) init(): void {
     // self.buckets = new Vec<HashEntry<V>>{};
     self.buckets.clear();
-    self.size = 2;
-    foreach (const i in 0..1) {
+    self.size = 20;
+    foreach (const i in 0..self.size) {
         self.buckets.push(new HashEntry<K, V>{next: null, value: 0});
     }
     // Implementation of insert method


### PR DESCRIPTION
## Summary

- Foreach range bounds were hardcoded to only accept `i64`, rejecting valid expressions like `0..self.size` where `size` is `u32`
- Now uses `type_is_integer()` to accept any integer type (`i8`–`i64`, `u8`–`u64`) in range bounds
- Loop variable type is inferred from the range, preferring the end type when the start is a default `i64` literal (e.g., `0..self.size` with `size: u32` yields a `uint32_t` loop variable)

## Changes

- **ast.h**: Added `resolved_type` field to `foreach_stmt` for checker-determined loop variable type
- **checker.c**: Replaced `== TYPE_INT64` checks with `type_is_integer()`, added loop type inference logic
- **codegen_emit.c**: Replaced hardcoded `int64_t` with `emit_resolved_type()` for correct C type emission
- **test/hash_table.w**: Updated to use `0..self.size` instead of hardcoded range

## Test plan

- [x] All 111 tests pass (`make test`)
- [x] `hash_table.w` type-checks and compiles/runs successfully
- [x] Generated C uses correct `uint32_t` loop variable type

🤖 Generated with [Claude Code](https://claude.com/claude-code)