### PR TITLE
feat: implement std.exit(code: i32) for process exit

### DIFF
--- a/lib/std.w
+++ b/lib/std.w
@@ -4,6 +4,10 @@ private extern stdio {
     func printf(fmt: string, ...): i32;
 }
 
+private extern stdlib {
+    func exit(status: i32) as _exit;
+}
+
 func print(s: string): void {
     printf("%s", s);
 }
@@ -12,6 +16,9 @@ func println(s: string): void {
     printf("%s\n", s);
 }
 
+func exit(status: i32): void {
+    _exit(status);
+}
 
 func abs_i64(x: i64): i64 {
     if (x < 0) {

--- a/w0/test/std_exit.w
+++ b/w0/test/std_exit.w
@@ -1,0 +1,7 @@
+import std;
+
+func main(): i32 {
+    std.exit(42);
+    std.println("Hello, world!");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `std.exit(code: i32)` to terminate the process with a given exit code
- Bind C `exit()` via `private extern stdlib` with `as _exit` rename to avoid name collision
- Add `std_exit.w` test that verifies process exits immediately with code 42

Closes #90

## Test plan
- [x] `make test` — all 144 tests pass
- [x] Runtime verification: compiled test exits with code 42, `println` after `exit` is not reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)