### PR TITLE
feat: implement string operations (#67-#73)

### DIFF
--- a/lib/include/std_str.h
+++ b/lib/include/std_str.h
@@ -1,0 +1,31 @@
+/*
+ * std_str.h — String conversion helpers for the Whist standard library
+ *
+ * Static inline functions using whist-compatible types.
+ * Functions use the std__ prefix (double underscore) to avoid
+ * colliding with the module-prefixed wrapper names (std_*) generated
+ * by the whist compiler.
+ *
+ * Usage: compile with -Ilib/include so #include <std_str.h> resolves.
+ */
+
+#ifndef WHIST_STD_STR_H
+#define WHIST_STD_STR_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+static inline int64_t std__parse_i64(const char* s) {
+    return (int64_t)strtoll(s, NULL, 10);
+}
+
+static inline const char* std__to_string(int64_t n) {
+    char buf[32];
+    int len = snprintf(buf, sizeof(buf), "%lld", (long long)n);
+    char* r = (char*)malloc(len + 1);
+    snprintf(r, len + 1, "%lld", (long long)n);
+    return r;
+}
+
+#endif

--- a/lib/std.w
+++ b/lib/std.w
@@ -29,6 +29,20 @@ func min_i64(a: i64, b: i64): i64 {
     return b;
 }
 
+// String/integer conversion
+private extern std_str {
+    func std__parse_i64(s: string): i64;
+    func std__to_string(n: i64): string;
+}
+
+func parse_i64(s: string): i64 {
+    return std__parse_i64(s);
+}
+
+func to_string(n: i64): string {
+    return std__to_string(n);
+}
+
 // Private internal function - should not be visible outside std
 private func _internal_std(): i64 {
     return 42;

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -181,6 +181,7 @@ struct Node {
             TokenType op;
             Node*     left;
             Node*     right;
+            int       is_string_op; // Set by checker for string ==, !=, +
         } binary;
 
         // Unary expression
@@ -212,6 +213,7 @@ struct Node {
             Type* resolved_type; // Set by checker
             int   is_array;      // Set by checker: 1 if slicing array, 0 if slicing span
             int   is_vec;        // Set by checker: 1 if slicing a vec
+            int   is_string;     // Set by checker: 1 if slicing a string
         } slice;
 
         // Member access: obj.member

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -574,6 +574,12 @@ static void check_var_decl_stmt(Checker* checker, Node* node) {
     Symbol* sym = checker_define(checker, name, SYM_VAR, var_type, node->as.var_decl.is_const,
                                  node->as.var_decl.is_public, checker->current_module);
 
+    // Store resolved type for codegen when type is inferred from non-literal expressions
+    if (!node->as.var_decl.type && init_type && init_type->kind == TYPE_STRING &&
+        node->as.var_decl.init->type != NODE_STRING_LIT) {
+        node->as.var_decl.resolved_type = init_type;
+    }
+
     // Propagate RC tracking
     if (sym && node->as.var_decl.init) {
         if (var_type && var_type->kind == TYPE_ENUM && var_type->as.enm.has_rc_fields) {

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -26,6 +26,16 @@ static Type* check_binary_expr(Checker* checker, Node* node) {
     // Comparison operators return bool
     if (op == TOK_EQ_EQ || op == TOK_BANG_EQ || op == TOK_LT || op == TOK_GT || op == TOK_LT_EQ ||
         op == TOK_GT_EQ) {
+        // String comparison: only == and != allowed
+        if (left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
+            if (op == TOK_EQ_EQ || op == TOK_BANG_EQ) {
+                node->as.binary.is_string_op = 1;
+                return type_bool;
+            }
+            check_error(checker, node->line, node->column,
+                        "Strings only support == and != comparison");
+            return type_error;
+        }
         if (type_equals(left, right))
             return type_bool;
         // voidptr/struct == null and null == voidptr/struct (only for == and !=)
@@ -59,6 +69,11 @@ static Type* check_binary_expr(Checker* checker, Node* node) {
     // Arithmetic operators
     if (op == TOK_PLUS || op == TOK_MINUS || op == TOK_STAR || op == TOK_SLASH ||
         op == TOK_PERCENT) {
+        // String concatenation: string + string
+        if (op == TOK_PLUS && left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
+            node->as.binary.is_string_op = 1;
+            return type_string;
+        }
         if ((type_is_integer(left) || left->kind == TYPE_F32 || left->kind == TYPE_F64) &&
             (type_is_integer(right) || right->kind == TYPE_F32 || right->kind == TYPE_F64)) {
             if (left->kind == TYPE_F64 || right->kind == TYPE_F64)
@@ -204,6 +219,26 @@ static Type* check_slice_expr(Checker* checker, Node* node) {
     } else if (object->kind == TYPE_VEC) {
         elem_type             = object->as.vec.elem;
         node->as.slice.is_vec = 1;
+    } else if (object->kind == TYPE_STRING) {
+        // String slicing returns a new string
+        node->as.slice.is_string = 1;
+
+        // Check bounds are integers (if present)
+        if (node->as.slice.start) {
+            Type* t = check_expression(checker, node->as.slice.start);
+            if (!type_is_integer(t) && t->kind != TYPE_ERROR) {
+                check_error(checker, node->as.slice.start->line, node->as.slice.start->column,
+                            "Slice start index must be an integer, got '%s'", type_name(t));
+            }
+        }
+        if (node->as.slice.end) {
+            Type* t = check_expression(checker, node->as.slice.end);
+            if (!type_is_integer(t) && t->kind != TYPE_ERROR) {
+                check_error(checker, node->as.slice.end->line, node->as.slice.end->column,
+                            "Slice end index must be an integer, got '%s'", type_name(t));
+            }
+        }
+        return type_string;
     } else {
         check_error(checker, node->line, node->column, "Cannot slice type '%s'", type_name(object));
         return type_error;
@@ -236,6 +271,13 @@ static Type* check_member_expr(Checker* checker, Node* node) {
     if (node->as.member.object->type == NODE_IDENT) {
         const char* name = node->as.member.object->as.ident.name;
         if (is_imported_module(checker, name)) {
+            // Built-in: std.format(string, ...) -> string
+            if (strcmp(name, "std") == 0 && strcmp(node->as.member.name, "format") == 0) {
+                node->as.member.module_name = xstrdup(name);
+                Type** params               = xmalloc(1 * sizeof(Type*));
+                params[0]                   = type_string;
+                return type_func(params, 1, type_string, 1);
+            }
             Symbol* sym = checker_lookup_in_module(checker, name, node->as.member.name);
             if (!sym) {
                 check_error(checker, node->line, node->column,
@@ -326,8 +368,14 @@ static Type* check_member_expr(Checker* checker, Node* node) {
             node->as.member.struct_name = xstrdup("__String");
             return type_func(NULL, 0, type_int64, 0);
         }
-        check_error(checker, node->line, node->column,
-                    "String has no member '%s'", member_name);
+        if (strcmp(member_name, "contains") == 0 || strcmp(member_name, "starts_with") == 0 ||
+            strcmp(member_name, "ends_with") == 0) {
+            node->as.member.struct_name = xstrdup("__String");
+            Type** params               = xmalloc(1 * sizeof(Type*));
+            params[0]                   = type_string;
+            return type_func(params, 1, type_bool, 0);
+        }
+        check_error(checker, node->line, node->column, "String has no member '%s'", member_name);
         return type_error;
     }
 

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -523,6 +523,7 @@ static void emit_c_headers(CodeGen* gen) {
     emit(gen, "#include <stdlib.h>\n");
     emit(gen, "#include <stdio.h>\n");
     emit(gen, "#include <string.h>\n");
+    emit(gen, "#include <stdarg.h>\n");
     emit(gen, "\n");
 }
 
@@ -603,7 +604,42 @@ static void emit_bounds_checks(CodeGen* gen) {
 // Emit string method helpers
 static void emit_string_helpers(CodeGen* gen) {
     emit(gen, "static inline int64_t __String_length(const char* s) { return (int64_t)strlen(s); "
-              "}\n\n");
+              "}\n");
+    emit(gen, "static inline const char* __String_concat(const char* a, const char* b) {\n");
+    emit(gen, "    size_t la = strlen(a), lb = strlen(b);\n");
+    emit(gen, "    char* r = (char*)malloc(la + lb + 1);\n");
+    emit(gen, "    memcpy(r, a, la); memcpy(r + la, b, lb + 1);\n");
+    emit(gen, "    return r;\n");
+    emit(gen, "}\n");
+    emit(gen, "static inline const char* __String_substr(const char* s, int64_t start, int64_t "
+              "end) {\n");
+    emit(gen, "    int64_t len = end - start;\n");
+    emit(gen, "    if (len < 0) len = 0;\n");
+    emit(gen, "    char* r = (char*)malloc(len + 1);\n");
+    emit(gen, "    memcpy(r, s + start, len);\n");
+    emit(gen, "    r[len] = '\\0';\n");
+    emit(gen, "    return r;\n");
+    emit(gen, "}\n");
+    emit(gen, "static inline bool __String_contains(const char* s, const char* sub) {\n");
+    emit(gen, "    return strstr(s, sub) != NULL;\n");
+    emit(gen, "}\n");
+    emit(gen, "static inline bool __String_starts_with(const char* s, const char* prefix) {\n");
+    emit(gen, "    return strncmp(s, prefix, strlen(prefix)) == 0;\n");
+    emit(gen, "}\n");
+    emit(gen, "static inline bool __String_ends_with(const char* s, const char* suffix) {\n");
+    emit(gen, "    size_t ls = strlen(s), lsuf = strlen(suffix);\n");
+    emit(gen, "    return ls >= lsuf && strcmp(s + ls - lsuf, suffix) == 0;\n");
+    emit(gen, "}\n");
+    emit(gen, "static inline const char* __std_format(const char* fmt, ...) {\n");
+    emit(gen, "    va_list args1, args2;\n");
+    emit(gen, "    va_start(args1, fmt); va_copy(args2, args1);\n");
+    emit(gen, "    int n = vsnprintf(NULL, 0, fmt, args1);\n");
+    emit(gen, "    va_end(args1);\n");
+    emit(gen, "    char* buf = (char*)malloc(n + 1);\n");
+    emit(gen, "    vsnprintf(buf, n + 1, fmt, args2);\n");
+    emit(gen, "    va_end(args2);\n");
+    emit(gen, "    return buf;\n");
+    emit(gen, "}\n\n");
 }
 
 // Emit C struct typedefs for each collected tuple type (__tuple_tN)

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -1059,6 +1059,19 @@ static void emit_call_expr(CodeGen* gen, Node* node) {
     Node* func = node->as.call.func;
     // Check if this is a module-qualified call (e.g., std.print())
     if (func->type == NODE_MEMBER && func->as.member.module_name != NULL) {
+        // Built-in: std.format -> __std_format
+        if (strcmp(func->as.member.module_name, "std") == 0 &&
+            strncmp(func->as.member.name, "format", func->as.member.length) == 0 &&
+            func->as.member.length == 6) {
+            emit(gen, "__std_format(");
+            for (int i = 0; i < node->as.call.args.count; i++) {
+                if (i > 0)
+                    emit(gen, ", ");
+                emit_expr(gen, node->as.call.args.nodes[i]);
+            }
+            emit(gen, ")");
+            return;
+        }
         // Module-qualified call: emit module_func(args...)
         emit(gen, "%s_%.*s(", func->as.member.module_name, func->as.member.length,
              func->as.member.name);
@@ -1180,6 +1193,28 @@ static void emit_index_expr(CodeGen* gen, Node* node) {
 
 // Emit a slice expression as a Span compound literal with data pointer and count
 static void emit_slice_expr(CodeGen* gen, Node* node) {
+    // String slicing: produces a new string via __String_substr
+    if (node->as.slice.is_string) {
+        emit(gen, "__String_substr(");
+        emit_expr(gen, node->as.slice.object);
+        emit(gen, ", ");
+        if (node->as.slice.start) {
+            emit_expr(gen, node->as.slice.start);
+        } else {
+            emit(gen, "0");
+        }
+        emit(gen, ", ");
+        if (node->as.slice.end) {
+            emit_expr(gen, node->as.slice.end);
+        } else {
+            emit(gen, "(int64_t)strlen(");
+            emit_expr(gen, node->as.slice.object);
+            emit(gen, ")");
+        }
+        emit(gen, ")");
+        return;
+    }
+
     // Slice produces a span: (__Span_T){ .data = ..., .count = ... }
     Type* span_type = node->as.slice.resolved_type;
     Type* elem_type = span_type->as.span.elem;
@@ -1404,11 +1439,34 @@ static void emit_expr(CodeGen* gen, Node* node) {
         break;
 
     case NODE_BINARY:
-        emit(gen, "(");
-        emit_expr(gen, node->as.binary.left);
-        emit(gen, " %s ", binary_op_str(node->as.binary.op));
-        emit_expr(gen, node->as.binary.right);
-        emit(gen, ")");
+        if (node->as.binary.is_string_op) {
+            TokenType op = node->as.binary.op;
+            if (op == TOK_EQ_EQ) {
+                emit(gen, "(strcmp(");
+                emit_expr(gen, node->as.binary.left);
+                emit(gen, ", ");
+                emit_expr(gen, node->as.binary.right);
+                emit(gen, ") == 0)");
+            } else if (op == TOK_BANG_EQ) {
+                emit(gen, "(strcmp(");
+                emit_expr(gen, node->as.binary.left);
+                emit(gen, ", ");
+                emit_expr(gen, node->as.binary.right);
+                emit(gen, ") != 0)");
+            } else if (op == TOK_PLUS) {
+                emit(gen, "__String_concat(");
+                emit_expr(gen, node->as.binary.left);
+                emit(gen, ", ");
+                emit_expr(gen, node->as.binary.right);
+                emit(gen, ")");
+            }
+        } else {
+            emit(gen, "(");
+            emit_expr(gen, node->as.binary.left);
+            emit(gen, " %s ", binary_op_str(node->as.binary.op));
+            emit_expr(gen, node->as.binary.right);
+            emit(gen, ")");
+        }
         break;
 
     case NODE_UNARY:
@@ -1726,14 +1784,14 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
 
 // Emit an RC-managed Vec declaration: var v = new Vec<T>{...}
 static void emit_var_decl_rc_new_vec(CodeGen* gen, Node* node) {
-    Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
+    Type*       rtype      = node->as.var_decl.init->as.new_expr.resolved_type;
     const char* elem_tname = type_name(rtype->as.vec.elem);
     emit_indent(gen);
     emit(gen, "__Vec_%s* %s = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s));\n", elem_tname,
          node->as.var_decl.name, elem_tname, elem_tname);
     emit_indent(gen);
-    emit(gen, "%s->data = NULL; %s->count = 0; %s->capacity = 0;\n",
-         node->as.var_decl.name, node->as.var_decl.name, node->as.var_decl.name);
+    emit(gen, "%s->data = NULL; %s->count = 0; %s->capacity = 0;\n", node->as.var_decl.name,
+         node->as.var_decl.name, node->as.var_decl.name);
     Node* init = node->as.var_decl.init->as.new_expr.init;
     for (int i = 0; i < init->as.struct_init.fields.count; i++) {
         Node* field = init->as.struct_init.fields.nodes[i];
@@ -1751,11 +1809,11 @@ static void emit_var_decl_rc_new_vec(CodeGen* gen, Node* node) {
 
 // Emit an RC-managed struct declaration: var p = new Point { x: 1, y: 2 }
 static void emit_var_decl_rc_new_struct(CodeGen* gen, Node* node) {
-    Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
+    Type*       rtype = node->as.var_decl.init->as.new_expr.resolved_type;
     const char* tname = rtype->as.struc.name;
     emit_indent(gen);
-    emit(gen, "%s* %s = (%s*)__rc_alloc(sizeof(%s));\n", tname, node->as.var_decl.name,
-         tname, tname);
+    emit(gen, "%s* %s = (%s*)__rc_alloc(sizeof(%s));\n", tname, node->as.var_decl.name, tname,
+         tname);
     emit_indent(gen);
     emit(gen, "*%s = (%s)", node->as.var_decl.name, tname);
     emit_struct_init(gen, node->as.var_decl.init->as.new_expr.init);
@@ -1800,10 +1858,10 @@ static void emit_var_decl_rc_copy(CodeGen* gen, Node* node) {
     emit_expr(gen, node->as.var_decl.init);
     emit(gen, ";\n");
     // Function calls transfer ownership (rc already 1), no inc needed
-    Type* rc_type  = node->as.var_decl.resolved_type;
-    int   skip_inc = node->as.var_decl.init->type == NODE_CALL ||
-                   (rc_type && rc_type->kind == TYPE_ENUM &&
-                    node->as.var_decl.init->type == NODE_ENUM_VALUE);
+    Type* rc_type = node->as.var_decl.resolved_type;
+    int   skip_inc =
+        node->as.var_decl.init->type == NODE_CALL ||
+        (rc_type && rc_type->kind == TYPE_ENUM && node->as.var_decl.init->type == NODE_ENUM_VALUE);
     if (!skip_inc && rc_type) {
         const char* inc_fn = get_inc_func_for_type(rc_type);
         emit_indent(gen);
@@ -1867,7 +1925,7 @@ static void emit_var_decl_inferred_type(CodeGen* gen, Node* node) {
             }
         }
         Type* tuple = type_tuple(elems, count);
-        int idx = -1;
+        int   idx   = -1;
         for (int i = 0; i < gen->tuple_type_count; i++) {
             if (tuple_types_equal(gen->tuple_types[i], tuple)) {
                 idx = i;

--- a/w0/test/error_string_compare_lt.w
+++ b/w0/test/error_string_compare_lt.w
@@ -1,0 +1,5 @@
+// Expected error: Strings only support == and != comparison
+func main(): i32 {
+    if ("a" < "b") { return 1; }
+    return 0;
+}

--- a/w0/test/string_concat.w
+++ b/w0/test/string_concat.w
@@ -1,0 +1,9 @@
+func main(): i32 {
+    var s = "hello" + " " + "world";
+    if (s != "hello world") { return 1; }
+    var a = "foo";
+    var b = "bar";
+    if (a + b != "foobar") { return 2; }
+    if ("" + "x" != "x") { return 3; }
+    return 0;
+}

--- a/w0/test/string_conversion.w
+++ b/w0/test/string_conversion.w
@@ -1,0 +1,11 @@
+import std;
+
+func main(): i32 {
+    if (std.parse_i64("42") != 42) { return 1; }
+    if (std.parse_i64("-7") != -7) { return 2; }
+    if (std.parse_i64("0") != 0) { return 3; }
+    if (std.to_string(42) != "42") { return 4; }
+    if (std.to_string(-7) != "-7") { return 5; }
+    if (std.to_string(0) != "0") { return 6; }
+    return 0;
+}

--- a/w0/test/string_equality.w
+++ b/w0/test/string_equality.w
@@ -1,0 +1,8 @@
+func main(): i32 {
+    var s = "foo";
+    if (s != "foo") { return 1; }
+    if (s == "bar") { return 2; }
+    if ("hello" != "hello") { return 3; }
+    if ("hello" == "world") { return 4; }
+    return 0;
+}

--- a/w0/test/string_format.w
+++ b/w0/test/string_format.w
@@ -1,0 +1,11 @@
+import std;
+
+func main(): i32 {
+    var s = std.format("x=%d", 42);
+    if (s != "x=42") { return 1; }
+    var s2 = std.format("%s has %d items", "list", 3);
+    if (s2 != "list has 3 items") { return 2; }
+    var s3 = std.format("hello");
+    if (s3 != "hello") { return 3; }
+    return 0;
+}

--- a/w0/test/string_index.w
+++ b/w0/test/string_index.w
@@ -1,0 +1,8 @@
+func main(): i32 {
+    var s = "abc";
+    var c = s[1];
+    if (c != 'b') { return 1; }
+    if ("hello"[0] != 'h') { return 2; }
+    if ("hello"[4] != 'o') { return 3; }
+    return 0;
+}

--- a/w0/test/string_search.w
+++ b/w0/test/string_search.w
@@ -1,0 +1,11 @@
+func main(): i32 {
+    var s = "hello world";
+    if (!s.starts_with("hello")) { return 1; }
+    if (s.starts_with("world")) { return 2; }
+    if (!s.ends_with("world")) { return 3; }
+    if (s.ends_with("hello")) { return 4; }
+    if (!s.contains("llo w")) { return 5; }
+    if (s.contains("xyz")) { return 6; }
+    if (!"".starts_with("")) { return 7; }
+    return 0;
+}

--- a/w0/test/string_slice.w
+++ b/w0/test/string_slice.w
@@ -1,0 +1,10 @@
+func main(): i32 {
+    var s = "hello";
+    if (s[1:4] != "ell") { return 1; }
+    if (s[0:5] != "hello") { return 2; }
+    if (s[1:] != "ello") { return 3; }
+    if (s[:3] != "hel") { return 4; }
+    if (s[:] != "hello") { return 5; }
+    if ("abcdef"[2:5] != "cde") { return 6; }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- **String equality/inequality** (#67): `==`/`!=` use `strcmp` instead of pointer comparison; `<`/`>` etc. produce a type error
- **String concatenation** (#68): `+` operator calls `__String_concat` (malloc + memcpy)
- **String indexing** (#69): already worked, added test coverage
- **String slicing** (#70): `s[1:4]` via `__String_substr`, supports omitted bounds (`s[1:]`, `s[:3]`, `s[:]`)
- **std.format** (#71): compiler builtin with varargs, emits `__std_format` using `vsnprintf`
- **String ↔ integer conversion** (#72): `std.parse_i64` / `std.to_string` via extern C header `lib/include/std_str.h`
- **String searching** (#73): `contains`, `starts_with`, `ends_with` methods using `strstr`/`strncmp`/`strcmp`

Also fixes string type inference for `var s = string_expr` (non-literal) by setting `resolved_type` in the checker.

## Test plan
- [x] `make` — compiles cleanly
- [x] `make test` — all 121 tests pass (73 valid + 37 error + 11 RC runtime)
- [x] `make format` — code style compliant
- [x] Runtime tests for each feature: compile generated C and verify exit code 0
- [x] Error test: `"a" < "b"` produces expected type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)