### PR TITLE
feat: implement string interpolation with $"..." syntax

### DIFF
--- a/lib/std.w
+++ b/lib/std.w
@@ -8,6 +8,11 @@ func print(s: string): void {
     printf("%s", s);
 }
 
+func println(s: string): void {
+    printf("%s\n", s);
+}
+
+
 func abs_i64(x: i64): i64 {
     if (x < 0) {
         return -x;

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -111,6 +111,10 @@ void node_free(Node* node) {
         node_free(node->as.new_expr.type_node);
         node_free(node->as.new_expr.init);
         break;
+    case NODE_STRING_INTERP:
+        nodelist_free(&node->as.string_interp.parts);
+        free(node->as.string_interp.part_types);
+        break;
     case NODE_BINARY:
         node_free(node->as.binary.left);
         node_free(node->as.binary.right);
@@ -406,6 +410,11 @@ Node* node_clone(Node* node) {
         c->as.new_expr.type_node     = node_clone(node->as.new_expr.type_node);
         c->as.new_expr.init          = node_clone(node->as.new_expr.init);
         c->as.new_expr.resolved_type = NULL;
+        break;
+    case NODE_STRING_INTERP:
+        c->as.string_interp.parts      = nodelist_clone(&node->as.string_interp.parts);
+        c->as.string_interp.part_types = NULL;
+        c->as.string_interp.part_count = node->as.string_interp.part_count;
         break;
     case NODE_TUPLE_TYPE:
         c->as.tuple_type.elem_types = nodelist_clone(&node->as.tuple_type.elem_types);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -55,6 +55,7 @@ typedef enum {
     NODE_FIELD_INIT,
     NODE_ENUM_VALUE,
     NODE_NEW_EXPR,
+    NODE_STRING_INTERP,
 
     // Statements
     NODE_EXPR_STMT,
@@ -264,6 +265,13 @@ struct Node {
             Node* init;          // NODE_STRUCT_INIT
             Type* resolved_type; // Set by checker
         } new_expr;
+
+        // String interpolation: $"text {expr} text"
+        struct {
+            NodeList parts;      // Alternating NODE_STRING_LIT and expression nodes
+            Type**   part_types; // Set by checker: type of each part (NULL for text)
+            int      part_count; // Number of parts
+        } string_interp;
 
         // Tuple type: (T1, T2, ...)
         struct {

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -927,6 +927,33 @@ Type* check_expression(Checker* checker, Node* node) {
     case NODE_ARRAY_LIT:
         return check_array_lit_expr(checker, node);
 
+    case NODE_STRING_INTERP: {
+        int count                         = node->as.string_interp.parts.count;
+        node->as.string_interp.part_types = xcalloc(count, sizeof(Type*));
+        node->as.string_interp.part_count = count;
+        for (int i = 0; i < count; i++) {
+            Node* part = node->as.string_interp.parts.nodes[i];
+            if (part->type == NODE_STRING_LIT) {
+                node->as.string_interp.part_types[i] = type_string;
+            } else {
+                Type* t = check_expression(checker, part);
+                if (t->kind == TYPE_ERROR) {
+                    node->as.string_interp.part_types[i] = type_error;
+                    continue;
+                }
+                if (!type_is_integer(t) && t->kind != TYPE_F32 && t->kind != TYPE_F64 &&
+                    t->kind != TYPE_BOOL && t->kind != TYPE_STRING && t->kind != TYPE_CHAR) {
+                    check_error(checker, part->line, part->column,
+                                "String interpolation does not support type '%s'", type_name(t));
+                    node->as.string_interp.part_types[i] = type_error;
+                    continue;
+                }
+                node->as.string_interp.part_types[i] = t;
+            }
+        }
+        return type_string;
+    }
+
     default:
         check_error(checker, node->line, node->column, "Unknown expression type %d", node->type);
         return type_error;

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -37,6 +37,7 @@ static void emit_return_stmt(CodeGen* gen, Node* node);
 // Forward declarations for emit_expr helpers
 static void emit_string_lit(CodeGen* gen, Node* node);
 static void emit_char_lit(CodeGen* gen, Node* node);
+static void emit_string_interp(CodeGen* gen, Node* node);
 static void emit_enum_value(CodeGen* gen, Node* node);
 static void emit_call_expr(CodeGen* gen, Node* node);
 static void emit_index_expr(CodeGen* gen, Node* node);
@@ -1400,6 +1401,150 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
     }
 }
 
+// Emit string interpolation: $"text {expr} text" -> __std_format("fmt", args...)
+static void emit_string_interp(CodeGen* gen, Node* node) {
+    int count = node->as.string_interp.part_count;
+
+    // Optimization: if no expression parts, emit as a plain C string literal
+    int has_expr = 0;
+    for (int i = 0; i < count; i++) {
+        if (node->as.string_interp.parts.nodes[i]->type != NODE_STRING_LIT) {
+            has_expr = 1;
+            break;
+        }
+    }
+
+    if (!has_expr) {
+        // All parts are text — concatenate into a single string literal
+        emit(gen, "\"");
+        for (int i = 0; i < count; i++) {
+            Node* part = node->as.string_interp.parts.nodes[i];
+            // Emit with C escaping
+            const char* s = part->as.string_lit.value;
+            int         n = part->as.string_lit.length;
+            for (int j = 0; j < n; j++) {
+                switch (s[j]) {
+                case '\n':
+                    emit(gen, "\\n");
+                    break;
+                case '\t':
+                    emit(gen, "\\t");
+                    break;
+                case '\r':
+                    emit(gen, "\\r");
+                    break;
+                case '\\':
+                    emit(gen, "\\\\");
+                    break;
+                case '"':
+                    emit(gen, "\\\"");
+                    break;
+                case '\0':
+                    emit(gen, "\\0");
+                    break;
+                default:
+                    emit(gen, "%c", s[j]);
+                    break;
+                }
+            }
+        }
+        emit(gen, "\"");
+        return;
+    }
+
+    // Build __std_format("fmt", args...)
+    emit(gen, "__std_format(\"");
+
+    // First pass: format string
+    for (int i = 0; i < count; i++) {
+        Node* part = node->as.string_interp.parts.nodes[i];
+        Type* t    = node->as.string_interp.part_types[i];
+        if (part->type == NODE_STRING_LIT) {
+            // Text segment: emit with C escaping, and escape % as %%
+            const char* s = part->as.string_lit.value;
+            int         n = part->as.string_lit.length;
+            for (int j = 0; j < n; j++) {
+                switch (s[j]) {
+                case '\n':
+                    emit(gen, "\\n");
+                    break;
+                case '\t':
+                    emit(gen, "\\t");
+                    break;
+                case '\r':
+                    emit(gen, "\\r");
+                    break;
+                case '\\':
+                    emit(gen, "\\\\");
+                    break;
+                case '"':
+                    emit(gen, "\\\"");
+                    break;
+                case '\0':
+                    emit(gen, "\\0");
+                    break;
+                case '%':
+                    emit(gen, "%%%%");
+                    break;
+                default:
+                    emit(gen, "%c", s[j]);
+                    break;
+                }
+            }
+        } else {
+            // Expression: emit format specifier based on type
+            if (!t)
+                continue;
+            switch (t->kind) {
+            case TYPE_STRING:
+                emit(gen, "%%s");
+                break;
+            case TYPE_BOOL:
+                emit(gen, "%%s");
+                break;
+            case TYPE_CHAR:
+                emit(gen, "%%c");
+                break;
+            case TYPE_F32:
+            case TYPE_F64:
+                emit(gen, "%%g");
+                break;
+            case TYPE_INT64:
+                emit(gen, "%%lld");
+                break;
+            case TYPE_UINT64:
+                emit(gen, "%%llu");
+                break;
+            default:
+                // Other integer types
+                emit(gen, "%%d");
+                break;
+            }
+        }
+    }
+    emit(gen, "\"");
+
+    // Second pass: arguments
+    for (int i = 0; i < count; i++) {
+        Node* part = node->as.string_interp.parts.nodes[i];
+        Type* t    = node->as.string_interp.part_types[i];
+        if (part->type == NODE_STRING_LIT)
+            continue;
+        if (!t)
+            continue;
+        emit(gen, ", ");
+        if (t->kind == TYPE_BOOL) {
+            emit(gen, "(");
+            emit_expr(gen, part);
+            emit(gen, " ? \"true\" : \"false\")");
+        } else {
+            emit_expr(gen, part);
+        }
+    }
+
+    emit(gen, ")");
+}
+
 // Dispatch expression code generation based on node type
 static void emit_expr(CodeGen* gen, Node* node) {
     if (!node)
@@ -1527,6 +1672,10 @@ static void emit_expr(CodeGen* gen, Node* node) {
 
     case NODE_NEW_EXPR:
         emit_new_expr(gen, node);
+        break;
+
+    case NODE_STRING_INTERP:
+        emit_string_interp(gen, node);
         break;
 
     default:

--- a/w0/lexer.c
+++ b/w0/lexer.c
@@ -227,6 +227,61 @@ static Token string(Lexer* lexer) {
     return make_token(lexer, TOK_STRING);
 }
 
+static Token interp_string(Lexer* lexer) {
+    // Scan from after $" to closing ", tracking brace depth for {expr} regions
+    int brace_depth = 0;
+    while (!is_at_end(lexer)) {
+        char c = peek(lexer);
+        if (brace_depth == 0) {
+            if (c == '"') {
+                advance(lexer); // closing quote
+                return make_token(lexer, TOK_INTERP_STRING);
+            }
+            if (c == '{') {
+                if (peek_next(lexer) == '{') {
+                    advance(lexer); // skip first {
+                    advance(lexer); // skip second {
+                    continue;
+                }
+                brace_depth++;
+                advance(lexer);
+                continue;
+            }
+            if (c == '}' && peek_next(lexer) == '}') {
+                advance(lexer); // skip first }
+                advance(lexer); // skip second }
+                continue;
+            }
+            if (c == '\\' && peek_next(lexer) != '\0') {
+                advance(lexer); // skip backslash
+            }
+            advance(lexer);
+        } else {
+            // Inside {expr} region
+            if (c == '{') {
+                brace_depth++;
+            } else if (c == '}') {
+                brace_depth--;
+            } else if (c == '"') {
+                // String literal inside expression - skip it
+                advance(lexer); // opening quote
+                while (!is_at_end(lexer) && peek(lexer) != '"') {
+                    if (peek(lexer) == '\\' && peek_next(lexer) != '\0') {
+                        advance(lexer);
+                    }
+                    advance(lexer);
+                }
+                if (!is_at_end(lexer)) {
+                    advance(lexer); // closing quote
+                }
+                continue;
+            }
+            advance(lexer);
+        }
+    }
+    return error_token(lexer, "Unterminated interpolated string");
+}
+
 static Token character(Lexer* lexer) {
     if (is_at_end(lexer)) {
         return error_token(lexer, "Unterminated character literal");
@@ -368,6 +423,11 @@ Token lexer_next(Lexer* lexer) {
         return string(lexer);
     case '\'':
         return character(lexer);
+    case '$':
+        if (match(lexer, '"')) {
+            return interp_string(lexer);
+        }
+        return error_token(lexer, "Unexpected character '$'");
     }
 
     return error_token(lexer, "Unexpected character");
@@ -375,88 +435,89 @@ Token lexer_next(Lexer* lexer) {
 
 // Token type names indexed by TokenType enum value (must match lexer.h order)
 static const char* token_names[] = {
-    [TOK_EOF]         = "EOF",
-    [TOK_IDENT]       = "IDENT",
-    [TOK_INT]         = "INT",
-    [TOK_FLOAT]       = "FLOAT",
-    [TOK_STRING]      = "STRING",
-    [TOK_CHAR]        = "CHAR",
-    [TOK_IF]          = "IF",
-    [TOK_ELSE]        = "ELSE",
-    [TOK_WHILE]       = "WHILE",
-    [TOK_FOR]         = "FOR",
-    [TOK_FOREACH]     = "FOREACH",
-    [TOK_RETURN]      = "RETURN",
-    [TOK_BREAK]       = "BREAK",
-    [TOK_CONTINUE]    = "CONTINUE",
-    [TOK_STRUCT]      = "STRUCT",
-    [TOK_ENUM]        = "ENUM",
-    [TOK_TRAIT]       = "TRAIT",
-    [TOK_TYPE]        = "TYPE",
-    [TOK_IMPL]        = "IMPL",
-    [TOK_FUNC]        = "FUNC",
-    [TOK_VAR]         = "VAR",
-    [TOK_CONST]       = "CONST",
-    [TOK_BY]          = "BY",
-    [TOK_TRUE]        = "TRUE",
-    [TOK_FALSE]       = "FALSE",
-    [TOK_IN]          = "IN",
-    [TOK_NULL]        = "NULL",
-    [TOK_NEW]         = "NEW",
-    [TOK_SELF]        = "SELF",
-    [TOK_DEFER]       = "DEFER",
-    [TOK_MATCH]       = "MATCH",
-    [TOK_PUBLIC]      = "PUBLIC",
-    [TOK_PRIVATE]     = "PRIVATE",
-    [TOK_EXTERN]      = "EXTERN",
-    [TOK_IMPORT]      = "IMPORT",
-    [TOK_PLUS]        = "PLUS",
-    [TOK_MINUS]       = "MINUS",
-    [TOK_STAR]        = "STAR",
-    [TOK_SLASH]       = "SLASH",
-    [TOK_PERCENT]     = "PERCENT",
-    [TOK_AMP]         = "AMP",
-    [TOK_PIPE]        = "PIPE",
-    [TOK_CARET]       = "CARET",
-    [TOK_TILDE]       = "TILDE",
-    [TOK_BANG]        = "BANG",
-    [TOK_EQ]          = "EQ",
-    [TOK_LT]          = "LT",
-    [TOK_GT]          = "GT",
-    [TOK_PLUS_EQ]     = "PLUS_EQ",
-    [TOK_MINUS_EQ]    = "MINUS_EQ",
-    [TOK_STAR_EQ]     = "STAR_EQ",
-    [TOK_SLASH_EQ]    = "SLASH_EQ",
-    [TOK_PERCENT_EQ]  = "PERCENT_EQ",
-    [TOK_AMP_EQ]      = "AMP_EQ",
-    [TOK_PIPE_EQ]     = "PIPE_EQ",
-    [TOK_CARET_EQ]    = "CARET_EQ",
-    [TOK_EQ_EQ]       = "EQ_EQ",
-    [TOK_BANG_EQ]     = "BANG_EQ",
-    [TOK_LT_EQ]       = "LT_EQ",
-    [TOK_GT_EQ]       = "GT_EQ",
-    [TOK_AMP_AMP]     = "AMP_AMP",
-    [TOK_PIPE_PIPE]   = "PIPE_PIPE",
-    [TOK_LT_LT]       = "LT_LT",
-    [TOK_GT_GT]       = "GT_GT",
-    [TOK_LT_LT_EQ]    = "LT_LT_EQ",
-    [TOK_GT_GT_EQ]    = "GT_GT_EQ",
-    [TOK_ARROW]       = "ARROW",
-    [TOK_FAT_ARROW]   = "FAT_ARROW",
-    [TOK_LPAREN]      = "LPAREN",
-    [TOK_RPAREN]      = "RPAREN",
-    [TOK_LBRACE]      = "LBRACE",
-    [TOK_RBRACE]      = "RBRACE",
-    [TOK_LBRACKET]    = "LBRACKET",
-    [TOK_RBRACKET]    = "RBRACKET",
-    [TOK_SEMICOLON]   = "SEMICOLON",
-    [TOK_COLON]       = "COLON",
-    [TOK_COLON_COLON] = "COLON_COLON",
-    [TOK_COMMA]       = "COMMA",
-    [TOK_DOT]         = "DOT",
-    [TOK_DOT_DOT]     = "DOT_DOT",
-    [TOK_ELLIPSIS]    = "ELLIPSIS",
-    [TOK_ERROR]       = "ERROR",
+    [TOK_EOF]           = "EOF",
+    [TOK_IDENT]         = "IDENT",
+    [TOK_INT]           = "INT",
+    [TOK_FLOAT]         = "FLOAT",
+    [TOK_STRING]        = "STRING",
+    [TOK_CHAR]          = "CHAR",
+    [TOK_INTERP_STRING] = "INTERP_STRING",
+    [TOK_IF]            = "IF",
+    [TOK_ELSE]          = "ELSE",
+    [TOK_WHILE]         = "WHILE",
+    [TOK_FOR]           = "FOR",
+    [TOK_FOREACH]       = "FOREACH",
+    [TOK_RETURN]        = "RETURN",
+    [TOK_BREAK]         = "BREAK",
+    [TOK_CONTINUE]      = "CONTINUE",
+    [TOK_STRUCT]        = "STRUCT",
+    [TOK_ENUM]          = "ENUM",
+    [TOK_TRAIT]         = "TRAIT",
+    [TOK_TYPE]          = "TYPE",
+    [TOK_IMPL]          = "IMPL",
+    [TOK_FUNC]          = "FUNC",
+    [TOK_VAR]           = "VAR",
+    [TOK_CONST]         = "CONST",
+    [TOK_BY]            = "BY",
+    [TOK_TRUE]          = "TRUE",
+    [TOK_FALSE]         = "FALSE",
+    [TOK_IN]            = "IN",
+    [TOK_NULL]          = "NULL",
+    [TOK_NEW]           = "NEW",
+    [TOK_SELF]          = "SELF",
+    [TOK_DEFER]         = "DEFER",
+    [TOK_MATCH]         = "MATCH",
+    [TOK_PUBLIC]        = "PUBLIC",
+    [TOK_PRIVATE]       = "PRIVATE",
+    [TOK_EXTERN]        = "EXTERN",
+    [TOK_IMPORT]        = "IMPORT",
+    [TOK_PLUS]          = "PLUS",
+    [TOK_MINUS]         = "MINUS",
+    [TOK_STAR]          = "STAR",
+    [TOK_SLASH]         = "SLASH",
+    [TOK_PERCENT]       = "PERCENT",
+    [TOK_AMP]           = "AMP",
+    [TOK_PIPE]          = "PIPE",
+    [TOK_CARET]         = "CARET",
+    [TOK_TILDE]         = "TILDE",
+    [TOK_BANG]          = "BANG",
+    [TOK_EQ]            = "EQ",
+    [TOK_LT]            = "LT",
+    [TOK_GT]            = "GT",
+    [TOK_PLUS_EQ]       = "PLUS_EQ",
+    [TOK_MINUS_EQ]      = "MINUS_EQ",
+    [TOK_STAR_EQ]       = "STAR_EQ",
+    [TOK_SLASH_EQ]      = "SLASH_EQ",
+    [TOK_PERCENT_EQ]    = "PERCENT_EQ",
+    [TOK_AMP_EQ]        = "AMP_EQ",
+    [TOK_PIPE_EQ]       = "PIPE_EQ",
+    [TOK_CARET_EQ]      = "CARET_EQ",
+    [TOK_EQ_EQ]         = "EQ_EQ",
+    [TOK_BANG_EQ]       = "BANG_EQ",
+    [TOK_LT_EQ]         = "LT_EQ",
+    [TOK_GT_EQ]         = "GT_EQ",
+    [TOK_AMP_AMP]       = "AMP_AMP",
+    [TOK_PIPE_PIPE]     = "PIPE_PIPE",
+    [TOK_LT_LT]         = "LT_LT",
+    [TOK_GT_GT]         = "GT_GT",
+    [TOK_LT_LT_EQ]      = "LT_LT_EQ",
+    [TOK_GT_GT_EQ]      = "GT_GT_EQ",
+    [TOK_ARROW]         = "ARROW",
+    [TOK_FAT_ARROW]     = "FAT_ARROW",
+    [TOK_LPAREN]        = "LPAREN",
+    [TOK_RPAREN]        = "RPAREN",
+    [TOK_LBRACE]        = "LBRACE",
+    [TOK_RBRACE]        = "RBRACE",
+    [TOK_LBRACKET]      = "LBRACKET",
+    [TOK_RBRACKET]      = "RBRACKET",
+    [TOK_SEMICOLON]     = "SEMICOLON",
+    [TOK_COLON]         = "COLON",
+    [TOK_COLON_COLON]   = "COLON_COLON",
+    [TOK_COMMA]         = "COMMA",
+    [TOK_DOT]           = "DOT",
+    [TOK_DOT_DOT]       = "DOT_DOT",
+    [TOK_ELLIPSIS]      = "ELLIPSIS",
+    [TOK_ERROR]         = "ERROR",
 };
 
 const char* token_type_name(TokenType type) {

--- a/w0/lexer.h
+++ b/w0/lexer.h
@@ -13,6 +13,7 @@ typedef enum {
     TOK_FLOAT,
     TOK_STRING,
     TOK_CHAR,
+    TOK_INTERP_STRING,
 
     // Keywords
     TOK_IF,

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -341,6 +341,170 @@ static Node* parse_struct_init(Parser* parser) {
 }
 
 // ============================================================================
+// String Interpolation Parsing
+// ============================================================================
+
+// Decode a single escape character for interpolated string text segments
+static char interp_decode_escape(char c) {
+    switch (c) {
+    case 'n':
+        return '\n';
+    case 't':
+        return '\t';
+    case 'r':
+        return '\r';
+    case '0':
+        return '\0';
+    case '\\':
+        return '\\';
+    case '"':
+        return '"';
+    default:
+        return c;
+    }
+}
+
+// Flush accumulated text buffer as a NODE_STRING_LIT part
+static void flush_text_part(NodeList* parts, char* buf, int* buf_len, int line, int column) {
+    if (*buf_len == 0)
+        return;
+    Node* text_node                = node_new(NODE_STRING_LIT, line, column);
+    text_node->as.string_lit.value = xmalloc(*buf_len + 1);
+    memcpy(text_node->as.string_lit.value, buf, *buf_len);
+    text_node->as.string_lit.value[*buf_len] = '\0';
+    text_node->as.string_lit.length          = *buf_len;
+    nodelist_push(parts, text_node);
+    *buf_len = 0;
+}
+
+static Node* parse_interp_string(Parser* parser) {
+    Token token = parser->previous; // TOK_INTERP_STRING already consumed
+
+    // Raw source: token.start points to '$', so content is from start+2 to start+length-1
+    const char* src = token.start + 2;                // skip $"
+    const char* end = token.start + token.length - 1; // before closing "
+
+    Node* node = node_new(NODE_STRING_INTERP, token.line, token.column);
+    nodelist_init(&node->as.string_interp.parts);
+    node->as.string_interp.part_types = NULL;
+    node->as.string_interp.part_count = 0;
+
+    // Text buffer for accumulating literal text
+    int   buf_cap = (int)(end - src) + 1;
+    char* buf     = xmalloc(buf_cap);
+    int   buf_len = 0;
+
+    while (src < end) {
+        if (*src == '\\' && src + 1 < end) {
+            // Escape sequence in text
+            src++;
+            buf[buf_len++] = interp_decode_escape(*src);
+            src++;
+        } else if (*src == '{') {
+            if (src + 1 < end && src[1] == '{') {
+                // Escaped brace: {{ -> literal {
+                buf[buf_len++] = '{';
+                src += 2;
+            } else {
+                // Expression: {expr}
+                src++; // skip '{'
+
+                // Find matching '}' tracking brace depth
+                const char* expr_start = src;
+                int         depth      = 1;
+                while (src < end && depth > 0) {
+                    if (*src == '{') {
+                        depth++;
+                    } else if (*src == '}') {
+                        depth--;
+                        if (depth == 0)
+                            break;
+                    } else if (*src == '"') {
+                        // Skip string literals inside expressions
+                        src++;
+                        while (src < end && *src != '"') {
+                            if (*src == '\\' && src + 1 < end)
+                                src++;
+                            src++;
+                        }
+                        if (src < end)
+                            src++; // skip closing "
+                        continue;
+                    }
+                    src++;
+                }
+
+                int expr_len = (int)(src - expr_start);
+                if (src < end)
+                    src++; // skip '}'
+
+                // Check for empty expression
+                if (expr_len == 0) {
+                    if (!parser->panic_mode) {
+                        parser->panic_mode = 1;
+                        parser->had_error  = 1;
+                        fprintf(stderr,
+                                "[line %d:%d] Error: Empty expression in string interpolation\n",
+                                token.line, token.column);
+                    }
+                    free(buf);
+                    node_free(node);
+                    return NULL;
+                }
+
+                // Flush any accumulated text
+                flush_text_part(&node->as.string_interp.parts, buf, &buf_len, token.line,
+                                token.column);
+
+                // Create a null-terminated copy of the expression source
+                char* expr_source = xmalloc(expr_len + 2); // +1 for ';', +1 for '\0'
+                memcpy(expr_source, expr_start, expr_len);
+                expr_source[expr_len]     = ';';
+                expr_source[expr_len + 1] = '\0';
+
+                // Parse the expression with a sub-parser
+                Parser sub_parser;
+                parser_init(&sub_parser, expr_source);
+                Node* expr_node = parse_expression(&sub_parser);
+
+                if (sub_parser.had_error || !expr_node) {
+                    char error_msg[256];
+                    snprintf(error_msg, sizeof(error_msg),
+                             "Invalid expression in string interpolation");
+                    parse_error_at(parser, &token, error_msg);
+                    free(expr_source);
+                    free(buf);
+                    node_free(expr_node);
+                    node_free(node);
+                    return NULL;
+                }
+
+                // Fix line/column info (sub-parser uses line 1, col 1)
+                expr_node->line   = token.line;
+                expr_node->column = token.column;
+
+                nodelist_push(&node->as.string_interp.parts, expr_node);
+                free(expr_source);
+            }
+        } else if (*src == '}' && src + 1 < end && src[1] == '}') {
+            // Escaped brace: }} -> literal }
+            buf[buf_len++] = '}';
+            src += 2;
+        } else {
+            buf[buf_len++] = *src;
+            src++;
+        }
+    }
+
+    // Flush any remaining text
+    flush_text_part(&node->as.string_interp.parts, buf, &buf_len, token.line, token.column);
+
+    free(buf);
+    node->as.string_interp.part_count = node->as.string_interp.parts.count;
+    return node;
+}
+
+// ============================================================================
 // Primary Expression Parsing
 // ============================================================================
 
@@ -378,6 +542,10 @@ static Node* parse_primary_expression(Parser* parser) {
         Node* node               = node_new(NODE_FLOAT_LIT, token.line, token.column);
         node->as.float_lit.value = strtod(token.start, NULL);
         return node;
+    }
+
+    if (match_token(parser, TOK_INTERP_STRING)) {
+        return parse_interp_string(parser);
     }
 
     if (match_token(parser, TOK_STRING)) {

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -502,6 +502,13 @@ void print_ast(Node* node, int depth) {
         print_ast(node->as.new_expr.init, depth + 2);
         break;
 
+    case NODE_STRING_INTERP:
+        printf("StringInterp (%d parts)\n", node->as.string_interp.parts.count);
+        for (int i = 0; i < node->as.string_interp.parts.count; i++) {
+            print_ast(node->as.string_interp.parts.nodes[i], depth + 1);
+        }
+        break;
+
     case NODE_TUPLE_TYPE:
         printf("TupleType\n");
         for (int i = 0; i < node->as.tuple_type.elem_types.count; i++) {

--- a/w0/test/error_interp_empty.w
+++ b/w0/test/error_interp_empty.w
@@ -1,0 +1,7 @@
+// ERROR TEST: Empty expression in interpolated string
+// Expected error: Empty expression in string interpolation
+
+func main(): i32 {
+    var s = $"hello {}";
+    return 0;
+}

--- a/w0/test/error_interp_type.w
+++ b/w0/test/error_interp_type.w
@@ -1,0 +1,10 @@
+// ERROR TEST: Struct in interpolation
+// Expected error: String interpolation does not support type
+
+struct Point { x: i64, y: i64 }
+
+func main(): i32 {
+    var p = new Point {x: 1, y: 2};
+    var s = $"Point: {p}";
+    return 0;
+}

--- a/w0/test/string_interp.w
+++ b/w0/test/string_interp.w
@@ -1,0 +1,68 @@
+import std;
+
+func twice(x: i64): i64 {
+    return x * 2;
+}
+
+func main(): i32 {
+    // Basic variable interpolation
+    var name: string = "world";
+    var greeting = $"Hello {name}!";
+    std.println(greeting);
+
+    // Integer interpolation
+    var age: i64 = 30;
+    var msg = $"Age is {age}";
+    std.println(msg);
+
+    // Float interpolation
+    var pi: f64 = 3.14;
+    var fmsg = $"Pi is {pi}";
+    std.println(fmsg);
+
+    // Bool interpolation
+    var flag: bool = true;
+    var bmsg = $"Flag: {flag}";
+    std.println(bmsg);
+    // Expression interpolation
+    var a: i64 = 10;
+    var b: i64 = 20;
+    var expr_msg = $"Sum: {a + b}";
+    std.println(expr_msg);
+
+    // Function call in interpolation
+    var call_msg = $"Double 5 = {twice(5)}";
+    std.println(call_msg);
+    // Member access in interpolation
+    var s: string = "test";
+    var len_msg = $"Length is {s.length()}";
+    std.println(len_msg);
+
+    // Escaped braces
+    var escaped = $"literal {{braces}}";
+    std.println(escaped);
+
+    // Adjacent interpolations
+    var adj = $"{a}{b}";
+    std.println(adj);
+
+    // No expressions (plain string)
+    var plain = $"hello";
+    std.println(plain);
+
+    // Empty string
+    var empty = $"";
+    std.println(empty);
+
+    // Char interpolation
+    var ch: char = 'A';
+    var cmsg = $"Char: {ch}";
+    std.println(cmsg);
+
+    // Small integer types
+    var small: i32 = 42;
+    var smsg = $"Small: {small}";
+    std.println(smsg);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `$"text {expr}"` string interpolation syntax that lowers to `__std_format()` calls in generated C
- Supports interpolating strings, integers, floats, bools, and chars with type checking
- Escaped braces via `{{` and `}}`, handles nested expressions with brace depth tracking

## Implementation
- **Lexer**: New `TOK_INTERP_STRING` token captures entire `$"..."` as single token, tracking brace depth for `{expr}` regions
- **Parser**: Re-walks raw token source to split into text/expression parts using sub-parsers for each `{expr}`
- **Checker**: Validates interpolated expression types; errors on unsupported types (e.g. structs)
- **Codegen**: Lowers to `__std_format("fmt", args...)` with type-appropriate format specifiers; optimizes text-only interpolations to plain C string literals
- **Stdlib**: Added `std.println()` convenience function

## Test plan
- [x] Valid test: `string_interp.w` — variables, expressions, function calls, member access, escaped braces, adjacent interpolations, empty/plain strings, char and i32 types
- [x] Error test: `error_interp_type.w` — struct in interpolation produces compile error
- [x] Error test: `error_interp_empty.w` — empty `$"{}"` produces parse error
- [x] Full test suite: 141/141 tests pass
- [x] Runtime verification: compiled program executes correctly

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)