### PR TITLE
feat: add standard Result<T, E> enum to std library

### DIFF
--- a/lib/std.w
+++ b/lib/std.w
@@ -1,5 +1,10 @@
 // Standard library for Whist
 
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
 private extern stdio {
     func printf(fmt: string, ...): i32;
 }

--- a/w0/test/std_result.w
+++ b/w0/test/std_result.w
@@ -1,0 +1,39 @@
+// Test std.Result<T, E> — return Ok and Err, match on both
+import std;
+
+func parse_number(s: string): Result<i64, string> {
+    if (s == "42") {
+        return Result::Ok(42);
+    }
+    return Result::Err("not a number");
+}
+
+func main(): i32 {
+    // Test Ok case
+    var r1 = parse_number("42");
+    match (r1) {
+        Ok(val) => {
+            if (val != 42) {
+                return 1;
+            }
+        },
+        Err(msg) => {
+            return 2;
+        },
+    }
+
+    // Test Err case
+    var r2 = parse_number("abc");
+    match (r2) {
+        Ok(val) => {
+            return 3;
+        },
+        Err(msg) => {
+            if (msg != "not a number") {
+                return 4;
+            }
+        },
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Adds `Result<T, E>` generic enum with `Ok(T)` and `Err(E)` variants to `lib/std.w`
- Adds `std_result.w` test that returns `Result::Ok(value)` and `Result::Err(msg)` from a function and matches on both variants

Closes #86

## Test plan
- [x] New `std_result.w` test passes (compile + run)
- [x] Full test suite passes (148/148)

🤖 Generated with [Claude Code](https://claude.com/claude-code)