### PR TITLE
feat: implement string.length() method

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -319,6 +319,18 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         return type_error;
     }
 
+    if (object->kind == TYPE_STRING) {
+        const char* member_name = node->as.member.name;
+        node->as.member.is_ref  = 0;
+        if (strcmp(member_name, "length") == 0) {
+            node->as.member.struct_name = xstrdup("__String");
+            return type_func(NULL, 0, type_int64, 0);
+        }
+        check_error(checker, node->line, node->column,
+                    "String has no member '%s'", member_name);
+        return type_error;
+    }
+
     if (object->kind != TYPE_STRUCT) {
         check_error(checker, node->line, node->column,
                     "Member access requires struct type, got '%s'", type_name(object));

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -522,6 +522,7 @@ static void emit_c_headers(CodeGen* gen) {
     emit(gen, "#include <stddef.h>\n");
     emit(gen, "#include <stdlib.h>\n");
     emit(gen, "#include <stdio.h>\n");
+    emit(gen, "#include <string.h>\n");
     emit(gen, "\n");
 }
 
@@ -597,6 +598,12 @@ static void emit_bounds_checks(CodeGen* gen) {
         emit(gen, "    }\n");
         emit(gen, "}\n\n");
     }
+}
+
+// Emit string method helpers
+static void emit_string_helpers(CodeGen* gen) {
+    emit(gen, "static inline int64_t __String_length(const char* s) { return (int64_t)strlen(s); "
+              "}\n\n");
 }
 
 // Emit C struct typedefs for each collected tuple type (__tuple_tN)
@@ -1848,6 +1855,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit_c_headers(gen);
     emit_rc_runtime(gen);
     emit_bounds_checks(gen);
+    emit_string_helpers(gen);
     emit_tuple_typedefs(gen);
     register_enum_names(gen, ast);
     compute_enum_rc_flags(gen, ast);

--- a/w0/test/error_string_no_member.w
+++ b/w0/test/error_string_no_member.w
@@ -1,0 +1,6 @@
+// Expected error: String has no member 'foo'
+func main(): i32 {
+    var s = "hello";
+    var x = s.foo();
+    return 0;
+}

--- a/w0/test/string_length.w
+++ b/w0/test/string_length.w
@@ -1,0 +1,7 @@
+func main(): i32 {
+    var s = "hello";
+    if (s.length() != 5) { return 1; }
+    if ("".length() != 0) { return 2; }
+    if ("abc".length() != 3) { return 3; }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `string.length()` method returning `i64`, mapped to `strlen()` in generated C
- Checker resolves `string.length` via `TYPE_STRING` handler using existing struct method dispatch (`__String` prefix)
- Codegen emits `#include <string.h>` and a `static inline __String_length` helper

Closes #66

## Test plan
- [x] `string_length.w` — validates `s.length()`, `"".length()`, `"abc".length()`
- [x] `error_string_no_member.w` — validates error for `s.foo()`
- [x] All 113 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)