### PR TITLE
feat: update grammar docs and VSCode syntax highlighter

### DIFF
--- a/editors/vscode/syntaxes/whist.tmLanguage.json
+++ b/editors/vscode/syntaxes/whist.tmLanguage.json
@@ -4,6 +4,7 @@
   "scopeName": "source.whist",
   "patterns": [
     { "include": "#comments" },
+    { "include": "#interp-strings" },
     { "include": "#strings" },
     { "include": "#characters" },
     { "include": "#numbers" },
@@ -34,6 +35,45 @@
           "name": "comment.block.whist",
           "begin": "/\\*",
           "end": "\\*/"
+        }
+      ]
+    },
+    "interp-strings": {
+      "patterns": [
+        {
+          "name": "string.interpolated.whist",
+          "begin": "\\$\"",
+          "end": "\"",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.string.begin.whist" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.string.end.whist" }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape.brace.whist",
+              "match": "\\{\\{|\\}\\}"
+            },
+            {
+              "name": "meta.interpolation.whist",
+              "begin": "\\{",
+              "end": "\\}",
+              "beginCaptures": {
+                "0": { "name": "punctuation.section.interpolation.begin.whist" }
+              },
+              "endCaptures": {
+                "0": { "name": "punctuation.section.interpolation.end.whist" }
+              },
+              "patterns": [
+                { "include": "$self" }
+              ]
+            },
+            {
+              "name": "constant.character.escape.whist",
+              "match": "\\\\(x[0-9a-fA-F]{2}|[0-7]{1,3}|[nrt\\\\'\"/0])"
+            }
+          ]
         }
       ]
     },
@@ -99,11 +139,11 @@
       "patterns": [
         {
           "name": "keyword.control.whist",
-          "match": "\\b(if|else|for|foreach|while|return|break|continue|in|by)\\b"
+          "match": "\\b(if|else|for|foreach|while|match|return|break|continue|in|by)\\b"
         },
         {
           "name": "keyword.other.whist",
-          "match": "\\b(func|new|self|defer)\\b"
+          "match": "\\b(as|func|new|self|defer)\\b"
         },
         {
           "name": "storage.type.whist",
@@ -265,6 +305,10 @@
         {
           "name": "keyword.operator.arrow.whist",
           "match": "->"
+        },
+        {
+          "name": "keyword.operator.fat-arrow.whist",
+          "match": "=>"
         },
         {
           "name": "punctuation.separator.scope.whist",

--- a/grammar.md
+++ b/grammar.md
@@ -218,7 +218,7 @@ Create vecs: `var v = new Vec<i64>{};` or `var v = new Vec<i64>{1, 2, 3};`
 
 The first form iterates over a range. The range `start..end` is **end-exclusive**: iterates from `start` up to but not including `end`. For example, `0..5` iterates `0, 1, 2, 3, 4`.
 
-The second form iterates over a collection. Currently supported: `Vec<T>`.
+The second form iterates over a collection. Currently supported: `Vec<T>`, `Span<T>`, `string`.
 
 <return-stmt> ::= 'return' [ <expression> ] ';'
 
@@ -311,6 +311,7 @@ Match statements destructure enum values by variant. The expression must be an e
 <primary-expr> ::= <int-literal>
                 | <float-literal>
                 | <string-literal>
+                | <interp-string-literal>
                 | <char-literal>
                 | 'true'
                 | 'false'
@@ -360,11 +361,11 @@ Match statements destructure enum values by variant. The expression must be an e
 ### Keywords
 
 ```
-as       break    const       continue  defer     else
-enum     extern   false       for       foreach   func
-if       impl     import      in        match     new
-null     public   private     return    self      struct
-trait    true     type        var       while
+as       break    by          const     continue  defer
+else     enum     extern      false     for       foreach
+func     if       impl        import    in        match
+new      null     public      private   return    self
+struct   trait    true        type      var       while
 ```
 
 ### Identifiers
@@ -406,6 +407,12 @@ trait    true     type        var       while
 
 <string-literal> ::= '"' { <string-char> } '"'
 
+<interp-string-literal> ::= '$"' { <interp-part> } '"'
+
+<interp-part> ::= <string-char>
+               | '{{' | '}}'
+               | '{' <expression> '}'
+
 <string-char> ::= <any-char-except-quote-or-backslash>
                | <escape-sequence>
 
@@ -417,6 +424,8 @@ trait    true     type        var       while
                    | '\\x' <hex-digit> <hex-digit>
                    | '\\' <octal-digit> [ <octal-digit> [ <octal-digit> ] ]
 ```
+
+**String interpolation:** `$"Hello {name}!"` embeds expressions inside `{...}` braces. Any expression that resolves to a printable type (`i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `bool`, `char`, `string`) can appear inside braces. Use `{{` and `}}` for literal brace characters. Interpolated strings produce a `string` value.
 
 ### Operators and Punctuation
 


### PR DESCRIPTION
## Summary
- Add `$"...{expr}..."` string interpolation syntax to grammar docs and VSCode syntax highlighter with full expression highlighting inside `{}`
- Add missing keywords to VSCode highlighter: `match` (control), `as` (keyword), `=>` (fat arrow operator)
- Add `by` to grammar keyword list (was in foreach rule but missing from keyword section)
- Update foreach documentation to include collection iteration form (`Vec<T>`, `Span<T>`, `string`)

## Test plan
- [ ] Open a `.w` file in VSCode with the updated extension and verify `$"Hello {name}!"` highlights the string, braces, and expression inside
- [ ] Verify `match`, `as`, and `=>` are highlighted correctly
- [ ] Verify grammar.md is consistent with wiki grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)