### PR TITLE
feat: add match exhaustiveness checking (#76)

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -784,6 +784,34 @@ static void check_match_stmt(Checker* checker, Node* node) {
         check_statement(checker, arm->as.match_arm.body);
         checker_pop_scope(checker);
     }
+
+    // Exhaustiveness check: if no wildcard arm, every variant must be covered
+    int has_wildcard = 0;
+    for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+        if (node->as.match_stmt.arms.nodes[a]->as.match_arm.is_wildcard) {
+            has_wildcard = 1;
+            break;
+        }
+    }
+
+    if (!has_wildcard) {
+        for (int i = 0; i < expr_type->as.enm.value_count; i++) {
+            int found = 0;
+            for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+                Node* arm = node->as.match_stmt.arms.nodes[a];
+                if (!arm->as.match_arm.is_wildcard && arm->as.match_arm.variant_name &&
+                    strcmp(arm->as.match_arm.variant_name, expr_type->as.enm.value_names[i]) == 0) {
+                    found = 1;
+                    break;
+                }
+            }
+            if (!found) {
+                check_error(checker, node->line, node->column,
+                            "Match is not exhaustive: missing variant '%s'",
+                            expr_type->as.enm.value_names[i]);
+            }
+        }
+    }
 }
 
 // =============================================================================

--- a/w0/test/error_match_exhaustive.w
+++ b/w0/test/error_match_exhaustive.w
@@ -1,0 +1,16 @@
+// Expected error: missing variant 'Blue'
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+func main(): i32 {
+    var c: Color = Color::Red;
+    match (c) {
+        Red => { return 0; },
+        Green => { return 1; },
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Error when a `match` statement doesn't cover all enum variants and has no wildcard (`_`) arm
- Reports each missing variant individually (e.g. `Match is not exhaustive: missing variant 'Blue'`)
- Existing tests with full coverage or wildcard arms pass unchanged

Closes #76

## Test plan
- [ ] `make test` — all 129 tests pass (77 valid + 41 error + 11 RC runtime)
- [ ] New `error_match_exhaustive.w` test verifies the error message for a missing variant
- [ ] Existing match tests (`match_basic`, `match_simple_enum`, `match_wildcard`, `match_generic`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)