### PR TITLE
refactor: extract helpers from print_ast and check_binary_expr

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -12,7 +12,85 @@ static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
 // Expression checking helpers
 // =============================================================================
 
-// Type-check a binary expression: comparison, logical, arithmetic, and bitwise operators
+// Check comparison operators: == != < > <= >=
+static Type* check_comparison_op(Checker* checker, Node* node, Type* left, Type* right) {
+    TokenType op = node->as.binary.op;
+
+    // String comparison: only == and != allowed
+    if (left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
+        if (op == TOK_EQ_EQ || op == TOK_BANG_EQ) {
+            node->as.binary.is_string_op = 1;
+            return type_bool;
+        }
+        check_error(checker, node->line, node->column, "Strings only support == and != comparison");
+        return type_error;
+    }
+    if (type_equals(left, right))
+        return type_bool;
+    // voidptr/struct == null and null == voidptr/struct (only for == and !=)
+    if (op == TOK_EQ_EQ || op == TOK_BANG_EQ) {
+        if ((left->kind == TYPE_VOIDPTR && right->kind == TYPE_NULL) ||
+            (left->kind == TYPE_NULL && right->kind == TYPE_VOIDPTR) ||
+            (left->kind == TYPE_STRUCT && right->kind == TYPE_NULL) ||
+            (left->kind == TYPE_NULL && right->kind == TYPE_STRUCT)) {
+            return type_bool;
+        }
+    }
+    if ((type_is_integer(left) || left->kind == TYPE_F32 || left->kind == TYPE_F64) &&
+        (type_is_integer(right) || right->kind == TYPE_F32 || right->kind == TYPE_F64)) {
+        return type_bool;
+    }
+    check_error(checker, node->line, node->column, "Cannot compare '%s' and '%s'", type_name(left),
+                type_name(right));
+    return type_error;
+}
+
+// Check logical operators: && ||
+static Type* check_logical_op(Checker* checker, Node* node, Type* left, Type* right) {
+    if (left->kind != TYPE_BOOL || right->kind != TYPE_BOOL) {
+        check_error(checker, node->line, node->column, "Logical operators require bool operands");
+        return type_error;
+    }
+    return type_bool;
+}
+
+// Check arithmetic operators: + - * / %
+static Type* check_arithmetic_op(Checker* checker, Node* node, Type* left, Type* right) {
+    TokenType op = node->as.binary.op;
+
+    // String concatenation: string + string
+    if (op == TOK_PLUS && left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
+        node->as.binary.is_string_op = 1;
+        return type_string;
+    }
+    if ((type_is_integer(left) || left->kind == TYPE_F32 || left->kind == TYPE_F64) &&
+        (type_is_integer(right) || right->kind == TYPE_F32 || right->kind == TYPE_F64)) {
+        if (left->kind == TYPE_F64 || right->kind == TYPE_F64)
+            return type_f64;
+        if (left->kind == TYPE_F32 || right->kind == TYPE_F32)
+            return type_f32;
+        if (type_equals(left, right))
+            return left;
+        return type_int64;
+    }
+    check_error(checker, node->line, node->column, "Invalid operands to '%s': '%s' and '%s'",
+                token_type_name(op), type_name(left), type_name(right));
+    return type_error;
+}
+
+// Check bitwise operators: & | ^ << >>
+static Type* check_bitwise_op(Checker* checker, Node* node, Type* left, Type* right) {
+    if (!type_is_integer(left) || !type_is_integer(right)) {
+        check_error(checker, node->line, node->column,
+                    "Bitwise operators require integer operands");
+        return type_error;
+    }
+    if (type_equals(left, right))
+        return left;
+    return type_int64;
+}
+
+// Type-check a binary expression: dispatch to operator-specific helpers
 static Type* check_binary_expr(Checker* checker, Node* node) {
     Type* left  = check_expression(checker, node->as.binary.left);
     Type* right = check_expression(checker, node->as.binary.right);
@@ -23,82 +101,19 @@ static Type* check_binary_expr(Checker* checker, Node* node) {
 
     TokenType op = node->as.binary.op;
 
-    // Comparison operators return bool
     if (op == TOK_EQ_EQ || op == TOK_BANG_EQ || op == TOK_LT || op == TOK_GT || op == TOK_LT_EQ ||
         op == TOK_GT_EQ) {
-        // String comparison: only == and != allowed
-        if (left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
-            if (op == TOK_EQ_EQ || op == TOK_BANG_EQ) {
-                node->as.binary.is_string_op = 1;
-                return type_bool;
-            }
-            check_error(checker, node->line, node->column,
-                        "Strings only support == and != comparison");
-            return type_error;
-        }
-        if (type_equals(left, right))
-            return type_bool;
-        // voidptr/struct == null and null == voidptr/struct (only for == and !=)
-        if (op == TOK_EQ_EQ || op == TOK_BANG_EQ) {
-            if ((left->kind == TYPE_VOIDPTR && right->kind == TYPE_NULL) ||
-                (left->kind == TYPE_NULL && right->kind == TYPE_VOIDPTR) ||
-                (left->kind == TYPE_STRUCT && right->kind == TYPE_NULL) ||
-                (left->kind == TYPE_NULL && right->kind == TYPE_STRUCT)) {
-                return type_bool;
-            }
-        }
-        if ((type_is_integer(left) || left->kind == TYPE_F32 || left->kind == TYPE_F64) &&
-            (type_is_integer(right) || right->kind == TYPE_F32 || right->kind == TYPE_F64)) {
-            return type_bool;
-        }
-        check_error(checker, node->line, node->column, "Cannot compare '%s' and '%s'",
-                    type_name(left), type_name(right));
-        return type_error;
+        return check_comparison_op(checker, node, left, right);
     }
-
-    // Logical operators
     if (op == TOK_AMP_AMP || op == TOK_PIPE_PIPE) {
-        if (left->kind != TYPE_BOOL || right->kind != TYPE_BOOL) {
-            check_error(checker, node->line, node->column,
-                        "Logical operators require bool operands");
-            return type_error;
-        }
-        return type_bool;
+        return check_logical_op(checker, node, left, right);
     }
-
-    // Arithmetic operators
     if (op == TOK_PLUS || op == TOK_MINUS || op == TOK_STAR || op == TOK_SLASH ||
         op == TOK_PERCENT) {
-        // String concatenation: string + string
-        if (op == TOK_PLUS && left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
-            node->as.binary.is_string_op = 1;
-            return type_string;
-        }
-        if ((type_is_integer(left) || left->kind == TYPE_F32 || left->kind == TYPE_F64) &&
-            (type_is_integer(right) || right->kind == TYPE_F32 || right->kind == TYPE_F64)) {
-            if (left->kind == TYPE_F64 || right->kind == TYPE_F64)
-                return type_f64;
-            if (left->kind == TYPE_F32 || right->kind == TYPE_F32)
-                return type_f32;
-            if (type_equals(left, right))
-                return left;
-            return type_int64;
-        }
-        check_error(checker, node->line, node->column, "Invalid operands to '%s': '%s' and '%s'",
-                    token_type_name(op), type_name(left), type_name(right));
-        return type_error;
+        return check_arithmetic_op(checker, node, left, right);
     }
-
-    // Bitwise operators
     if (op == TOK_AMP || op == TOK_PIPE || op == TOK_CARET || op == TOK_LT_LT || op == TOK_GT_GT) {
-        if (!type_is_integer(left) || !type_is_integer(right)) {
-            check_error(checker, node->line, node->column,
-                        "Bitwise operators require integer operands");
-            return type_error;
-        }
-        if (type_equals(left, right))
-            return left;
-        return type_int64;
+        return check_bitwise_op(checker, node, left, right);
     }
 
     check_error(checker, node->line, node->column, "Unknown binary operator");

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -39,6 +39,232 @@ static void print_visibility(int depth, int is_public) {
     }
 }
 
+static void print_func_decl(Node* node, int depth) {
+    if (node->as.func_decl.receiver_type) {
+        printf("MethodDecl: (%s%.*s) %.*s\n", node->as.func_decl.receiver_is_const ? "const " : "",
+               node->as.func_decl.receiver_type_len, node->as.func_decl.receiver_type,
+               node->as.func_decl.name_length, node->as.func_decl.name);
+    } else {
+        printf("FuncDecl: %.*s\n", node->as.func_decl.name_length, node->as.func_decl.name);
+    }
+    print_visibility(depth + 1, node->as.func_decl.is_public);
+    if (node->as.func_decl.receiver_type_args.count > 0) {
+        print_indent(depth + 1);
+        printf("ReceiverTypeArgs:\n");
+        for (int i = 0; i < node->as.func_decl.receiver_type_args.count; i++) {
+            print_ast(node->as.func_decl.receiver_type_args.nodes[i], depth + 2);
+        }
+    }
+    if (node->as.func_decl.params.count > 0) {
+        print_indent(depth + 1);
+        printf("Params:\n");
+        for (int i = 0; i < node->as.func_decl.params.count; i++) {
+            print_ast(node->as.func_decl.params.nodes[i], depth + 2);
+        }
+    }
+    if (node->as.func_decl.return_type) {
+        print_indent(depth + 1);
+        printf("ReturnType:\n");
+        print_ast(node->as.func_decl.return_type, depth + 2);
+    }
+    print_indent(depth + 1);
+    printf("Body:\n");
+    print_ast(node->as.func_decl.body, depth + 2);
+}
+
+static void print_struct_decl(Node* node, int depth) {
+    printf("StructDecl: %.*s\n", node->as.struct_decl.name_length, node->as.struct_decl.name);
+    print_visibility(depth + 1, node->as.struct_decl.is_public);
+    if (node->as.struct_decl.type_param_count > 0) {
+        print_indent(depth + 1);
+        printf("TypeParams: <");
+        for (int i = 0; i < node->as.struct_decl.type_param_count; i++) {
+            if (i > 0)
+                printf(", ");
+            printf("%s", node->as.struct_decl.type_params[i]);
+        }
+        printf(">\n");
+    }
+    for (int i = 0; i < node->as.struct_decl.fields.count; i++) {
+        print_ast(node->as.struct_decl.fields.nodes[i], depth + 1);
+    }
+}
+
+static void print_enum_variant(Node* node, int depth) {
+    printf("EnumVariant: %.*s", node->as.enum_variant.name_length, node->as.enum_variant.name);
+    if (node->as.enum_variant.types.count > 0) {
+        printf("(");
+        for (int i = 0; i < node->as.enum_variant.types.count; i++) {
+            if (i > 0)
+                printf(", ");
+            printf("...");
+        }
+        printf(")");
+    }
+    printf("\n");
+    for (int i = 0; i < node->as.enum_variant.types.count; i++) {
+        print_ast(node->as.enum_variant.types.nodes[i], depth + 1);
+    }
+}
+
+static void print_var_decl(Node* node, int depth) {
+    if (node->as.var_decl.destruct_pattern) {
+        printf("VarDecl: ");
+        print_destruct_pattern(node->as.var_decl.destruct_pattern);
+        printf("%s\n", node->as.var_decl.is_const ? " (const)" : "");
+    } else {
+        printf("VarDecl: %.*s%s\n", node->as.var_decl.name_length, node->as.var_decl.name,
+               node->as.var_decl.is_const ? " (const)" : "");
+    }
+    if (node->as.var_decl.type) {
+        print_indent(depth + 1);
+        printf("Type:\n");
+        print_ast(node->as.var_decl.type, depth + 2);
+    }
+    if (node->as.var_decl.init) {
+        print_indent(depth + 1);
+        printf("Init:\n");
+        print_ast(node->as.var_decl.init, depth + 2);
+    }
+}
+
+static void print_for_stmt(Node* node, int depth) {
+    printf("For\n");
+    if (node->as.for_stmt.init) {
+        print_indent(depth + 1);
+        printf("Init:\n");
+        print_ast(node->as.for_stmt.init, depth + 2);
+    }
+    if (node->as.for_stmt.cond) {
+        print_indent(depth + 1);
+        printf("Cond:\n");
+        print_ast(node->as.for_stmt.cond, depth + 2);
+    }
+    if (node->as.for_stmt.post) {
+        print_indent(depth + 1);
+        printf("Post:\n");
+        print_ast(node->as.for_stmt.post, depth + 2);
+    }
+    print_indent(depth + 1);
+    printf("Body:\n");
+    print_ast(node->as.for_stmt.body, depth + 2);
+}
+
+static void print_match_stmt(Node* node, int depth) {
+    printf("Match\n");
+    print_indent(depth + 1);
+    printf("Expr:\n");
+    print_ast(node->as.match_stmt.expr, depth + 2);
+    print_indent(depth + 1);
+    printf("Arms:\n");
+    for (int i = 0; i < node->as.match_stmt.arms.count; i++) {
+        print_ast(node->as.match_stmt.arms.nodes[i], depth + 2);
+    }
+}
+
+static void print_match_arm(Node* node, int depth) {
+    if (node->as.match_arm.is_wildcard) {
+        printf("MatchArm: _\n");
+    } else {
+        printf("MatchArm: ");
+        if (node->as.match_arm.enum_name) {
+            printf("%.*s::", node->as.match_arm.enum_name_length, node->as.match_arm.enum_name);
+        }
+        printf("%.*s", node->as.match_arm.variant_name_length, node->as.match_arm.variant_name);
+        if (node->as.match_arm.binding_count > 0) {
+            printf("(");
+            for (int i = 0; i < node->as.match_arm.binding_count; i++) {
+                if (i > 0)
+                    printf(", ");
+                printf("%s", node->as.match_arm.bindings[i]);
+            }
+            printf(")");
+        }
+        printf("\n");
+    }
+    print_indent(depth + 1);
+    printf("Body:\n");
+    print_ast(node->as.match_arm.body, depth + 2);
+}
+
+static void print_enum_value(Node* node, int depth) {
+    printf("EnumValue: %.*s::%.*s\n", node->as.enum_value.enum_name_length,
+           node->as.enum_value.enum_name, node->as.enum_value.value_name_length,
+           node->as.enum_value.value_name);
+    if (node->as.enum_value.args.count > 0) {
+        print_indent(depth + 1);
+        printf("Args:\n");
+        for (int i = 0; i < node->as.enum_value.args.count; i++) {
+            print_ast(node->as.enum_value.args.nodes[i], depth + 2);
+        }
+    }
+}
+
+static void print_array_type(Node* node, int depth) {
+    printf("ArrayType\n");
+    print_indent(depth + 1);
+    printf("ElemType:\n");
+    print_ast(node->as.array_type.elem_type, depth + 2);
+    if (node->as.array_type.size) {
+        print_indent(depth + 1);
+        printf("Size:\n");
+        print_ast(node->as.array_type.size, depth + 2);
+    }
+}
+
+static void print_generic_type(Node* node, int depth) {
+    printf("GenericType: %.*s\n", node->as.generic_type.base_name_length,
+           node->as.generic_type.base_name);
+    print_indent(depth + 1);
+    printf("TypeArgs:\n");
+    for (int i = 0; i < node->as.generic_type.type_args.count; i++) {
+        print_ast(node->as.generic_type.type_args.nodes[i], depth + 2);
+    }
+}
+
+static void print_type_alias(Node* node, int depth) {
+    printf("TypeAlias: %.*s", node->as.type_alias.name_length, node->as.type_alias.name);
+    if (node->as.type_alias.type_param_count > 0) {
+        printf("<");
+        for (int i = 0; i < node->as.type_alias.type_param_count; i++) {
+            if (i > 0)
+                printf(", ");
+            printf("%s", node->as.type_alias.type_params[i]);
+        }
+        printf(">");
+    }
+    printf("\n");
+    print_visibility(depth + 1, node->as.type_alias.is_public);
+    print_indent(depth + 1);
+    printf("Target:\n");
+    print_ast(node->as.type_alias.target_type, depth + 2);
+}
+
+static void print_impl_decl(Node* node, int depth) {
+    printf("ImplDecl: %.*s for %.*s", node->as.impl_decl.trait_name_length,
+           node->as.impl_decl.trait_name, node->as.impl_decl.type_name_length,
+           node->as.impl_decl.type_name);
+    if (node->as.impl_decl.type_args.count > 0) {
+        printf("<");
+        for (int i = 0; i < node->as.impl_decl.type_args.count; i++) {
+            if (i > 0)
+                printf(", ");
+            // Print type arg inline (simplified)
+            Node* ta = node->as.impl_decl.type_args.nodes[i];
+            if (ta->type == NODE_IDENT) {
+                printf("%.*s", ta->as.ident.length, ta->as.ident.name);
+            } else {
+                printf("?");
+            }
+        }
+        printf(">");
+    }
+    printf("\n");
+    for (int i = 0; i < node->as.impl_decl.methods.count; i++) {
+        print_ast(node->as.impl_decl.methods.nodes[i], depth + 1);
+    }
+}
+
 void print_ast(Node* node, int depth) {
     if (!node) {
         print_indent(depth);
@@ -69,37 +295,7 @@ void print_ast(Node* node, int depth) {
         }
         break;
     case NODE_FUNC_DECL:
-        if (node->as.func_decl.receiver_type) {
-            printf("MethodDecl: (%s%.*s) %.*s\n",
-                   node->as.func_decl.receiver_is_const ? "const " : "",
-                   node->as.func_decl.receiver_type_len, node->as.func_decl.receiver_type,
-                   node->as.func_decl.name_length, node->as.func_decl.name);
-        } else {
-            printf("FuncDecl: %.*s\n", node->as.func_decl.name_length, node->as.func_decl.name);
-        }
-        print_visibility(depth + 1, node->as.func_decl.is_public);
-        if (node->as.func_decl.receiver_type_args.count > 0) {
-            print_indent(depth + 1);
-            printf("ReceiverTypeArgs:\n");
-            for (int i = 0; i < node->as.func_decl.receiver_type_args.count; i++) {
-                print_ast(node->as.func_decl.receiver_type_args.nodes[i], depth + 2);
-            }
-        }
-        if (node->as.func_decl.params.count > 0) {
-            print_indent(depth + 1);
-            printf("Params:\n");
-            for (int i = 0; i < node->as.func_decl.params.count; i++) {
-                print_ast(node->as.func_decl.params.nodes[i], depth + 2);
-            }
-        }
-        if (node->as.func_decl.return_type) {
-            print_indent(depth + 1);
-            printf("ReturnType:\n");
-            print_ast(node->as.func_decl.return_type, depth + 2);
-        }
-        print_indent(depth + 1);
-        printf("Body:\n");
-        print_ast(node->as.func_decl.body, depth + 2);
+        print_func_decl(node, depth);
         break;
 
     case NODE_PARAM:
@@ -115,21 +311,7 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_STRUCT_DECL:
-        printf("StructDecl: %.*s\n", node->as.struct_decl.name_length, node->as.struct_decl.name);
-        print_visibility(depth + 1, node->as.struct_decl.is_public);
-        if (node->as.struct_decl.type_param_count > 0) {
-            print_indent(depth + 1);
-            printf("TypeParams: <");
-            for (int i = 0; i < node->as.struct_decl.type_param_count; i++) {
-                if (i > 0)
-                    printf(", ");
-                printf("%s", node->as.struct_decl.type_params[i]);
-            }
-            printf(">\n");
-        }
-        for (int i = 0; i < node->as.struct_decl.fields.count; i++) {
-            print_ast(node->as.struct_decl.fields.nodes[i], depth + 1);
-        }
+        print_struct_decl(node, depth);
         break;
 
     case NODE_FIELD:
@@ -146,41 +328,11 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_ENUM_VARIANT:
-        printf("EnumVariant: %.*s", node->as.enum_variant.name_length, node->as.enum_variant.name);
-        if (node->as.enum_variant.types.count > 0) {
-            printf("(");
-            for (int i = 0; i < node->as.enum_variant.types.count; i++) {
-                if (i > 0)
-                    printf(", ");
-                printf("...");
-            }
-            printf(")");
-        }
-        printf("\n");
-        for (int i = 0; i < node->as.enum_variant.types.count; i++) {
-            print_ast(node->as.enum_variant.types.nodes[i], depth + 1);
-        }
+        print_enum_variant(node, depth);
         break;
 
     case NODE_VAR_DECL:
-        if (node->as.var_decl.destruct_pattern) {
-            printf("VarDecl: ");
-            print_destruct_pattern(node->as.var_decl.destruct_pattern);
-            printf("%s\n", node->as.var_decl.is_const ? " (const)" : "");
-        } else {
-            printf("VarDecl: %.*s%s\n", node->as.var_decl.name_length, node->as.var_decl.name,
-                   node->as.var_decl.is_const ? " (const)" : "");
-        }
-        if (node->as.var_decl.type) {
-            print_indent(depth + 1);
-            printf("Type:\n");
-            print_ast(node->as.var_decl.type, depth + 2);
-        }
-        if (node->as.var_decl.init) {
-            print_indent(depth + 1);
-            printf("Init:\n");
-            print_ast(node->as.var_decl.init, depth + 2);
-        }
+        print_var_decl(node, depth);
         break;
 
     case NODE_BLOCK:
@@ -216,25 +368,7 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_FOR:
-        printf("For\n");
-        if (node->as.for_stmt.init) {
-            print_indent(depth + 1);
-            printf("Init:\n");
-            print_ast(node->as.for_stmt.init, depth + 2);
-        }
-        if (node->as.for_stmt.cond) {
-            print_indent(depth + 1);
-            printf("Cond:\n");
-            print_ast(node->as.for_stmt.cond, depth + 2);
-        }
-        if (node->as.for_stmt.post) {
-            print_indent(depth + 1);
-            printf("Post:\n");
-            print_ast(node->as.for_stmt.post, depth + 2);
-        }
-        print_indent(depth + 1);
-        printf("Body:\n");
-        print_ast(node->as.for_stmt.body, depth + 2);
+        print_for_stmt(node, depth);
         break;
 
     case NODE_RETURN:
@@ -258,40 +392,11 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_MATCH:
-        printf("Match\n");
-        print_indent(depth + 1);
-        printf("Expr:\n");
-        print_ast(node->as.match_stmt.expr, depth + 2);
-        print_indent(depth + 1);
-        printf("Arms:\n");
-        for (int i = 0; i < node->as.match_stmt.arms.count; i++) {
-            print_ast(node->as.match_stmt.arms.nodes[i], depth + 2);
-        }
+        print_match_stmt(node, depth);
         break;
 
     case NODE_MATCH_ARM:
-        if (node->as.match_arm.is_wildcard) {
-            printf("MatchArm: _\n");
-        } else {
-            printf("MatchArm: ");
-            if (node->as.match_arm.enum_name) {
-                printf("%.*s::", node->as.match_arm.enum_name_length, node->as.match_arm.enum_name);
-            }
-            printf("%.*s", node->as.match_arm.variant_name_length, node->as.match_arm.variant_name);
-            if (node->as.match_arm.binding_count > 0) {
-                printf("(");
-                for (int i = 0; i < node->as.match_arm.binding_count; i++) {
-                    if (i > 0)
-                        printf(", ");
-                    printf("%s", node->as.match_arm.bindings[i]);
-                }
-                printf(")");
-            }
-            printf("\n");
-        }
-        print_indent(depth + 1);
-        printf("Body:\n");
-        print_ast(node->as.match_arm.body, depth + 2);
+        print_match_arm(node, depth);
         break;
 
     case NODE_EXPR_STMT:
@@ -384,16 +489,7 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_ENUM_VALUE:
-        printf("EnumValue: %.*s::%.*s\n", node->as.enum_value.enum_name_length,
-               node->as.enum_value.enum_name, node->as.enum_value.value_name_length,
-               node->as.enum_value.value_name);
-        if (node->as.enum_value.args.count > 0) {
-            print_indent(depth + 1);
-            printf("Args:\n");
-            for (int i = 0; i < node->as.enum_value.args.count; i++) {
-                print_ast(node->as.enum_value.args.nodes[i], depth + 2);
-            }
-        }
+        print_enum_value(node, depth);
         break;
 
     case NODE_NEW_EXPR:
@@ -421,25 +517,11 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_ARRAY_TYPE:
-        printf("ArrayType\n");
-        print_indent(depth + 1);
-        printf("ElemType:\n");
-        print_ast(node->as.array_type.elem_type, depth + 2);
-        if (node->as.array_type.size) {
-            print_indent(depth + 1);
-            printf("Size:\n");
-            print_ast(node->as.array_type.size, depth + 2);
-        }
+        print_array_type(node, depth);
         break;
 
     case NODE_GENERIC_TYPE:
-        printf("GenericType: %.*s\n", node->as.generic_type.base_name_length,
-               node->as.generic_type.base_name);
-        print_indent(depth + 1);
-        printf("TypeArgs:\n");
-        for (int i = 0; i < node->as.generic_type.type_args.count; i++) {
-            print_ast(node->as.generic_type.type_args.nodes[i], depth + 2);
-        }
+        print_generic_type(node, depth);
         break;
 
     case NODE_TRAIT_DECL:
@@ -450,46 +532,11 @@ void print_ast(Node* node, int depth) {
         break;
 
     case NODE_TYPE_ALIAS:
-        printf("TypeAlias: %.*s", node->as.type_alias.name_length, node->as.type_alias.name);
-        if (node->as.type_alias.type_param_count > 0) {
-            printf("<");
-            for (int i = 0; i < node->as.type_alias.type_param_count; i++) {
-                if (i > 0)
-                    printf(", ");
-                printf("%s", node->as.type_alias.type_params[i]);
-            }
-            printf(">");
-        }
-        printf("\n");
-        print_visibility(depth + 1, node->as.type_alias.is_public);
-        print_indent(depth + 1);
-        printf("Target:\n");
-        print_ast(node->as.type_alias.target_type, depth + 2);
+        print_type_alias(node, depth);
         break;
 
     case NODE_IMPL_DECL:
-        printf("ImplDecl: %.*s for %.*s", node->as.impl_decl.trait_name_length,
-               node->as.impl_decl.trait_name, node->as.impl_decl.type_name_length,
-               node->as.impl_decl.type_name);
-        if (node->as.impl_decl.type_args.count > 0) {
-            printf("<");
-            for (int i = 0; i < node->as.impl_decl.type_args.count; i++) {
-                if (i > 0)
-                    printf(", ");
-                // Print type arg inline (simplified)
-                Node* ta = node->as.impl_decl.type_args.nodes[i];
-                if (ta->type == NODE_IDENT) {
-                    printf("%.*s", ta->as.ident.length, ta->as.ident.name);
-                } else {
-                    printf("?");
-                }
-            }
-            printf(">");
-        }
-        printf("\n");
-        for (int i = 0; i < node->as.impl_decl.methods.count; i++) {
-            print_ast(node->as.impl_decl.methods.nodes[i], depth + 1);
-        }
+        print_impl_decl(node, depth);
         break;
 
     default:


### PR DESCRIPTION
## Summary
- Extract 12 static helpers from `print_ast` switch cases in `print_ast.c`, reducing CCN from 104 to 63
- Extract 4 operator-category helpers (`check_comparison_op`, `check_logical_op`, `check_arithmetic_op`, `check_bitwise_op`) from `check_binary_expr` in `checker_expr.c`, reducing CCN from 61 to 21
- Purely structural refactor — no behavioral changes

## Test plan
- [x] `make` builds cleanly with no warnings
- [x] `make test` passes all 134/134 tests
- [x] `make metrics` confirms complexity reductions

🤖 Generated with [Claude Code](https://claude.com/claude-code)