### PR TITLE
fix: enforce extern return types and prefix intra-module calls

### DIFF
--- a/lib/std.w
+++ b/lib/std.w
@@ -5,7 +5,7 @@ private extern stdio {
 }
 
 private extern stdlib {
-    func exit(status: i32) as _exit;
+    func exit(status: i32): void as _exit;
 }
 
 func print(s: string): void {
@@ -18,6 +18,11 @@ func println(s: string): void {
 
 func exit(status: i32): void {
     _exit(status);
+}
+
+func panic(s: string): void {
+    println($"Panic: {s}");
+    exit(1);
 }
 
 func abs_i64(x: i64): i64 {

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -983,8 +983,13 @@ static void check_extern_module_decl(Checker* checker, Node* node) {
     for (int i = 0; i < node->as.extern_module.decls.count; i++) {
         Node* decl = node->as.extern_module.decls.nodes[i];
         if (decl->type == NODE_FUNC_DECL) {
-            func_decl_node* fdn       = &decl->as.func_decl;
-            Type*           func_type = get_function_type(checker, decl);
+            func_decl_node* fdn = &decl->as.func_decl;
+            if (fdn->return_type == NULL) {
+                check_error(checker, decl->line, decl->column,
+                            "Extern function '%s' must have an explicit return type", fdn->name);
+                continue;
+            }
+            Type* func_type = get_function_type(checker, decl);
 
             checker_define(checker, fdn->name, SYM_FUNC, func_type, 0, fdn->is_public,
                            checker->current_module);

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -492,6 +492,9 @@ void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, i
     gen->extern_aliases         = NULL;
     gen->extern_alias_count     = 0;
     gen->extern_alias_capacity  = 0;
+    gen->extern_funcs           = NULL;
+    gen->extern_func_count      = 0;
+    gen->extern_func_capacity   = 0;
 }
 
 // Collect tuple types from all declarations and register non-generic type aliases

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -75,6 +75,10 @@ typedef struct {
     }*  extern_aliases;
     int extern_alias_count;
     int extern_alias_capacity;
+    // Extern function name tracking (all extern functions, for intra-module call prefixing)
+    char** extern_funcs;
+    int    extern_func_count;
+    int    extern_func_capacity;
 } CodeGen;
 
 void codegen_init(CodeGen* gen, FILE* out, GenericInstance* generic_instances, int generic_count,

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -1157,6 +1157,21 @@ static void emit_call_expr(CodeGen* gen, Node* node) {
             }
         }
         if (!alias_found) {
+            // If inside a module, prefix non-extern function calls with module name
+            if (gen->current_module && func->type == NODE_IDENT) {
+                int is_extern = 0;
+                for (int i = 0; i < gen->extern_func_count; i++) {
+                    if (strncmp(gen->extern_funcs[i], func->as.ident.name,
+                                func->as.ident.length) == 0 &&
+                        gen->extern_funcs[i][func->as.ident.length] == '\0') {
+                        is_extern = 1;
+                        break;
+                    }
+                }
+                if (!is_extern) {
+                    emit(gen, "%s_", gen->current_module);
+                }
+            }
             emit_expr(gen, func);
             emit(gen, "(");
         }
@@ -2584,15 +2599,23 @@ void emit_decl(CodeGen* gen, Node* node) {
     switch (node->type) {
     case NODE_EXTERN_MODULE:
         emit(gen, "\n#include <%s.h>\n", node->as.extern_module.module_name);
-        // Register extern function aliases (Whist name -> C name)
+        // Register extern function aliases and names
         for (int i = 0; i < node->as.extern_module.decls.count; i++) {
             Node* decl = node->as.extern_module.decls.nodes[i];
-            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.extern_name) {
-                VEC_GROW(gen->extern_aliases, gen->extern_alias_count, gen->extern_alias_capacity);
-                gen->extern_aliases[gen->extern_alias_count].whist_name = decl->as.func_decl.name;
-                gen->extern_aliases[gen->extern_alias_count].c_name =
-                    decl->as.func_decl.extern_name;
-                gen->extern_alias_count++;
+            if (decl->type == NODE_FUNC_DECL) {
+                // Track all extern function names (for intra-module call prefixing)
+                VEC_GROW(gen->extern_funcs, gen->extern_func_count, gen->extern_func_capacity);
+                gen->extern_funcs[gen->extern_func_count++] = decl->as.func_decl.name;
+                // Register aliases (Whist name -> C name) for renamed externs
+                if (decl->as.func_decl.extern_name) {
+                    VEC_GROW(gen->extern_aliases, gen->extern_alias_count,
+                             gen->extern_alias_capacity);
+                    gen->extern_aliases[gen->extern_alias_count].whist_name =
+                        decl->as.func_decl.name;
+                    gen->extern_aliases[gen->extern_alias_count].c_name =
+                        decl->as.func_decl.extern_name;
+                    gen->extern_alias_count++;
+                }
             }
         }
         break;

--- a/w0/test/error_extern_no_return_type.w
+++ b/w0/test/error_extern_no_return_type.w
@@ -1,0 +1,10 @@
+// ERROR TEST: extern function without explicit return type should fail
+// Expected error: Extern function 'foo' must have an explicit return type
+
+private extern mylib {
+    func foo(x: i32);
+}
+
+func main(): i32 {
+    return 0;
+}


### PR DESCRIPTION
## Summary

- **Extern return type enforcement**: The checker now errors when extern functions omit a return type annotation (previously silently defaulted to void). Fixes `_exit` declaration in `lib/std.w`.
- **Intra-module call prefixing**: Codegen now correctly prefixes non-extern function calls with the module name when emitting code inside a module (e.g., `std_println(...)` instead of `println(...)` inside `std_panic`).
- **Adds `std.panic(s: string)`**: New standard library function that prints a panic message and exits.

## Test plan

- [x] All 145 tests pass (`make test`), including new `error_extern_no_return_type.w`
- [x] Verified generated C for `std.panic` correctly emits `std_println(...)` and `std_exit(...)`
- [x] Verified extern functions like `printf` are NOT prefixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)