### PR TITLE
feat: implement foreach over Vec<T> collections

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -212,8 +212,11 @@ Create vecs: `var v = new Vec<i64>{};` or `var v = new Vec<i64>{1, 2, 3};`
             | <expression>
 
 <foreach-stmt> ::= 'foreach' '(' 'const' <identifier> 'in' <expression> '..' <expression> [ 'by' <expression> ] ')' '{' <block> '}'
+                 | 'foreach' '(' 'const' <identifier> 'in' <expression> ')' '{' <block> '}'
 
-The range `start..end` is **end-exclusive**: iterates from `start` up to but not including `end`. For example, `0..5` iterates `0, 1, 2, 3, 4`.
+The first form iterates over a range. The range `start..end` is **end-exclusive**: iterates from `start` up to but not including `end`. For example, `0..5` iterates `0, 1, 2, 3, 4`.
+
+The second form iterates over a collection. Currently supported: `Vec<T>`.
 
 <return-stmt> ::= 'return' [ <expression> ] ';'
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -185,6 +185,7 @@ void node_free(Node* node) {
         node_free(node->as.foreach_stmt.end);
         node_free(node->as.foreach_stmt.step);
         node_free(node->as.foreach_stmt.body);
+        node_free(node->as.foreach_stmt.collection);
         break;
     case NODE_RETURN:
         node_free(node->as.return_stmt.value);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -335,6 +335,7 @@ struct Node {
             Node* end;
             Node* step;
             Node* body;
+            Node* collection;    // Non-NULL for collection foreach (e.g. Vec<T>)
             Type* resolved_type; // Set by checker (loop variable type)
         } foreach_stmt;
 

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -645,33 +645,52 @@ static void check_for_stmt(Checker* checker, Node* node) {
 static void check_foreach_stmt(Checker* checker, Node* node) {
     checker_push_scope(checker); // New scope for loop variable
 
-    // Check that start and end are integers
-    Type* start_type = check_expression(checker, node->as.foreach_stmt.start);
-    Type* end_type   = check_expression(checker, node->as.foreach_stmt.end);
-
-    if (!type_is_integer(start_type) && start_type->kind != TYPE_ERROR) {
-        check_error(checker, node->as.foreach_stmt.start->line, node->as.foreach_stmt.start->column,
-                    "Foreach range start must be int, got '%s'", type_name(start_type));
-    }
-
-    if (!type_is_integer(end_type) && end_type->kind != TYPE_ERROR) {
-        check_error(checker, node->as.foreach_stmt.end->line, node->as.foreach_stmt.end->column,
-                    "Foreach range end must be int, got '%s'", type_name(end_type));
-    }
-
-    // Determine loop variable type: prefer end type when start is a default i64 literal
     Type* loop_type;
-    if (type_is_integer(end_type) &&
-        (start_type->kind == TYPE_INT64 || !type_is_integer(start_type))) {
-        loop_type = end_type;
-    } else if (type_is_integer(start_type)) {
-        loop_type = start_type;
+
+    if (node->as.foreach_stmt.collection) {
+        // Collection foreach: foreach (const item in vec)
+        Type* coll_type = check_expression(checker, node->as.foreach_stmt.collection);
+
+        if (coll_type->kind == TYPE_VEC) {
+            loop_type = coll_type->as.vec.elem;
+        } else if (coll_type->kind != TYPE_ERROR) {
+            check_error(checker, node->as.foreach_stmt.collection->line,
+                        node->as.foreach_stmt.collection->column,
+                        "Foreach collection must be Vec<T>, got '%s'", type_name(coll_type));
+            loop_type = type_int64;
+        } else {
+            loop_type = type_int64;
+        }
     } else {
-        loop_type = type_int64;
+        // Range foreach: foreach (const i in start..end [by step])
+        Type* start_type = check_expression(checker, node->as.foreach_stmt.start);
+        Type* end_type   = check_expression(checker, node->as.foreach_stmt.end);
+
+        if (!type_is_integer(start_type) && start_type->kind != TYPE_ERROR) {
+            check_error(checker, node->as.foreach_stmt.start->line,
+                        node->as.foreach_stmt.start->column,
+                        "Foreach range start must be int, got '%s'", type_name(start_type));
+        }
+
+        if (!type_is_integer(end_type) && end_type->kind != TYPE_ERROR) {
+            check_error(checker, node->as.foreach_stmt.end->line, node->as.foreach_stmt.end->column,
+                        "Foreach range end must be int, got '%s'", type_name(end_type));
+        }
+
+        // Determine loop variable type: prefer end type when start is a default i64 literal
+        if (type_is_integer(end_type) &&
+            (start_type->kind == TYPE_INT64 || !type_is_integer(start_type))) {
+            loop_type = end_type;
+        } else if (type_is_integer(start_type)) {
+            loop_type = start_type;
+        } else {
+            loop_type = type_int64;
+        }
     }
+
     node->as.foreach_stmt.resolved_type = loop_type;
 
-    // Add the loop variable as a const integer (immutable)
+    // Add the loop variable as a const (immutable)
     Symbol* sym =
         checker_define(checker, node->as.foreach_stmt.var_name, SYM_VAR, loop_type, 1, 0, NULL);
     if (!sym) {

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -2316,28 +2316,59 @@ void emit_stmt(CodeGen* gen, Node* node) {
         break;
 
     case NODE_FOREACH:
-        emit_indent(gen);
-        // Generate: for (<type> var = start; var < end; var += step) {
-        emit(gen, "for (");
-        emit_resolved_type(gen, node->as.foreach_stmt.resolved_type
-                                    ? node->as.foreach_stmt.resolved_type
-                                    : type_int64);
-        emit(gen, " %s = ", node->as.foreach_stmt.var_name);
-        emit_expr(gen, node->as.foreach_stmt.start);
-        emit(gen, "; %s < ", node->as.foreach_stmt.var_name);
-        emit_expr(gen, node->as.foreach_stmt.end);
-        emit(gen, "; %s += ", node->as.foreach_stmt.var_name);
-        emit_expr(gen, node->as.foreach_stmt.step);
-        emit(gen, ") {\n");
-        gen->indent++;
-        if (node->as.foreach_stmt.body->type == NODE_BLOCK) {
-            emit_block_contents(gen, node->as.foreach_stmt.body);
+        if (node->as.foreach_stmt.collection) {
+            // Collection foreach: foreach (const item in vec)
+            // Generate:
+            //   for (int64_t __foreach_N = 0; __foreach_N < vec->count; __foreach_N++) {
+            //       <type> item = vec->data[__foreach_N];
+            //       // body
+            //   }
+            int idx_id = gen->temp_count++;
+            emit_indent(gen);
+            emit(gen, "for (int64_t __foreach_%d = 0; __foreach_%d < ", idx_id, idx_id);
+            emit_expr(gen, node->as.foreach_stmt.collection);
+            emit(gen, "->count; __foreach_%d++) {\n", idx_id);
+            gen->indent++;
+            // Declare the loop variable from vec->data[idx]
+            emit_indent(gen);
+            emit_resolved_type(gen, node->as.foreach_stmt.resolved_type
+                                        ? node->as.foreach_stmt.resolved_type
+                                        : type_int64);
+            emit(gen, " %s = ", node->as.foreach_stmt.var_name);
+            emit_expr(gen, node->as.foreach_stmt.collection);
+            emit(gen, "->data[__foreach_%d];\n", idx_id);
+            if (node->as.foreach_stmt.body->type == NODE_BLOCK) {
+                emit_block_contents(gen, node->as.foreach_stmt.body);
+            } else {
+                emit_stmt(gen, node->as.foreach_stmt.body);
+            }
+            gen->indent--;
+            emit_indent(gen);
+            emit(gen, "}\n");
         } else {
-            emit_stmt(gen, node->as.foreach_stmt.body);
+            // Range foreach: for (<type> var = start; var < end; var += step)
+            emit_indent(gen);
+            emit(gen, "for (");
+            emit_resolved_type(gen, node->as.foreach_stmt.resolved_type
+                                        ? node->as.foreach_stmt.resolved_type
+                                        : type_int64);
+            emit(gen, " %s = ", node->as.foreach_stmt.var_name);
+            emit_expr(gen, node->as.foreach_stmt.start);
+            emit(gen, "; %s < ", node->as.foreach_stmt.var_name);
+            emit_expr(gen, node->as.foreach_stmt.end);
+            emit(gen, "; %s += ", node->as.foreach_stmt.var_name);
+            emit_expr(gen, node->as.foreach_stmt.step);
+            emit(gen, ") {\n");
+            gen->indent++;
+            if (node->as.foreach_stmt.body->type == NODE_BLOCK) {
+                emit_block_contents(gen, node->as.foreach_stmt.body);
+            } else {
+                emit_stmt(gen, node->as.foreach_stmt.body);
+            }
+            gen->indent--;
+            emit_indent(gen);
+            emit(gen, "}\n");
         }
-        gen->indent--;
-        emit_indent(gen);
-        emit(gen, "}\n");
         break;
     case NODE_RETURN:
         emit_return_stmt(gen, node);

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -891,22 +891,29 @@ static Node* parse_foreach_stmt(Parser* parser) {
     // Parse: in
     consume_token(parser, TOK_IN, "Expected 'in' after foreach variable");
 
-    // Parse: start expression
-    Node* start = parse_expression(parser);
+    // Parse: first expression (either range start or collection)
+    Node* expr = parse_expression(parser);
 
-    // Parse: ..
-    consume_token(parser, TOK_DOT_DOT, "Expected '..' in range expression");
+    Node* start      = NULL;
+    Node* end        = NULL;
+    Node* step       = NULL;
+    Node* collection = NULL;
 
-    // Parse: end expression
-    Node* end  = parse_expression(parser);
-    Node* step = NULL;
+    if (match_token(parser, TOK_DOT_DOT)) {
+        // Range foreach: foreach (const i in start..end [by step])
+        start = expr;
+        end   = parse_expression(parser);
 
-    if (match_token(parser, TOK_BY)) {
-        step = parse_expression(parser);
+        if (match_token(parser, TOK_BY)) {
+            step = parse_expression(parser);
+        } else {
+            // Default step is 1
+            step                   = node_new(NODE_INT_LIT, token.line, token.column);
+            step->as.int_lit.value = 1;
+        }
     } else {
-        // Default step is 1
-        step                   = node_new(NODE_INT_LIT, token.line, token.column);
-        step->as.int_lit.value = 1;
+        // Collection foreach: foreach (const item in vec)
+        collection = expr;
     }
 
     consume_token(parser, TOK_RPAREN, "Expected ')' after foreach clauses");
@@ -920,6 +927,7 @@ static Node* parse_foreach_stmt(Parser* parser) {
     node->as.foreach_stmt.end             = end;
     node->as.foreach_stmt.step            = step;
     node->as.foreach_stmt.body            = body;
+    node->as.foreach_stmt.collection      = collection;
     return node;
 }
 

--- a/w0/test/error_foreach_not_vec.w
+++ b/w0/test/error_foreach_not_vec.w
@@ -1,0 +1,9 @@
+// Expected error: Foreach collection must be Vec<T>
+
+func main(): i32 {
+    var x: i64 = 42;
+    foreach (const item in x) {
+        x = item;
+    }
+    return 0;
+}

--- a/w0/test/foreach_vec.w
+++ b/w0/test/foreach_vec.w
@@ -1,0 +1,20 @@
+// Test foreach over Vec<i64>
+
+func main(): i32 {
+    var nums = new Vec<i64>{};
+
+    nums.push(10);
+    nums.push(20);
+    nums.push(30);
+
+    var total: i64 = 0;
+    foreach (const n in nums) {
+        total = total + n;
+    }
+
+    if (total != 60) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/w0/test/foreach_vec_empty.w
+++ b/w0/test/foreach_vec_empty.w
@@ -1,0 +1,16 @@
+// Test foreach over empty Vec iterates zero times
+
+func main(): i32 {
+    var nums = new Vec<i64>{};
+
+    var count: i64 = 0;
+    foreach (const n in nums) {
+        count = count + 1;
+    }
+
+    if (count != 0) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/w0/test/foreach_vec_struct.w
+++ b/w0/test/foreach_vec_struct.w
@@ -1,0 +1,28 @@
+// Test foreach over Vec<Point> with struct field access
+
+struct Point { x: i64, y: i64 }
+
+func main(): i32 {
+    var points = new Vec<Point>{};
+
+    points.push(new Point{x: 1, y: 2});
+    points.push(new Point{x: 3, y: 4});
+    points.push(new Point{x: 5, y: 6});
+
+    var sum_x: i64 = 0;
+    var sum_y: i64 = 0;
+    foreach (const p in points) {
+        sum_x = sum_x + p.x;
+        sum_y = sum_y + p.y;
+    }
+
+    if (sum_x != 9) {
+        return 1;
+    }
+
+    if (sum_y != 12) {
+        return 2;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Extends `foreach` to iterate over `Vec<T>` collections: `foreach (const item in vec) { ... }`
- Parser distinguishes range vs collection foreach by checking for `..` after the first expression
- Codegen emits an indexed for-loop (`__foreach_N`) with unique temp counter for nested foreach support

Closes #79

## Test plan
- [x] `make` builds without warnings
- [x] `make test` — all 133 tests pass (80 valid + 42 error + 11 RC)
- [x] New tests: `foreach_vec.w` (sum i64 elements), `foreach_vec_empty.w` (zero iterations), `foreach_vec_struct.w` (struct field access), `error_foreach_not_vec.w` (type error on non-Vec)
- [x] Verified generated C output for both primitive and struct element types

🤖 Generated with [Claude Code](https://claude.com/claude-code)