### PR TITLE
feat: implement foreach over Span<T> collections

### DIFF
--- a/w0/ast.h
+++ b/w0/ast.h
@@ -337,6 +337,7 @@ struct Node {
             Node* body;
             Node* collection;    // Non-NULL for collection foreach (e.g. Vec<T>)
             Type* resolved_type; // Set by checker (loop variable type)
+            int   is_span;       // Set by checker if collection is Span<T>
         } foreach_stmt;
 
         // Return statement

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -653,10 +653,14 @@ static void check_foreach_stmt(Checker* checker, Node* node) {
 
         if (coll_type->kind == TYPE_VEC) {
             loop_type = coll_type->as.vec.elem;
+        } else if (coll_type->kind == TYPE_SPAN) {
+            loop_type                     = coll_type->as.span.elem;
+            node->as.foreach_stmt.is_span = 1;
         } else if (coll_type->kind != TYPE_ERROR) {
             check_error(checker, node->as.foreach_stmt.collection->line,
                         node->as.foreach_stmt.collection->column,
-                        "Foreach collection must be Vec<T>, got '%s'", type_name(coll_type));
+                        "Foreach collection must be Vec<T> or Span<T>, got '%s'",
+                        type_name(coll_type));
             loop_type = type_int64;
         } else {
             loop_type = type_int64;

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -2317,26 +2317,23 @@ void emit_stmt(CodeGen* gen, Node* node) {
 
     case NODE_FOREACH:
         if (node->as.foreach_stmt.collection) {
-            // Collection foreach: foreach (const item in vec)
-            // Generate:
-            //   for (int64_t __foreach_N = 0; __foreach_N < vec->count; __foreach_N++) {
-            //       <type> item = vec->data[__foreach_N];
-            //       // body
-            //   }
-            int idx_id = gen->temp_count++;
+            // Collection foreach: foreach (const item in collection)
+            // Vec uses -> (pointer), Span uses . (value type)
+            const char* access = node->as.foreach_stmt.is_span ? "." : "->";
+            int         idx_id = gen->temp_count++;
             emit_indent(gen);
             emit(gen, "for (int64_t __foreach_%d = 0; __foreach_%d < ", idx_id, idx_id);
             emit_expr(gen, node->as.foreach_stmt.collection);
-            emit(gen, "->count; __foreach_%d++) {\n", idx_id);
+            emit(gen, "%scount; __foreach_%d++) {\n", access, idx_id);
             gen->indent++;
-            // Declare the loop variable from vec->data[idx]
+            // Declare the loop variable from collection data[idx]
             emit_indent(gen);
             emit_resolved_type(gen, node->as.foreach_stmt.resolved_type
                                         ? node->as.foreach_stmt.resolved_type
                                         : type_int64);
             emit(gen, " %s = ", node->as.foreach_stmt.var_name);
             emit_expr(gen, node->as.foreach_stmt.collection);
-            emit(gen, "->data[__foreach_%d];\n", idx_id);
+            emit(gen, "%sdata[__foreach_%d];\n", access, idx_id);
             if (node->as.foreach_stmt.body->type == NODE_BLOCK) {
                 emit_block_contents(gen, node->as.foreach_stmt.body);
             } else {

--- a/w0/test/error_foreach_not_vec.w
+++ b/w0/test/error_foreach_not_vec.w
@@ -1,4 +1,4 @@
-// Expected error: Foreach collection must be Vec<T>
+// Expected error: Foreach collection must be Vec<T> or Span<T>
 
 func main(): i32 {
     var x: i64 = 42;

--- a/w0/test/foreach_span.w
+++ b/w0/test/foreach_span.w
@@ -1,0 +1,45 @@
+// Test foreach over Span<i64>
+
+func main(): i32 {
+    var arr: [5]i64;
+    arr[0] = 10;
+    arr[1] = 20;
+    arr[2] = 30;
+    arr[3] = 40;
+    arr[4] = 50;
+
+    var s: Span<i64> = arr[:];
+
+    var total: i64 = 0;
+    foreach (const n in s) {
+        total = total + n;
+    }
+
+    if (total != 150) {
+        return 1;
+    }
+
+    // Foreach over a slice of the span
+    var s2: Span<i64> = arr[1:4];
+    var total2: i64 = 0;
+    foreach (const n in s2) {
+        total2 = total2 + n;
+    }
+
+    if (total2 != 90) {
+        return 2;
+    }
+
+    // Foreach over empty span
+    var empty: Span<i64> = arr[0:0];
+    var total3: i64 = 0;
+    foreach (const n in empty) {
+        total3 = total3 + n;
+    }
+
+    if (total3 != 0) {
+        return 3;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Extend collection `foreach` to support `Span<T>` in addition to `Vec<T>`
- Span uses value-type access (`.`) vs Vec's pointer access (`->`) in generated C, tracked via an `is_span` flag set by the checker
- Updated error message to reflect both supported collection types

## Changes
- **ast.h**: Added `is_span` flag to `foreach_stmt` node
- **checker.c**: Handle `TYPE_SPAN` in `check_foreach_stmt`, set `is_span` flag
- **codegen_emit.c**: Use `.` or `->` access based on `is_span` flag
- **test/foreach_span.w**: New test covering full span, sliced span, and empty span iteration
- **test/error_foreach_not_vec.w**: Updated expected error message

## Test plan
- [x] All 134 tests pass (`make test`)
- [x] New `foreach_span.w` test validates iteration over full, sliced, and empty spans

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)