### PR TITLE
feat: implement char/integer type casting with `as` keyword

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -279,8 +279,22 @@ Match statements destructure enum values by variant. The expression must be an e
 
 <term-expr> ::= <factor-expr> { ( '+' | '-' ) <factor-expr> }
 
-<factor-expr> ::= <unary-expr> { ( '*' | '/' | '%' ) <unary-expr> }
+<factor-expr> ::= <cast-expr> { ( '*' | '/' | '%' ) <cast-expr> }
 ```
+
+### Cast Expressions
+
+```bnf
+<cast-expr> ::= <unary-expr> { 'as' <type> }
+```
+
+Cast expressions convert between compatible types. Supported conversions:
+- `char` to any integer type (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`)
+- Any integer type to `char`
+- Integer to integer (widening or narrowing)
+- Identity casts (same type to same type)
+
+Examples: `'A' as i32` (yields 65), `65 as char` (yields 'A'), `x as i64`
 
 ### Unary Expressions
 
@@ -465,5 +479,6 @@ From lowest to highest precedence:
 | 9          | `<<` `>>`                                                | Left          |
 | 10         | `+` `-`                                                  | Left          |
 | 11         | `*` `/` `%`                                              | Left          |
-| 12         | `!` `-` `~` `&` `*` (unary prefix)                       | Right         |
-| 13         | `()` `[]` `.` `->` (postfix)                             | Left          |
+| 12         | `as` (type cast)                                         | Left          |
+| 13         | `!` `-` `~` `&` `*` (unary prefix)                       | Right         |
+| 14         | `()` `[]` `.` `->` (postfix)                             | Left          |

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -115,6 +115,10 @@ void node_free(Node* node) {
         nodelist_free(&node->as.string_interp.parts);
         free(node->as.string_interp.part_types);
         break;
+    case NODE_CAST:
+        node_free(node->as.cast_expr.expr);
+        node_free(node->as.cast_expr.type_node);
+        break;
     case NODE_BINARY:
         node_free(node->as.binary.left);
         node_free(node->as.binary.right);
@@ -416,6 +420,11 @@ Node* node_clone(Node* node) {
         c->as.string_interp.parts      = nodelist_clone(&node->as.string_interp.parts);
         c->as.string_interp.part_types = NULL;
         c->as.string_interp.part_count = node->as.string_interp.part_count;
+        break;
+    case NODE_CAST:
+        c->as.cast_expr.expr          = node_clone(node->as.cast_expr.expr);
+        c->as.cast_expr.type_node     = node_clone(node->as.cast_expr.type_node);
+        c->as.cast_expr.resolved_type = NULL;
         break;
     case NODE_TUPLE_TYPE:
         c->as.tuple_type.elem_types = nodelist_clone(&node->as.tuple_type.elem_types);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -56,6 +56,7 @@ typedef enum {
     NODE_ENUM_VALUE,
     NODE_NEW_EXPR,
     NODE_STRING_INTERP,
+    NODE_CAST,
 
     // Statements
     NODE_EXPR_STMT,
@@ -274,6 +275,13 @@ struct Node {
             Type**   part_types; // Set by checker: type of each part (NULL for text)
             int      part_count; // Number of parts
         } string_interp;
+
+        // Cast expression: expr as Type
+        struct {
+            Node* expr;
+            Node* type_node;
+            Type* resolved_type; // Set by checker
+        } cast_expr;
 
         // Tuple type: (T1, T2, ...)
         struct {

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -910,6 +910,33 @@ Type* check_expression(Checker* checker, Node* node) {
     case NODE_NEW_EXPR:
         return check_new_expr(checker, node);
 
+    case NODE_CAST: {
+        Type* expr_type = check_expression(checker, node->as.cast_expr.expr);
+        if (expr_type->kind == TYPE_ERROR)
+            return type_error;
+        Type* target = resolve_type(checker, node->as.cast_expr.type_node);
+        if (target->kind == TYPE_ERROR)
+            return type_error;
+        node->as.cast_expr.resolved_type = target;
+
+        // Allow: identity cast
+        if (expr_type == target)
+            return target;
+        // Allow: char -> integer
+        if (expr_type->kind == TYPE_CHAR && type_is_integer(target))
+            return target;
+        // Allow: integer -> char
+        if (type_is_integer(expr_type) && target->kind == TYPE_CHAR)
+            return target;
+        // Allow: integer -> integer (widening/narrowing)
+        if (type_is_integer(expr_type) && type_is_integer(target))
+            return target;
+
+        check_error(checker, node->line, node->column, "Cannot cast '%s' to '%s'",
+                    type_name(expr_type), type_name(target));
+        return type_error;
+    }
+
     case NODE_STRUCT_INIT:
         check_error(checker, node->line, node->column,
                     "Struct initializer requires a contextual struct type");

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -1161,8 +1161,8 @@ static void emit_call_expr(CodeGen* gen, Node* node) {
             if (gen->current_module && func->type == NODE_IDENT) {
                 int is_extern = 0;
                 for (int i = 0; i < gen->extern_func_count; i++) {
-                    if (strncmp(gen->extern_funcs[i], func->as.ident.name,
-                                func->as.ident.length) == 0 &&
+                    if (strncmp(gen->extern_funcs[i], func->as.ident.name, func->as.ident.length) ==
+                            0 &&
                         gen->extern_funcs[i][func->as.ident.length] == '\0') {
                         is_extern = 1;
                         break;
@@ -1705,6 +1705,14 @@ static void emit_expr(CodeGen* gen, Node* node) {
 
     case NODE_STRING_INTERP:
         emit_string_interp(gen, node);
+        break;
+
+    case NODE_CAST:
+        emit(gen, "((");
+        emit_resolved_type(gen, node->as.cast_expr.resolved_type);
+        emit(gen, ")(");
+        emit_expr(gen, node->as.cast_expr.expr);
+        emit(gen, "))");
         break;
 
     default:

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -885,6 +885,23 @@ static Node* parse_binary(Parser* parser, Precedence min_prec) {
         return NULL;
     }
 
+    // Cast expressions: expr as Type (binds tighter than binary operators)
+    while (match_token(parser, TOK_AS)) {
+        int   cast_line = parser->previous.line;
+        int   cast_col  = parser->previous.column;
+        Node* target    = parse_type(parser);
+        if (!target) {
+            parse_error(parser, "Expected type after 'as'");
+            parser->parse_depth--;
+            return left;
+        }
+        Node* cast                       = node_new(NODE_CAST, cast_line, cast_col);
+        cast->as.cast_expr.expr          = left;
+        cast->as.cast_expr.type_node     = target;
+        cast->as.cast_expr.resolved_type = NULL;
+        left                             = cast;
+    }
+
     while (get_precedence(parser->current.type) >= min_prec &&
            get_precedence(parser->current.type) != PREC_NONE) {
         Token op = parser->current;

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -513,6 +513,16 @@ void print_ast(Node* node, int depth) {
         }
         break;
 
+    case NODE_CAST:
+        printf("Cast\n");
+        print_indent(depth + 1);
+        printf("Expr:\n");
+        print_ast(node->as.cast_expr.expr, depth + 2);
+        print_indent(depth + 1);
+        printf("TargetType:\n");
+        print_ast(node->as.cast_expr.type_node, depth + 2);
+        break;
+
     case NODE_TUPLE_TYPE:
         printf("TupleType\n");
         for (int i = 0; i < node->as.tuple_type.elem_types.count; i++) {

--- a/w0/test/cast_char_int.w
+++ b/w0/test/cast_char_int.w
@@ -1,0 +1,66 @@
+// Test char <-> integer cast expressions
+
+func main(): i32 {
+    // char -> i32
+    var ch: char = 'A';
+    var code: i32 = ch as i32;
+    if (code != 65) {
+        return 1;
+    }
+
+    // i32 -> char
+    var num: i32 = 66;
+    var letter: char = num as char;
+    if (letter != 'B') {
+        return 2;
+    }
+
+    // Literal cast: char literal -> i32
+    var val: i32 = 'Z' as i32;
+    if (val != 90) {
+        return 3;
+    }
+
+    // Integer literal -> char
+    var c2: char = 67 as char;
+    if (c2 != 'C') {
+        return 4;
+    }
+
+    // Chained cast: char -> i32 -> char
+    var original: char = 'D';
+    var roundtrip: char = (original as i32) as char;
+    if (roundtrip != 'D') {
+        return 5;
+    }
+
+    // Identity cast: i32 -> i32
+    var x: i32 = 42;
+    var y: i32 = x as i32;
+    if (y != 42) {
+        return 6;
+    }
+
+    // Integer -> integer widening: i32 -> i64
+    var small: i32 = 100;
+    var big: i64 = small as i64;
+    if (big != 100) {
+        return 7;
+    }
+
+    // Integer -> integer narrowing: i64 -> i32
+    var wide: i64 = 200;
+    var narrow: i32 = wide as i32;
+    if (narrow != 200) {
+        return 8;
+    }
+
+    // Cast in expression context
+    var digit: char = '5';
+    var digit_val: i32 = digit as i32 - 48;
+    if (digit_val != 5) {
+        return 9;
+    }
+
+    return 0;
+}

--- a/w0/test/error_cast_invalid.w
+++ b/w0/test/error_cast_invalid.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Invalid cast from string to i32
+// Expected error: Cannot cast 'string' to 'i32'
+
+func main(): i32 {
+    var s: string = "hello";
+    var x: i32 = s as i32;
+    return x;
+}


### PR DESCRIPTION
## Summary
- Add `expr as Type` cast syntax for char↔integer conversions (char→int, int→char, int→int, identity)
- Cast binds tighter than binary operators but looser than unary (`'0' as i32 + 1` → `('0' as i32) + 1`)
- Reuses existing `as` keyword (TOK_AS) in expression context; adds `NODE_CAST` across AST, parser, checker, codegen, and printer

Closes #83

## Test plan
- [x] New `cast_char_int.w` test covers: char→i32, i32→char, literal casts, chained casts, identity, int widening/narrowing, cast in expression context
- [x] New `error_cast_invalid.w` test verifies string→i32 is rejected with correct error message
- [x] Full test suite passes (147/147)
- [x] Generated C verified: emits `((int32_t)(ch))`, `((char)(num))` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)