### PR TITLE
fix: support nested Vec<Vec<T>> with correct C identifier mangling

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -358,7 +358,7 @@ static Type* check_member_expr(Checker* checker, Node* node) {
             strcmp(member_name, "clear") == 0) {
             // Build mangled vec name for method dispatch
             char mangled[256];
-            snprintf(mangled, sizeof(mangled), "__Vec_%s", type_name(elem_type));
+            snprintf(mangled, sizeof(mangled), "__Vec_%s", type_mangle_name(elem_type));
             node->as.member.struct_name = xstrdup(mangled);
 
             if (strcmp(member_name, "push") == 0) {

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -364,7 +364,7 @@ static Type* resolve_vec_type(Checker* checker, Node* type_node) {
 
     // Generate mangled name for the vec instance
     char mangled[256];
-    snprintf(mangled, sizeof(mangled), "Vec_%s", type_name(elem_type));
+    snprintf(mangled, sizeof(mangled), "Vec_%s", type_mangle_name(elem_type));
 
     // Check if already instantiated
     VecInstance* existing = lookup_vec_instance(checker, mangled);
@@ -380,7 +380,7 @@ static Type* resolve_vec_type(Checker* checker, Node* type_node) {
 
     // Also ensure a Span instance for the same element type exists (for slicing)
     char span_mangled[256];
-    snprintf(span_mangled, sizeof(span_mangled), "Span_%s", type_name(elem_type));
+    snprintf(span_mangled, sizeof(span_mangled), "Span_%s", type_mangle_name(elem_type));
     if (!lookup_span_instance(checker, span_mangled)) {
         Type* span_type = type_span(elem_type);
         register_span_instance(checker, span_mangled, elem_type, span_type);
@@ -406,7 +406,7 @@ static Type* resolve_span_type(Checker* checker, Node* type_node) {
 
     // Generate mangled name for the span instance
     char mangled[256];
-    snprintf(mangled, sizeof(mangled), "Span_%s", type_name(elem_type));
+    snprintf(mangled, sizeof(mangled), "Span_%s", type_mangle_name(elem_type));
 
     // Check if already instantiated
     SpanInstance* existing = lookup_span_instance(checker, mangled);

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -771,7 +771,7 @@ static void emit_span_typedefs(CodeGen* gen) {
         emit_resolved_type(gen, inst->elem_type);
         emit(gen, "* data;\n");
         emit(gen, "    uint64_t count;\n");
-        emit(gen, "} __Span_%s;\n\n", type_name(inst->elem_type));
+        emit(gen, "} __Span_%s;\n\n", type_mangle_name(inst->elem_type));
     }
 }
 
@@ -780,7 +780,7 @@ static void emit_vec_typedefs(CodeGen* gen) {
     for (int i = 0; i < gen->vec_instance_count; i++) {
         VecInstance* inst       = &gen->vec_instances[i];
         Type*        elem_type  = inst->elem_type;
-        const char*  elem_tname = type_name(elem_type);
+        const char*  elem_tname = type_mangle_name(elem_type);
 
         emit(gen, "typedef struct {\n");
         emit(gen, "    ");
@@ -1522,7 +1522,7 @@ static void emit_vec_methods(CodeGen* gen) {
     for (int i = 0; i < gen->vec_instance_count; i++) {
         VecInstance* inst        = &gen->vec_instances[i];
         Type*        elem_type   = inst->elem_type;
-        const char*  elem_tname  = type_name(elem_type);
+        const char*  elem_tname  = type_mangle_name(elem_type);
         int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
 
         // Push
@@ -1558,7 +1558,7 @@ static void emit_vec_methods(CodeGen* gen) {
             emit(gen, "    for (int64_t i = 0; i < self->count; i++) {\n");
             if (elem_type->kind == TYPE_VEC) {
                 emit(gen, "        __rc_dec_Vec_%s(self->data[i]);\n",
-                     type_name(elem_type->as.vec.elem));
+                     type_mangle_name(elem_type->as.vec.elem));
             } else if (elem_type->kind == TYPE_STRUCT &&
                        (elem_type->as.struc.has_drop || elem_type->as.struc.has_rc_fields)) {
                 emit(gen, "        __rc_dec_%s(self->data[i]);\n", elem_type->as.struc.name);
@@ -1576,7 +1576,7 @@ static void emit_vec_methods(CodeGen* gen) {
 static void emit_vec_rc_dec(CodeGen* gen) {
     for (int i = 0; i < gen->vec_instance_count; i++) {
         VecInstance* inst       = &gen->vec_instances[i];
-        const char*  elem_tname = type_name(inst->elem_type);
+        const char*  elem_tname = type_mangle_name(inst->elem_type);
         emit(gen, "static inline void __rc_dec_Vec_%s(__Vec_%s* ptr);\n", elem_tname, elem_tname);
     }
 
@@ -1584,7 +1584,7 @@ static void emit_vec_rc_dec(CodeGen* gen) {
     for (int i = 0; i < gen->vec_instance_count; i++) {
         VecInstance* inst        = &gen->vec_instances[i];
         Type*        elem_type   = inst->elem_type;
-        const char*  elem_tname  = type_name(elem_type);
+        const char*  elem_tname  = type_mangle_name(elem_type);
         int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
 
         emit(gen, "static inline void __rc_dec_Vec_%s(__Vec_%s* ptr) {\n", elem_tname, elem_tname);
@@ -1595,7 +1595,7 @@ static void emit_vec_rc_dec(CodeGen* gen) {
             emit(gen, "        for (int64_t i = 0; i < ptr->count; i++) {\n");
             if (elem_type->kind == TYPE_VEC) {
                 emit(gen, "            __rc_dec_Vec_%s(ptr->data[i]);\n",
-                     type_name(elem_type->as.vec.elem));
+                     type_mangle_name(elem_type->as.vec.elem));
             } else if (elem_type->kind == TYPE_STRUCT &&
                        (elem_type->as.struc.has_drop || elem_type->as.struc.has_rc_fields)) {
                 emit(gen, "            __rc_dec_%s(ptr->data[i]);\n", elem_type->as.struc.name);
@@ -1713,7 +1713,7 @@ static void emit_struct_rc_dec(CodeGen* gen, Node* ast) {
                     emit(gen, "        __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
                 }
             } else if (ft && ft->kind == TYPE_VEC) {
-                emit(gen, "        __rc_dec_Vec_%s(ptr->%s);\n", type_name(ft->as.vec.elem),
+                emit(gen, "        __rc_dec_Vec_%s(ptr->%s);\n", type_mangle_name(ft->as.vec.elem),
                      t->as.struc.field_names[f]);
             }
         }
@@ -1909,16 +1909,16 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     register_enum_names(gen, ast);
     compute_enum_rc_flags(gen, ast);
     emit_struct_forward_decls(gen, ast);
-    emit_span_typedefs(gen);
     emit_vec_typedefs(gen);
+    emit_span_typedefs(gen);
     emit_enum_typedefs(gen, ast);
     emit_generic_enum_typedefs(gen, ast);
     emit_enum_rc_helpers(gen, ast);
     emit_struct_body_typedefs(gen, ast);
     emit_function_forward_decls(gen, ast);
     emit_struct_rc_dec_forward_decls(gen, ast);
-    emit_vec_methods(gen);
     emit_vec_rc_dec(gen);
+    emit_vec_methods(gen);
     emit_struct_rc_dec(gen, ast);
     emit_declarations(gen, ast);
     emit_generic_method_impls(gen, ast);

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -72,7 +72,7 @@ static const char* get_dec_func_for_type(Type* t) {
         return buf;
     }
     if (t && t->kind == TYPE_VEC) {
-        const char* elem_tname = type_name(t->as.vec.elem);
+        const char* elem_tname = type_mangle_name(t->as.vec.elem);
         size_t      len        = strlen("__rc_dec_Vec_") + strlen(elem_tname) + 1;
         char*       buf        = xmalloc(len);
         snprintf(buf, len, "__rc_dec_Vec_%s", elem_tname);
@@ -522,7 +522,7 @@ void emit_type(CodeGen* gen, Node* type_node) {
                     for (int s = 0; s < gen->subst_ctx->count; s++) {
                         if (strcmp(gen->subst_ctx->type_params[s], arg_name) == 0) {
                             Type* subst_type = gen->subst_ctx->type_args[s];
-                            emit(gen, "%s", type_name(subst_type));
+                            emit(gen, "%s", type_mangle_name(subst_type));
                             substituted = 1;
                             break;
                         }
@@ -675,10 +675,10 @@ void emit_resolved_type(CodeGen* gen, Type* type) {
         emit(gen, "%s*", type->as.struc.name);
         break;
     case TYPE_SPAN:
-        emit(gen, "__Span_%s", type_name(type->as.span.elem));
+        emit(gen, "__Span_%s", type_mangle_name(type->as.span.elem));
         break;
     case TYPE_VEC:
-        emit(gen, "__Vec_%s*", type_name(type->as.vec.elem));
+        emit(gen, "__Vec_%s*", type_mangle_name(type->as.vec.elem));
         break;
     case TYPE_ENUM:
         emit(gen, "%s", type->as.enm.name);
@@ -869,7 +869,7 @@ static char* resolve_generic_method_target(CodeGen* gen, Node* member) {
                 for (int s = 0; s < gen->subst_ctx->count; s++) {
                     if (strcmp(gen->subst_ctx->type_params[s], elem_name) == 0) {
                         snprintf(buf, sizeof(buf), "__Vec_%s",
-                                 type_name(gen->subst_ctx->type_args[s]));
+                                 type_mangle_name(gen->subst_ctx->type_args[s]));
                         return xstrdup(buf);
                     }
                 }
@@ -1221,7 +1221,7 @@ static void emit_slice_expr(CodeGen* gen, Node* node) {
     Type* elem_type = span_type->as.span.elem;
 
     // Emit compound literal
-    emit(gen, "((__Span_%s){ .data = ", type_name(elem_type));
+    emit(gen, "((__Span_%s){ .data = ", type_mangle_name(elem_type));
 
     if (node->as.slice.is_vec) {
         // Vec slicing: .data = vec->data + start
@@ -1358,7 +1358,7 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
     }
     if (rtype->kind == TYPE_VEC) {
         // new Vec<T>{elems} as inline expression using GCC statement expression
-        const char* elem_tname = type_name(rtype->as.vec.elem);
+        const char* elem_tname = type_mangle_name(rtype->as.vec.elem);
         int         tmp        = gen->temp_count++;
         emit(gen,
              "({ __Vec_%s* __rc_tmp%d = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s)); "
@@ -1934,7 +1934,7 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
 // Emit an RC-managed Vec declaration: var v = new Vec<T>{...}
 static void emit_var_decl_rc_new_vec(CodeGen* gen, Node* node) {
     Type*       rtype      = node->as.var_decl.init->as.new_expr.resolved_type;
-    const char* elem_tname = type_name(rtype->as.vec.elem);
+    const char* elem_tname = type_mangle_name(rtype->as.vec.elem);
     emit_indent(gen);
     emit(gen, "__Vec_%s* %s = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s));\n", elem_tname,
          node->as.var_decl.name, elem_tname, elem_tname);

--- a/w0/test/vec_nested.w
+++ b/w0/test/vec_nested.w
@@ -1,0 +1,49 @@
+// Test nested Vec<Vec<i64>> — create, push, index, count
+
+func main(): i32 {
+    var outer = new Vec<Vec<i64>>{};
+
+    var inner1 = new Vec<i64>{1, 2, 3};
+    var inner2 = new Vec<i64>{4, 5};
+
+    outer.push(inner1);
+    outer.push(inner2);
+
+    if (outer.count != 2) {
+        return 1;
+    }
+
+    if (outer[0].count != 3) {
+        return 2;
+    }
+
+    if (outer[1].count != 2) {
+        return 3;
+    }
+
+    if (outer[0][0] != 1) {
+        return 4;
+    }
+
+    if (outer[0][2] != 3) {
+        return 5;
+    }
+
+    if (outer[1][1] != 5) {
+        return 6;
+    }
+
+    // Push to inner vec after it's in outer
+    outer[0].push(10);
+
+    if (outer[0].count != 4) {
+        return 7;
+    }
+
+    if (outer[0][3] != 10) {
+        return 8;
+    }
+
+    // outer goes out of scope — should __rc_dec each inner Vec
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -473,10 +473,18 @@ int type_is_builtin_name(const char* name) {
 }
 
 // Buffer for mangled span names
-static char type_mangle_buf[256];
+#define TYPE_MANGLE_BUFS 4
+static char type_mangle_bufs[TYPE_MANGLE_BUFS][256];
+static int  type_mangle_idx = 0;
 
-// Helper to get a simple name for mangling (without spaces or special chars)
-static const char* type_mangle_name(Type* type) {
+static char* next_type_mangle_buf(void) {
+    char* buf       = type_mangle_bufs[type_mangle_idx];
+    type_mangle_idx = (type_mangle_idx + 1) % TYPE_MANGLE_BUFS;
+    return buf;
+}
+
+// Get a C-identifier-safe name for a type (no angle brackets or special chars)
+const char* type_mangle_name(Type* type) {
     if (!type)
         return "void";
 
@@ -511,14 +519,16 @@ static const char* type_mangle_name(Type* type) {
         return "string";
     case TYPE_VOIDPTR:
         return "voidptr";
-    case TYPE_SPAN:
-        snprintf(type_mangle_buf, sizeof(type_mangle_buf), "Span_%s",
-                 type_mangle_name(type->as.span.elem));
-        return type_mangle_buf;
-    case TYPE_VEC:
-        snprintf(type_mangle_buf, sizeof(type_mangle_buf), "Vec_%s",
-                 type_mangle_name(type->as.vec.elem));
-        return type_mangle_buf;
+    case TYPE_SPAN: {
+        char* buf = next_type_mangle_buf();
+        snprintf(buf, 256, "Span_%s", type_mangle_name(type->as.span.elem));
+        return buf;
+    }
+    case TYPE_VEC: {
+        char* buf = next_type_mangle_buf();
+        snprintf(buf, 256, "Vec_%s", type_mangle_name(type->as.vec.elem));
+        return buf;
+    }
     case TYPE_STRUCT:
         return type->as.struc.name;
     case TYPE_ENUM:

--- a/w0/types.h
+++ b/w0/types.h
@@ -153,8 +153,9 @@ Type* type_generic_param(const char* name);
 Type* type_span(Type* elem);
 Type* type_vec(Type* elem);
 
-// Generic type name mangling
-char* type_mangle_generic(const char* base, Type** args, int count);
+// Type name mangling for C identifiers (no angle brackets or special chars)
+const char* type_mangle_name(Type* type);
+char*       type_mangle_generic(const char* base, Type** args, int count);
 
 void        type_free(Type* type);
 int         type_equals(Type* a, Type* b);


### PR DESCRIPTION
## Summary
- Expose `type_mangle_name()` from types.c to produce C-identifier-safe type names (`Vec_i64` instead of `Vec<i64>`)
- Replace all `type_name()` calls used for C identifier generation in checker and codegen with `type_mangle_name()`
- Fix codegen emission ordering: Vec typedefs before Span typedefs, Vec rc_dec forward declarations before Vec methods
- Add `vec_nested.w` test covering create, push, nested indexing, nested count, and push-to-inner-after-added-to-outer

Closes #106

## Test plan
- [x] `make test` — all 142 tests pass (including new `vec_nested.w`)
- [x] Nested `Vec<Vec<i64>>` compiles and runs with exit code 0
- [x] No regressions in existing Vec, Span, RC, or generic tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)