### PR TITLE
feat: implement match statements with payload binding (#75)

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -192,6 +192,7 @@ Create vecs: `var v = new Vec<i64>{};` or `var v = new Vec<i64>{1, 2, 3};`
              | <while-stmt>
              | <for-stmt>
              | <foreach-stmt>
+             | <match-stmt>
              | <return-stmt>
              | <break-stmt>
              | <continue-stmt>
@@ -222,6 +223,18 @@ The range `start..end` is **end-exclusive**: iterates from `start` up to but not
 
 <defer-stmt> ::= 'defer' <statement>
 
+<match-stmt> ::= 'match' '(' <expression> ')' '{' { <match-arm> } '}'
+
+<match-arm> ::= <match-pattern> '=>' <statement> [ ',' ]
+
+<match-pattern> ::= '_'
+                  | <identifier> [ '(' <identifier> { ',' <identifier> } ')' ]
+                  | <identifier> '::' <identifier> [ '(' <identifier> { ',' <identifier> } ')' ]
+```
+
+Match statements destructure enum values by variant. The expression must be an enum type. Each arm matches a variant pattern and binds payload fields to local variables. Variant names can be unqualified (`Some(v)`) or qualified (`Option::Some(v)`). The wildcard pattern `_` matches any variant. Commas between arms are optional.
+
+```bnf
 <expr-stmt> ::= <expression> ';'
 ```
 
@@ -344,9 +357,9 @@ The range `start..end` is **end-exclusive**: iterates from `start` up to but not
 ```
 break    const    continue    defer     else      enum
 extern   false    for         foreach   func      if
-impl     import   in          new       null      public
-private  return   self        struct    trait     true
-type     var      while
+impl     import   in          match     new       null
+public   private  return      self      struct    trait
+true     type     var         while
 ```
 
 ### Identifiers
@@ -407,7 +420,7 @@ type     var      while
 =     <     >
 +=    -=    *=    /=    %=    &=    |=    ^=
 ==    !=    <=    >=    &&    ||    <<    >>    <<=   >>=
-->    ::    ..
+->    =>    ::    ..
 (     )     {     }     [     ]     ;     :     ,     .
 ```
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -192,6 +192,19 @@ void node_free(Node* node) {
     case NODE_DEFER:
         node_free(node->as.defer_stmt.stmt);
         break;
+    case NODE_MATCH:
+        node_free(node->as.match_stmt.expr);
+        nodelist_free(&node->as.match_stmt.arms);
+        break;
+    case NODE_MATCH_ARM:
+        free(node->as.match_arm.enum_name);
+        free(node->as.match_arm.variant_name);
+        for (int i = 0; i < node->as.match_arm.binding_count; i++) {
+            free(node->as.match_arm.bindings[i]);
+        }
+        free(node->as.match_arm.bindings);
+        node_free(node->as.match_arm.body);
+        break;
     case NODE_FUNC_DECL:
         free(node->as.func_decl.receiver_type);
         // Free receiver type args if present

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -68,6 +68,8 @@ typedef enum {
     NODE_BREAK,
     NODE_CONTINUE,
     NODE_DEFER,
+    NODE_MATCH,
+    NODE_MATCH_ARM,
 
     // Declarations
     NODE_FUNC_DECL,
@@ -345,6 +347,25 @@ struct Node {
         struct {
             Node* stmt;
         } defer_stmt;
+
+        // Match statement
+        struct {
+            Node*    expr;          // Expression being matched
+            NodeList arms;          // List of NODE_MATCH_ARM nodes
+            Type*    resolved_type; // Set by checker: enum type of expr
+        } match_stmt;
+
+        // Match arm
+        struct {
+            char*  enum_name; // Explicit enum name (NULL if inferred)
+            int    enum_name_length;
+            char*  variant_name; // Variant name (NULL if wildcard)
+            int    variant_name_length;
+            char** bindings; // Binding names [f0_name, f1_name, ...]
+            int    binding_count;
+            int    is_wildcard; // 1 if this is a `_` arm
+            Node*  body;        // Statement/block to execute
+        } match_arm;
 
         // Function declaration
         func_decl_node func_decl;

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -29,6 +29,9 @@ static int check_destruct_pattern_against_type(Checker* checker, DestructPattern
 static void define_destruct_pattern_vars(Checker* checker, DestructPattern* pattern, Type* type,
                                          int is_const, int is_public);
 
+// Forward declaration for match checking
+static void check_match_stmt(Checker* checker, Node* node);
+
 // Forward declarations for check_decl helpers
 static void check_extern_module_decl(Checker* checker, Node* node);
 static void check_func_decl(Checker* checker, Node* node);
@@ -709,6 +712,81 @@ static void check_return_stmt(Checker* checker, Node* node) {
 }
 
 // =============================================================================
+// Match statement checking
+// =============================================================================
+
+static void check_match_stmt(Checker* checker, Node* node) {
+    Type* expr_type = check_expression(checker, node->as.match_stmt.expr);
+
+    if (expr_type->kind != TYPE_ENUM && expr_type->kind != TYPE_ERROR) {
+        check_error(checker, node->line, node->column,
+                    "Match expression must be an enum type, got '%s'", type_name(expr_type));
+        return;
+    }
+
+    if (expr_type->kind == TYPE_ERROR)
+        return;
+
+    node->as.match_stmt.resolved_type = expr_type;
+
+    for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+        Node* arm = node->as.match_stmt.arms.nodes[a];
+
+        if (arm->as.match_arm.is_wildcard) {
+            // Wildcard: just check body
+            check_statement(checker, arm->as.match_arm.body);
+            continue;
+        }
+
+        // Look up variant in enum type
+        const char* variant_name = arm->as.match_arm.variant_name;
+        int         variant_idx  = -1;
+
+        for (int i = 0; i < expr_type->as.enm.value_count; i++) {
+            if (strcmp(expr_type->as.enm.value_names[i], variant_name) == 0) {
+                variant_idx = i;
+                break;
+            }
+        }
+
+        if (variant_idx < 0) {
+            check_error(checker, arm->line, arm->column, "'%s' is not a variant of enum '%s'",
+                        variant_name, expr_type->as.enm.name);
+            continue;
+        }
+
+        // If qualified name given, verify it matches the enum type
+        if (arm->as.match_arm.enum_name) {
+            if (strcmp(arm->as.match_arm.enum_name, expr_type->as.enm.name) != 0) {
+                check_error(checker, arm->line, arm->column,
+                            "Enum name '%s' does not match match expression type '%s'",
+                            arm->as.match_arm.enum_name, expr_type->as.enm.name);
+                continue;
+            }
+        }
+
+        // Check binding count
+        int expected_bindings = expr_type->as.enm.variant_type_counts[variant_idx];
+        if (arm->as.match_arm.binding_count != expected_bindings) {
+            check_error(checker, arm->line, arm->column,
+                        "Variant '%s' expects %d binding(s), got %d", variant_name,
+                        expected_bindings, arm->as.match_arm.binding_count);
+            continue;
+        }
+
+        // Push scope, define bindings, check body, pop scope
+        checker_push_scope(checker);
+        for (int j = 0; j < arm->as.match_arm.binding_count; j++) {
+            Type* binding_type = expr_type->as.enm.variant_types[variant_idx][j];
+            checker_define(checker, arm->as.match_arm.bindings[j], SYM_VAR, binding_type, 0, 0,
+                           NULL);
+        }
+        check_statement(checker, arm->as.match_arm.body);
+        checker_pop_scope(checker);
+    }
+}
+
+// =============================================================================
 // Statement checking
 // =============================================================================
 
@@ -790,6 +868,10 @@ void check_statement(Checker* checker, Node* node) {
             return;
         }
         check_statement(checker, node->as.defer_stmt.stmt);
+        break;
+
+    case NODE_MATCH:
+        check_match_stmt(checker, node);
         break;
 
     default:

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -2090,6 +2090,85 @@ static void emit_return_stmt(CodeGen* gen, Node* node) {
     }
 }
 
+// Emit a match statement as an if/else-if chain over the enum tag
+static void emit_match_stmt(CodeGen* gen, Node* node) {
+    Type* enum_type = node->as.match_stmt.resolved_type;
+    if (!enum_type)
+        return;
+
+    int         is_data   = enum_type->as.enm.has_data;
+    const char* enum_name = enum_type->as.enm.name;
+
+    // Emit temp variable: EnumType __matchN = <expr>;
+    int match_id = gen->temp_count++;
+    emit_indent(gen);
+    emit(gen, "%s __match%d = ", enum_name, match_id);
+    emit_expr(gen, node->as.match_stmt.expr);
+    emit(gen, ";\n");
+
+    int first = 1;
+    for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+        Node* arm = node->as.match_stmt.arms.nodes[a];
+
+        emit_indent(gen);
+        if (arm->as.match_arm.is_wildcard) {
+            if (first) {
+                emit(gen, "{\n");
+            } else {
+                emit(gen, "else {\n");
+            }
+        } else {
+            const char* variant = arm->as.match_arm.variant_name;
+            if (first) {
+                emit(gen, "if (");
+            } else {
+                emit(gen, "else if (");
+            }
+            if (is_data) {
+                emit(gen, "__match%d.tag == %s_%s", match_id, enum_name, variant);
+            } else {
+                emit(gen, "__match%d == %s_%s", match_id, enum_name, variant);
+            }
+            emit(gen, ") {\n");
+        }
+        first = 0;
+
+        gen->indent++;
+
+        // Emit binding declarations for data enum variants
+        if (!arm->as.match_arm.is_wildcard && is_data && arm->as.match_arm.binding_count > 0) {
+            const char* variant = arm->as.match_arm.variant_name;
+            // Look up variant index to get types
+            int variant_idx = -1;
+            for (int i = 0; i < enum_type->as.enm.value_count; i++) {
+                if (strcmp(enum_type->as.enm.value_names[i], variant) == 0) {
+                    variant_idx = i;
+                    break;
+                }
+            }
+            for (int j = 0; j < arm->as.match_arm.binding_count; j++) {
+                emit_indent(gen);
+                emit_resolved_type(gen, enum_type->as.enm.variant_types[variant_idx][j]);
+                emit(gen, " %s = __match%d.%s.f%d;\n", arm->as.match_arm.bindings[j], match_id,
+                     variant, j);
+            }
+        }
+
+        // Emit arm body
+        if (arm->as.match_arm.body) {
+            if (arm->as.match_arm.body->type == NODE_BLOCK) {
+                emit_block_contents(gen, arm->as.match_arm.body);
+            } else {
+                emit_stmt(gen, arm->as.match_arm.body);
+            }
+        }
+
+        gen->indent--;
+        emit_indent(gen);
+        emit(gen, "}\n");
+    }
+}
+
 // Dispatch statement code generation based on node type
 void emit_stmt(CodeGen* gen, Node* node) {
     if (!node)
@@ -2267,6 +2346,10 @@ void emit_stmt(CodeGen* gen, Node* node) {
     case NODE_DEFER:
         // Don't emit anything here - just push to defer stack
         defer_push(gen, node->as.defer_stmt.stmt);
+        break;
+
+    case NODE_MATCH:
+        emit_match_stmt(gen, node);
         break;
 
     case NODE_BREAK:

--- a/w0/lexer.c
+++ b/w0/lexer.c
@@ -124,12 +124,13 @@ static const Keyword keywords[] = {
     {"foreach", 7, TOK_FOREACH}, {"func", 4, TOK_FUNC},
     {"if", 2, TOK_IF},           {"impl", 4, TOK_IMPL},
     {"import", 6, TOK_IMPORT},   {"in", 2, TOK_IN},
-    {"new", 3, TOK_NEW},         {"null", 4, TOK_NULL},
-    {"public", 6, TOK_PUBLIC},   {"private", 7, TOK_PRIVATE},
-    {"return", 6, TOK_RETURN},   {"self", 4, TOK_SELF},
-    {"struct", 6, TOK_STRUCT},   {"trait", 5, TOK_TRAIT},
-    {"true", 4, TOK_TRUE},       {"type", 4, TOK_TYPE},
-    {"var", 3, TOK_VAR},         {"while", 5, TOK_WHILE},
+    {"match", 5, TOK_MATCH},     {"new", 3, TOK_NEW},
+    {"null", 4, TOK_NULL},       {"public", 6, TOK_PUBLIC},
+    {"private", 7, TOK_PRIVATE}, {"return", 6, TOK_RETURN},
+    {"self", 4, TOK_SELF},       {"struct", 6, TOK_STRUCT},
+    {"trait", 5, TOK_TRAIT},     {"true", 4, TOK_TRUE},
+    {"type", 4, TOK_TYPE},       {"var", 3, TOK_VAR},
+    {"while", 5, TOK_WHILE},
 };
 
 static const size_t keyword_count = sizeof(keywords) / sizeof(keywords[0]);
@@ -348,6 +349,8 @@ Token lexer_next(Lexer* lexer) {
     case '!':
         return make_token(lexer, match(lexer, '=') ? TOK_BANG_EQ : TOK_BANG);
     case '=':
+        if (match(lexer, '>'))
+            return make_token(lexer, TOK_FAT_ARROW);
         return make_token(lexer, match(lexer, '=') ? TOK_EQ_EQ : TOK_EQ);
     case '<':
         if (match(lexer, '<'))
@@ -402,6 +405,7 @@ static const char* token_names[] = {
     [TOK_NEW]         = "NEW",
     [TOK_SELF]        = "SELF",
     [TOK_DEFER]       = "DEFER",
+    [TOK_MATCH]       = "MATCH",
     [TOK_PUBLIC]      = "PUBLIC",
     [TOK_PRIVATE]     = "PRIVATE",
     [TOK_EXTERN]      = "EXTERN",
@@ -438,6 +442,7 @@ static const char* token_names[] = {
     [TOK_LT_LT_EQ]    = "LT_LT_EQ",
     [TOK_GT_GT_EQ]    = "GT_GT_EQ",
     [TOK_ARROW]       = "ARROW",
+    [TOK_FAT_ARROW]   = "FAT_ARROW",
     [TOK_LPAREN]      = "LPAREN",
     [TOK_RPAREN]      = "RPAREN",
     [TOK_LBRACE]      = "LBRACE",

--- a/w0/lexer.h
+++ b/w0/lexer.h
@@ -39,6 +39,7 @@ typedef enum {
     TOK_NEW,
     TOK_SELF,
     TOK_DEFER,
+    TOK_MATCH,
     TOK_PUBLIC,
     TOK_PRIVATE,
     TOK_EXTERN,
@@ -79,6 +80,7 @@ typedef enum {
     TOK_LT_LT_EQ,   // <<=
     TOK_GT_GT_EQ,   // >>=
     TOK_ARROW,      // ->
+    TOK_FAT_ARROW,  // =>
 
     // Punctuation
     TOK_LPAREN,      // (

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -121,6 +121,7 @@ void synchronize(Parser* parser) {
         case TOK_IF:
         case TOK_WHILE:
         case TOK_FOR:
+        case TOK_MATCH:
         case TOK_RETURN:
             return;
         default:
@@ -948,6 +949,109 @@ static Node* parse_defer_stmt(Parser* parser) {
 }
 
 // ============================================================================
+// Match Statement Parsing
+// ============================================================================
+
+static Node* parse_match_stmt(Parser* parser) {
+    Token token = parser->previous; // TOK_MATCH already consumed
+    consume_token(parser, TOK_LPAREN, "Expected '(' after 'match'");
+    Node* expr = parse_expression(parser);
+    consume_token(parser, TOK_RPAREN, "Expected ')' after match expression");
+    consume_token(parser, TOK_LBRACE, "Expected '{' after match expression");
+
+    Node* node                        = node_new(NODE_MATCH, token.line, token.column);
+    node->as.match_stmt.expr          = expr;
+    node->as.match_stmt.resolved_type = NULL;
+    nodelist_init(&node->as.match_stmt.arms);
+
+    while (!check_token(parser, TOK_RBRACE) && !check_token(parser, TOK_EOF)) {
+        Token arm_token             = parser->current;
+        Node* arm                   = node_new(NODE_MATCH_ARM, arm_token.line, arm_token.column);
+        arm->as.match_arm.enum_name = NULL;
+        arm->as.match_arm.enum_name_length    = 0;
+        arm->as.match_arm.variant_name        = NULL;
+        arm->as.match_arm.variant_name_length = 0;
+        arm->as.match_arm.bindings            = NULL;
+        arm->as.match_arm.binding_count       = 0;
+        arm->as.match_arm.is_wildcard         = 0;
+        arm->as.match_arm.body                = NULL;
+
+        // Parse pattern
+        if (parser->current.type == TOK_IDENT && parser->current.length == 1 &&
+            parser->current.start[0] == '_') {
+            // Wildcard: _
+            advance_token(parser);
+            arm->as.match_arm.is_wildcard = 1;
+        } else if (check_token(parser, TOK_IDENT)) {
+            Token first_ident = parser->current;
+            advance_token(parser);
+
+            if (check_token(parser, TOK_COLON_COLON)) {
+                // Qualified: EnumName::VariantName or EnumName::VariantName(bindings...)
+                advance_token(parser); // consume ::
+                Token variant = parser->current;
+                consume_token(parser, TOK_IDENT, "Expected variant name after '::'");
+                arm->as.match_arm.enum_name           = copy_token_string(&first_ident);
+                arm->as.match_arm.enum_name_length    = first_ident.length;
+                arm->as.match_arm.variant_name        = copy_token_string(&variant);
+                arm->as.match_arm.variant_name_length = variant.length;
+            } else {
+                // Unqualified: VariantName or VariantName(bindings...)
+                arm->as.match_arm.variant_name        = copy_token_string(&first_ident);
+                arm->as.match_arm.variant_name_length = first_ident.length;
+            }
+
+            // Optional bindings: (a, b, ...)
+            if (match_token(parser, TOK_LPAREN)) {
+                int    capacity = 4;
+                char** bindings = xmalloc(capacity * sizeof(char*));
+                int    count    = 0;
+
+                while (!check_token(parser, TOK_RPAREN) && !check_token(parser, TOK_EOF)) {
+                    Token binding = parser->current;
+                    consume_token(parser, TOK_IDENT, "Expected binding name in match pattern");
+                    if (count >= capacity) {
+                        capacity *= 2;
+                        bindings = xrealloc(bindings, capacity * sizeof(char*));
+                    }
+                    bindings[count++] = copy_token_string(&binding);
+                    if (!check_token(parser, TOK_RPAREN)) {
+                        consume_token(parser, TOK_COMMA, "Expected ',' or ')' after binding name");
+                    }
+                }
+                consume_token(parser, TOK_RPAREN, "Expected ')' after bindings");
+                arm->as.match_arm.bindings      = bindings;
+                arm->as.match_arm.binding_count = count;
+            }
+        } else {
+            parse_error(parser, "Expected match pattern");
+            node_free(arm);
+            node_free(node);
+            return NULL;
+        }
+
+        // Expect =>
+        consume_token(parser, TOK_FAT_ARROW, "Expected '=>' after match pattern");
+
+        // Parse arm body: block or single statement
+        if (check_token(parser, TOK_LBRACE)) {
+            advance_token(parser);
+            arm->as.match_arm.body = parse_block(parser);
+        } else {
+            arm->as.match_arm.body = parse_statement(parser);
+        }
+
+        nodelist_push(&node->as.match_stmt.arms, arm);
+
+        // Optional comma between arms
+        match_token(parser, TOK_COMMA);
+    }
+
+    consume_token(parser, TOK_RBRACE, "Expected '}' after match arms");
+    return node;
+}
+
+// ============================================================================
 // Statement Parsing
 // ============================================================================
 
@@ -975,6 +1079,9 @@ static Node* parse_statement(Parser* parser) {
     }
     if (match_token(parser, TOK_DEFER)) {
         return parse_defer_stmt(parser);
+    }
+    if (match_token(parser, TOK_MATCH)) {
+        return parse_match_stmt(parser);
     }
     if (match_token(parser, TOK_BREAK)) {
         Token token = parser->previous;

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -257,6 +257,43 @@ void print_ast(Node* node, int depth) {
         print_ast(node->as.defer_stmt.stmt, depth + 1);
         break;
 
+    case NODE_MATCH:
+        printf("Match\n");
+        print_indent(depth + 1);
+        printf("Expr:\n");
+        print_ast(node->as.match_stmt.expr, depth + 2);
+        print_indent(depth + 1);
+        printf("Arms:\n");
+        for (int i = 0; i < node->as.match_stmt.arms.count; i++) {
+            print_ast(node->as.match_stmt.arms.nodes[i], depth + 2);
+        }
+        break;
+
+    case NODE_MATCH_ARM:
+        if (node->as.match_arm.is_wildcard) {
+            printf("MatchArm: _\n");
+        } else {
+            printf("MatchArm: ");
+            if (node->as.match_arm.enum_name) {
+                printf("%.*s::", node->as.match_arm.enum_name_length, node->as.match_arm.enum_name);
+            }
+            printf("%.*s", node->as.match_arm.variant_name_length, node->as.match_arm.variant_name);
+            if (node->as.match_arm.binding_count > 0) {
+                printf("(");
+                for (int i = 0; i < node->as.match_arm.binding_count; i++) {
+                    if (i > 0)
+                        printf(", ");
+                    printf("%s", node->as.match_arm.bindings[i]);
+                }
+                printf(")");
+            }
+            printf("\n");
+        }
+        print_indent(depth + 1);
+        printf("Body:\n");
+        print_ast(node->as.match_arm.body, depth + 2);
+        break;
+
     case NODE_EXPR_STMT:
         printf("ExprStmt\n");
         print_ast(node->as.expr_stmt.expr, depth + 1);

--- a/w0/test/error_match_bindings.w
+++ b/w0/test/error_match_bindings.w
@@ -1,0 +1,15 @@
+// Expected error: expects 1 binding(s), got 2
+
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+func main(): i32 {
+    var opt: Option<i64> = Option::Some(42);
+    match (opt) {
+        Some(a, b) => { return 1; },
+        None => { return 0; },
+    }
+    return 0;
+}

--- a/w0/test/error_match_nonenum.w
+++ b/w0/test/error_match_nonenum.w
@@ -1,0 +1,9 @@
+// Expected error: Match expression must be an enum type
+
+func main(): i32 {
+    var x: i64 = 42;
+    match (x) {
+        _ => { return 0; },
+    }
+    return 0;
+}

--- a/w0/test/error_match_variant.w
+++ b/w0/test/error_match_variant.w
@@ -1,0 +1,16 @@
+// Expected error: is not a variant of enum
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+func main(): i32 {
+    var c: Color = Color::Red;
+    match (c) {
+        Red => { return 0; },
+        Purple => { return 1; },
+    }
+    return 0;
+}

--- a/w0/test/match_basic.w
+++ b/w0/test/match_basic.w
@@ -1,0 +1,60 @@
+// Test basic match on data enum
+
+enum Shape {
+    Circle(f64),
+    Rect(f64, f64),
+    None,
+}
+
+func main(): i32 {
+    var s: Shape = Shape::Circle(3.14);
+
+    var result: i64 = 0;
+    match (s) {
+        Circle(r) => {
+            // r should be 3.14
+            if (r > 3.0) {
+                result = 1;
+            }
+        },
+        Rect(w, h) => {
+            result = 2;
+        },
+        None => {
+            result = 3;
+        },
+    }
+
+    // result should be 1
+    if (result != 1) {
+        return 1;
+    }
+
+    // Test matching Rect
+    var r2: Shape = Shape::Rect(10.0, 20.0);
+    var area: f64 = 0.0;
+    match (r2) {
+        Circle(r) => { area = 0.0; },
+        Rect(w, h) => { area = w * h; },
+        None => { area = 0.0; },
+    }
+
+    if (area != 200.0) {
+        return 2;
+    }
+
+    // Test matching None
+    var n: Shape = Shape::None;
+    var tag: i64 = 0;
+    match (n) {
+        Circle(r) => { tag = 1; },
+        Rect(w, h) => { tag = 2; },
+        None => { tag = 3; },
+    }
+
+    if (tag != 3) {
+        return 3;
+    }
+
+    return 0;
+}

--- a/w0/test/match_generic.w
+++ b/w0/test/match_generic.w
@@ -1,0 +1,37 @@
+// Test match on generic enum (Option<i64>)
+
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+func main(): i32 {
+    var opt: Option<i64> = Option::Some(42);
+
+    var result: i64 = 0;
+    match (opt) {
+        Some(v) => {
+            result = v;
+        },
+        None => {
+            result = -1;
+        },
+    }
+
+    if (result != 42) {
+        return 1;
+    }
+
+    // Test None case
+    var empty: Option<i64> = Option::None;
+    match (empty) {
+        Some(v) => { result = v; },
+        None => { result = -1; },
+    }
+
+    if (result != -1) {
+        return 2;
+    }
+
+    return 0;
+}

--- a/w0/test/match_simple_enum.w
+++ b/w0/test/match_simple_enum.w
@@ -1,0 +1,39 @@
+// Test match on simple (non-data) enum
+
+enum Direction {
+    North,
+    South,
+    East,
+    West,
+}
+
+func main(): i32 {
+    var d: Direction = Direction::East;
+
+    var result: i64 = 0;
+    match (d) {
+        North => { result = 1; },
+        South => { result = 2; },
+        East => { result = 3; },
+        West => { result = 4; },
+    }
+
+    if (result != 3) {
+        return 1;
+    }
+
+    // Test qualified variant names
+    var d2: Direction = Direction::West;
+    match (d2) {
+        Direction::North => { result = 1; },
+        Direction::South => { result = 2; },
+        Direction::East => { result = 3; },
+        Direction::West => { result = 4; },
+    }
+
+    if (result != 4) {
+        return 2;
+    }
+
+    return 0;
+}

--- a/w0/test/match_wildcard.w
+++ b/w0/test/match_wildcard.w
@@ -1,0 +1,40 @@
+// Test match with wildcard arm
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+    Yellow,
+}
+
+enum Shape {
+    Circle(f64),
+    Rect(f64, f64),
+}
+
+func main(): i32 {
+    var c: Color = Color::Green;
+
+    var result: i64 = 0;
+    match (c) {
+        Red => { result = 1; },
+        _ => { result = 99; },
+    }
+
+    if (result != 99) {
+        return 1;
+    }
+
+    // Test wildcard with data enum
+    var s: Shape = Shape::Rect(3.0, 4.0);
+    match (s) {
+        Circle(r) => { result = 1; },
+        _ => { result = 42; },
+    }
+
+    if (result != 42) {
+        return 2;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add `match` statements that destructure enum values by variant pattern, enabling ergonomic pattern matching on both data enums and simple enums
- Support payload binding (`Some(v) => { ... }`), qualified variant names (`Shape::Circle(r)`), and wildcard patterns (`_`)
- Compile match to if/else-if chains over enum tags in generated C

Closes #75

## Changes

**Lexer**: `TOK_MATCH` keyword and `TOK_FAT_ARROW` (`=>`) operator

**Parser**: `parse_match_stmt()` with pattern parsing for wildcards, unqualified/qualified variants, and payload bindings

**AST**: `NODE_MATCH` and `NODE_MATCH_ARM` node types with match_stmt/match_arm structs

**Checker**: Validates match expression is enum type, looks up variants, checks binding counts against variant type counts, defines scoped binding variables with correct types

**Codegen**: Emits temp variable, if/else-if chain comparing tags, and binding declarations accessing union payload fields

**Grammar**: Updated with `match-stmt`, `match-arm`, `match-pattern` productions, `match` keyword, and `=>` operator

**Tests**: 4 valid tests (match_basic, match_generic, match_simple_enum, match_wildcard) + 3 error tests (error_match_nonenum, error_match_bindings, error_match_variant). All 128 tests pass.

## Test plan

- [x] `make` builds cleanly with no warnings
- [x] `make test` passes all 128 tests (77 valid + 40 error + 11 RC runtime)
- [x] Data enum matching with payload extraction (`match_basic.w`)
- [x] Generic enum matching (`match_generic.w`)
- [x] Simple non-data enum matching (`match_simple_enum.w`)
- [x] Wildcard `_` pattern matching (`match_wildcard.w`)
- [x] Error: match on non-enum type (`error_match_nonenum.w`)
- [x] Error: wrong binding count (`error_match_bindings.w`)
- [x] Error: unknown variant name (`error_match_variant.w`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)