### PR TITLE
refactor: sub-structure the Checker struct

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -85,50 +85,50 @@ static unsigned int hash_string(const char* str) {
 
 // Initialize all checker state to zero/NULL defaults
 void checker_init(Checker* checker) {
-    checker->scope                            = NULL;
-    checker->current_func_return              = NULL;
-    checker->in_loop                          = 0;
-    checker->error_count                      = 0;
-    checker->direct_imports                   = NULL;
-    checker->direct_imports_count             = 0;
-    checker->current_accessible_modules       = NULL;
-    checker->current_accessible_modules_count = 0;
-    checker->current_module                   = NULL;
+    checker->scope                                    = NULL;
+    checker->current_func_return                      = NULL;
+    checker->in_loop                                  = 0;
+    checker->error_count                              = 0;
+    checker->modules.direct_imports                   = NULL;
+    checker->modules.direct_imports_count             = 0;
+    checker->modules.current_accessible_modules       = NULL;
+    checker->modules.current_accessible_modules_count = 0;
+    checker->modules.current_module                   = NULL;
     // Generic support
-    checker->generic_defs              = NULL;
-    checker->generic_def_count         = 0;
-    checker->generic_def_capacity      = 0;
-    checker->generic_instances         = NULL;
-    checker->generic_instance_count    = 0;
-    checker->generic_instance_capacity = 0;
-    checker->current_type_params       = NULL;
-    checker->current_type_args         = NULL;
-    checker->current_type_param_count  = 0;
+    checker->generics.defs                     = NULL;
+    checker->generics.def_count                = 0;
+    checker->generics.def_capacity             = 0;
+    checker->generics.instances                = NULL;
+    checker->generics.instance_count           = 0;
+    checker->generics.instance_capacity        = 0;
+    checker->generics.current_type_params      = NULL;
+    checker->generics.current_type_args        = NULL;
+    checker->generics.current_type_param_count = 0;
     // Span support
-    checker->span_instances         = NULL;
-    checker->span_instance_count    = 0;
-    checker->span_instance_capacity = 0;
+    checker->containers.spans         = NULL;
+    checker->containers.span_count    = 0;
+    checker->containers.span_capacity = 0;
     // Vec support
-    checker->vec_instances         = NULL;
-    checker->vec_instance_count    = 0;
-    checker->vec_instance_capacity = 0;
+    checker->containers.vecs         = NULL;
+    checker->containers.vec_count    = 0;
+    checker->containers.vec_capacity = 0;
     // Trait support
-    checker->trait_impls         = NULL;
-    checker->trait_impl_count    = 0;
-    checker->trait_impl_capacity = 0;
+    checker->traits.impls         = NULL;
+    checker->traits.impl_count    = 0;
+    checker->traits.impl_capacity = 0;
     // Primitive methods
-    checker->primitive_methods         = NULL;
-    checker->primitive_method_count    = 0;
-    checker->primitive_method_capacity = 0;
-    checker->alias_depth               = 0;
-    checker->enum_target_hint          = NULL;
+    checker->traits.primitive_methods         = NULL;
+    checker->traits.primitive_method_count    = 0;
+    checker->traits.primitive_method_capacity = 0;
+    checker->alias_depth                      = 0;
+    checker->enum_target_hint                 = NULL;
     types_init();
 }
 
 // Set the list of directly imported module names for visibility checking
 void checker_set_direct_imports(Checker* checker, char** direct_imports, int count) {
-    checker->direct_imports       = direct_imports;
-    checker->direct_imports_count = count;
+    checker->modules.direct_imports       = direct_imports;
+    checker->modules.direct_imports_count = count;
 }
 
 // Push a new scope onto the scope chain for block-level symbol resolution
@@ -168,47 +168,47 @@ void checker_free(Checker* checker) {
         checker_pop_scope(checker);
     }
     // Free generic definitions
-    for (int i = 0; i < checker->generic_def_count; i++) {
-        free(checker->generic_defs[i].name);
-        for (int j = 0; j < checker->generic_defs[i].type_param_count; j++) {
-            free(checker->generic_defs[i].type_params[j]);
-            free(checker->generic_defs[i].type_param_bounds[j]);
+    for (int i = 0; i < checker->generics.def_count; i++) {
+        free(checker->generics.defs[i].name);
+        for (int j = 0; j < checker->generics.defs[i].type_param_count; j++) {
+            free(checker->generics.defs[i].type_params[j]);
+            free(checker->generics.defs[i].type_param_bounds[j]);
         }
-        free(checker->generic_defs[i].type_params);
-        free(checker->generic_defs[i].type_param_bounds);
+        free(checker->generics.defs[i].type_params);
+        free(checker->generics.defs[i].type_param_bounds);
         // Note: methods array contains pointers to AST nodes, don't free them
-        free(checker->generic_defs[i].methods);
+        free(checker->generics.defs[i].methods);
     }
-    free(checker->generic_defs);
+    free(checker->generics.defs);
     // Free generic instances
-    for (int i = 0; i < checker->generic_instance_count; i++) {
-        free(checker->generic_instances[i].mangled_name);
-        free(checker->generic_instances[i].base_name);
-        free(checker->generic_instances[i].type_args);
+    for (int i = 0; i < checker->generics.instance_count; i++) {
+        free(checker->generics.instances[i].mangled_name);
+        free(checker->generics.instances[i].base_name);
+        free(checker->generics.instances[i].type_args);
     }
-    free(checker->generic_instances);
+    free(checker->generics.instances);
     // Free span instances
-    for (int i = 0; i < checker->span_instance_count; i++) {
-        free(checker->span_instances[i].mangled_name);
+    for (int i = 0; i < checker->containers.span_count; i++) {
+        free(checker->containers.spans[i].mangled_name);
     }
-    free(checker->span_instances);
+    free(checker->containers.spans);
     // Free vec instances
-    for (int i = 0; i < checker->vec_instance_count; i++) {
-        free(checker->vec_instances[i].mangled_name);
+    for (int i = 0; i < checker->containers.vec_count; i++) {
+        free(checker->containers.vecs[i].mangled_name);
     }
-    free(checker->vec_instances);
+    free(checker->containers.vecs);
     // Free trait implementations
-    for (int i = 0; i < checker->trait_impl_count; i++) {
-        free(checker->trait_impls[i].trait_name);
-        free(checker->trait_impls[i].type_name);
+    for (int i = 0; i < checker->traits.impl_count; i++) {
+        free(checker->traits.impls[i].trait_name);
+        free(checker->traits.impls[i].type_name);
     }
-    free(checker->trait_impls);
+    free(checker->traits.impls);
     // Free primitive methods
-    for (int i = 0; i < checker->primitive_method_count; i++) {
-        free(checker->primitive_methods[i].type_name);
-        free(checker->primitive_methods[i].method_name);
+    for (int i = 0; i < checker->traits.primitive_method_count; i++) {
+        free(checker->traits.primitive_methods[i].type_name);
+        free(checker->traits.primitive_methods[i].method_name);
     }
-    free(checker->primitive_methods);
+    free(checker->traits.primitive_methods);
     types_cleanup();
 }
 
@@ -249,17 +249,18 @@ static int is_module_accessible(Checker* checker, const char* source_module) {
     }
 
     // If we're currently in the same module, it's accessible
-    if (checker->current_module && strcmp(checker->current_module, source_module) == 0) {
+    if (checker->modules.current_module &&
+        strcmp(checker->modules.current_module, source_module) == 0) {
         return 1;
     }
 
     // Use current function's accessible modules if set, otherwise use global direct_imports
-    char** modules = checker->current_accessible_modules;
-    int    count   = checker->current_accessible_modules_count;
+    char** modules = checker->modules.current_accessible_modules;
+    int    count   = checker->modules.current_accessible_modules_count;
 
     if (!modules) {
-        modules = checker->direct_imports;
-        count   = checker->direct_imports_count;
+        modules = checker->modules.direct_imports;
+        count   = checker->modules.direct_imports_count;
     }
 
     // Check if module is in the accessible list
@@ -275,12 +276,12 @@ static int is_module_accessible(Checker* checker, const char* source_module) {
 // Check if a name is a directly imported library module
 int is_imported_module(Checker* checker, const char* name) {
     // Use current function's accessible modules if set, otherwise use global direct_imports
-    char** modules = checker->current_accessible_modules;
-    int    count   = checker->current_accessible_modules_count;
+    char** modules = checker->modules.current_accessible_modules;
+    int    count   = checker->modules.current_accessible_modules_count;
 
     if (!modules) {
-        modules = checker->direct_imports;
-        count   = checker->direct_imports_count;
+        modules = checker->modules.direct_imports;
+        count   = checker->modules.direct_imports_count;
     }
 
     for (int i = 0; i < count; i++) {
@@ -322,9 +323,10 @@ Symbol* checker_lookup(Checker* checker, const char* name) {
                 }
                 // Symbols from library imports require module qualification
                 // Skip them here - they must be accessed via module.symbol syntax
-                int same_module = (sym->source_module == NULL && checker->current_module == NULL) ||
-                                  (sym->source_module && checker->current_module &&
-                                   strcmp(sym->source_module, checker->current_module) == 0);
+                int same_module =
+                    (sym->source_module == NULL && checker->modules.current_module == NULL) ||
+                    (sym->source_module && checker->modules.current_module &&
+                     strcmp(sym->source_module, checker->modules.current_module) == 0);
                 if (sym->source_module && !same_module) {
                     continue; // Library symbol - require module qualification
                 }
@@ -491,7 +493,7 @@ static void define_destruct_pattern_vars(Checker* checker, DestructPattern* patt
     switch (pattern->kind) {
     case PATTERN_IDENT:
         checker_define(checker, pattern->as.ident.name, SYM_VAR, type, is_const, is_public,
-                       checker->current_module);
+                       checker->modules.current_module);
         break;
 
     case PATTERN_TUPLE:
@@ -585,7 +587,7 @@ static void check_var_decl_stmt(Checker* checker, Node* node) {
     }
 
     Symbol* sym = checker_define(checker, name, SYM_VAR, var_type, node->as.var_decl.is_const,
-                                 node->as.var_decl.is_public, checker->current_module);
+                                 node->as.var_decl.is_public, checker->modules.current_module);
 
     // Store resolved type for codegen when type is inferred from non-literal expressions
     if (!node->as.var_decl.type && init_type && init_type->kind == TYPE_STRING &&
@@ -992,7 +994,7 @@ static void check_extern_module_decl(Checker* checker, Node* node) {
             Type* func_type = get_function_type(checker, decl);
 
             checker_define(checker, fdn->name, SYM_FUNC, func_type, 0, fdn->is_public,
-                           checker->current_module);
+                           checker->modules.current_module);
         }
     }
 }
@@ -1066,7 +1068,7 @@ static void check_func_decl(Checker* checker, Node* node) {
 
     // Pre-declare function for recursion
     checker_define(checker, mangled_name, SYM_FUNC, func_type, 1, fdn->is_public,
-                   checker->current_module);
+                   checker->modules.current_module);
 
     // For methods, also register the method on the struct type (or primitive)
     if (is_method) {
@@ -1088,13 +1090,14 @@ static void check_func_decl(Checker* checker, Node* node) {
             st->as.struc.method_count       = n + 1;
         } else if (type_builtin_from_name(receiver_type)) {
             // Register method on a primitive type
-            VEC_GROW(checker->primitive_methods, checker->primitive_method_count,
-                     checker->primitive_method_capacity);
-            PrimitiveMethod* pm = &checker->primitive_methods[checker->primitive_method_count++];
-            pm->type_name       = xstrdup(receiver_type);
-            pm->method_name     = xstrdup(name);
-            pm->method_type     = func_type;
-            pm->is_const        = fdn->receiver_is_const;
+            VEC_GROW(checker->traits.primitive_methods, checker->traits.primitive_method_count,
+                     checker->traits.primitive_method_capacity);
+            PrimitiveMethod* pm =
+                &checker->traits.primitive_methods[checker->traits.primitive_method_count++];
+            pm->type_name   = xstrdup(receiver_type);
+            pm->method_name = xstrdup(name);
+            pm->method_type = func_type;
+            pm->is_const    = fdn->receiver_is_const;
         } else {
             check_error(checker, node->line, node->column, "Unknown receiver type '%s'",
                         receiver_type);
@@ -1107,10 +1110,10 @@ static void check_func_decl(Checker* checker, Node* node) {
     checker->current_func_return = func_type->as.func.return_type;
 
     // Set this function's accessible modules for visibility checking
-    char** old_accessible_modules             = checker->current_accessible_modules;
-    int    old_accessible_modules_count       = checker->current_accessible_modules_count;
-    checker->current_accessible_modules       = fdn->accessible_modules;
-    checker->current_accessible_modules_count = fdn->accessible_modules_count;
+    char** old_accessible_modules               = checker->modules.current_accessible_modules;
+    int    old_accessible_modules_count         = checker->modules.current_accessible_modules_count;
+    checker->modules.current_accessible_modules = fdn->accessible_modules;
+    checker->modules.current_accessible_modules_count = fdn->accessible_modules_count;
 
     // For methods, inject 'self' into scope
     // self is a struct reference (the struct type itself, with reference semantics)
@@ -1151,8 +1154,8 @@ static void check_func_decl(Checker* checker, Node* node) {
     }
 
     // Restore previous accessible modules context
-    checker->current_accessible_modules       = old_accessible_modules;
-    checker->current_accessible_modules_count = old_accessible_modules_count;
+    checker->modules.current_accessible_modules       = old_accessible_modules;
+    checker->modules.current_accessible_modules_count = old_accessible_modules_count;
 
     checker->current_func_return = old_return;
     checker_pop_scope(checker);
@@ -1203,7 +1206,7 @@ static void check_struct_decl(Checker* checker, Node* node) {
     }
 
     checker_define(checker, name, SYM_TYPE, struct_type, 0, node->as.struct_decl.is_public,
-                   checker->current_module);
+                   checker->modules.current_module);
 }
 
 // Type-check an enum declaration: resolve variant types or register generic template
@@ -1232,7 +1235,7 @@ static void check_enum_decl(Checker* checker, Node* node) {
     enum_type->as.enm.variant_type_counts = xmalloc(value_count * sizeof(int));
 
     checker_define(checker, name, SYM_TYPE, enum_type, 0, node->as.enum_decl.is_public,
-                   checker->current_module);
+                   checker->modules.current_module);
 
     // Process enum variants
     for (int i = 0; i < value_count; i++) {
@@ -1286,7 +1289,7 @@ static void check_trait_decl(Checker* checker, Node* node) {
     }
 
     checker_define(checker, name, SYM_TYPE, trait_type, 0, node->as.trait_decl.is_public,
-                   checker->current_module);
+                   checker->modules.current_module);
 }
 
 // Type-check a type alias: resolve target type or register generic alias template
@@ -1325,7 +1328,7 @@ static void check_type_alias_decl(Checker* checker, Node* node) {
     }
 
     checker_define(checker, name, SYM_TYPE, resolved, 0, node->as.type_alias.is_public,
-                   checker->current_module);
+                   checker->modules.current_module);
 }
 
 // Type-check an impl block: verify methods match trait signatures and register trait impl
@@ -1460,8 +1463,8 @@ static void check_impl_decl(Checker* checker, Node* node) {
     }
 
     // Record the trait implementation
-    VEC_GROW(checker->trait_impls, checker->trait_impl_count, checker->trait_impl_capacity);
-    TraitImpl* impl  = &checker->trait_impls[checker->trait_impl_count++];
+    VEC_GROW(checker->traits.impls, checker->traits.impl_count, checker->traits.impl_capacity);
+    TraitImpl* impl  = &checker->traits.impls[checker->traits.impl_count++];
     impl->trait_name = xstrdup(trait_name);
     impl->type_name  = xstrdup(type_name_str);
 
@@ -1590,7 +1593,7 @@ static void check_decl(Checker* checker, Node* node) {
 //
 //   Pass 4: Check all declarations in the main module.
 //
-// Convention: checker->current_module is NULL for the "main" module and
+// Convention: checker->modules.current_module is NULL for the "main" module and
 // set to the module name string for library modules. A symbol's
 // source_module follows the same convention (NULL = main module).
 int checker_check(Checker* checker, Node* ast) {
@@ -1605,7 +1608,7 @@ int checker_check(Checker* checker, Node* ast) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
             continue;
-        checker->current_module =
+        checker->modules.current_module =
             strcmp(mod->as.module.name, "main") == 0 ? NULL : mod->as.module.name;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
@@ -1622,7 +1625,7 @@ int checker_check(Checker* checker, Node* ast) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
             continue;
-        checker->current_module =
+        checker->modules.current_module =
             strcmp(mod->as.module.name, "main") == 0 ? NULL : mod->as.module.name;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
@@ -1647,7 +1650,7 @@ int checker_check(Checker* checker, Node* ast) {
             continue;
         if (strcmp(mod->as.module.name, "main") == 0)
             continue;
-        checker->current_module = mod->as.module.name;
+        checker->modules.current_module = mod->as.module.name;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             // Skip already-processed declarations
@@ -1674,7 +1677,7 @@ int checker_check(Checker* checker, Node* ast) {
             continue;
         if (strcmp(mod->as.module.name, "main") != 0)
             continue;
-        checker->current_module = NULL;
+        checker->modules.current_module = NULL;
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             // Skip already-processed declarations
@@ -1693,7 +1696,7 @@ int checker_check(Checker* checker, Node* ast) {
         }
     }
 
-    checker->current_module = NULL;
+    checker->modules.current_module = NULL;
     checker_pop_scope(checker);
 
     return checker->error_count == 0;

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -86,57 +86,58 @@ typedef struct {
     Type* type;         // The TYPE_VEC instance
 } VecInstance;
 
+// Module import tracking
+typedef struct {
+    char**      direct_imports;
+    int         direct_imports_count;
+    char**      current_accessible_modules;
+    int         current_accessible_modules_count;
+    const char* current_module; // NULL = main module
+} CheckerModules;
+
+// Generic definitions and instantiations
+typedef struct {
+    GenericDef*      defs;
+    int              def_count;
+    int              def_capacity;
+    GenericInstance* instances;
+    int              instance_count;
+    int              instance_capacity;
+    char**           current_type_params; // Type parameter names
+    Type**           current_type_args;   // Concrete types for each param
+    int              current_type_param_count;
+} CheckerGenerics;
+
+// Instantiated container types (Span, Vec)
+typedef struct {
+    SpanInstance* spans;
+    int           span_count;
+    int           span_capacity;
+    VecInstance*  vecs;
+    int           vec_count;
+    int           vec_capacity;
+} CheckerContainers;
+
+// Trait implementations and primitive methods
+typedef struct {
+    TraitImpl*       impls;
+    int              impl_count;
+    int              impl_capacity;
+    PrimitiveMethod* primitive_methods;
+    int              primitive_method_count;
+    int              primitive_method_capacity;
+} CheckerTraits;
+
 struct Checker {
     Scope* scope;
     Type*  current_func_return; // Return type of current function
     int    in_loop;             // Are we inside a loop?
     int    error_count;
 
-    // Library modules directly imported by the root file (for global scope)
-    char** direct_imports;
-    int    direct_imports_count;
-
-    // Library modules accessible from the current function (NULL = use direct_imports)
-    char** current_accessible_modules;
-    int    current_accessible_modules_count;
-
-    // Current module being processed (NULL = main module)
-    const char* current_module;
-
-    // Generic struct definitions (templates)
-    GenericDef* generic_defs;
-    int         generic_def_count;
-    int         generic_def_capacity;
-
-    // Instantiated generic structs
-    GenericInstance* generic_instances;
-    int              generic_instance_count;
-    int              generic_instance_capacity;
-
-    // Context for type parameter substitution during instantiation
-    char** current_type_params; // Type parameter names
-    Type** current_type_args;   // Concrete types for each param
-    int    current_type_param_count;
-
-    // Instantiated span types
-    SpanInstance* span_instances;
-    int           span_instance_count;
-    int           span_instance_capacity;
-
-    // Instantiated vec types
-    VecInstance* vec_instances;
-    int          vec_instance_count;
-    int          vec_instance_capacity;
-
-    // Trait implementations
-    TraitImpl* trait_impls;
-    int        trait_impl_count;
-    int        trait_impl_capacity;
-
-    // Methods on primitive types (from trait impls)
-    PrimitiveMethod* primitive_methods;
-    int              primitive_method_count;
-    int              primitive_method_capacity;
+    CheckerModules    modules;
+    CheckerGenerics   generics;
+    CheckerContainers containers;
+    CheckerTraits     traits;
 
     // Type alias cycle detection
     int alias_depth;

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -397,12 +397,12 @@ static Type* check_member_expr(Checker* checker, Node* node) {
     if (object->kind != TYPE_STRUCT) {
         const char* prim_name   = type_name(object);
         const char* member_name = node->as.member.name;
-        for (int i = 0; i < checker->primitive_method_count; i++) {
-            if (strcmp(checker->primitive_methods[i].type_name, prim_name) == 0 &&
-                strcmp(checker->primitive_methods[i].method_name, member_name) == 0) {
+        for (int i = 0; i < checker->traits.primitive_method_count; i++) {
+            if (strcmp(checker->traits.primitive_methods[i].type_name, prim_name) == 0 &&
+                strcmp(checker->traits.primitive_methods[i].method_name, member_name) == 0) {
                 node->as.member.is_ref      = 0;
                 node->as.member.struct_name = xstrdup(prim_name);
-                return checker->primitive_methods[i].method_type;
+                return checker->traits.primitive_methods[i].method_type;
             }
         }
         if (object->kind == TYPE_STRING) {
@@ -616,8 +616,8 @@ static Type* check_enum_value_expr(Checker* checker, Node* node) {
             checker->enum_target_hint->kind == TYPE_ENUM) {
             // The target hint is an already-instantiated generic enum
             // Find the instance to get the type args
-            for (int gi = 0; gi < checker->generic_instance_count; gi++) {
-                GenericInstance* inst = &checker->generic_instances[gi];
+            for (int gi = 0; gi < checker->generics.instance_count; gi++) {
+                GenericInstance* inst = &checker->generics.instances[gi];
                 if (inst->type == checker->enum_target_hint &&
                     strcmp(inst->base_name, enum_name) == 0) {
                     // Use instance type args for any missing inferred params

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -13,8 +13,8 @@
 // Register a generic struct definition
 void register_generic_def(Checker* checker, const char* name, char** type_params,
                           char** type_param_bounds, int type_param_count, Node* decl) {
-    VEC_GROW(checker->generic_defs, checker->generic_def_count, checker->generic_def_capacity);
-    GenericDef* def        = &checker->generic_defs[checker->generic_def_count++];
+    VEC_GROW(checker->generics.defs, checker->generics.def_count, checker->generics.def_capacity);
+    GenericDef* def        = &checker->generics.defs[checker->generics.def_count++];
     def->name              = xstrdup(name);
     def->type_params       = xmalloc(type_param_count * sizeof(char*));
     def->type_param_bounds = xmalloc(type_param_count * sizeof(char*));
@@ -39,9 +39,9 @@ void register_generic_method(GenericDef* def, Node* method) {
 
 // Look up a generic struct definition by name
 GenericDef* lookup_generic_def(Checker* checker, const char* name) {
-    for (int i = 0; i < checker->generic_def_count; i++) {
-        if (strcmp(checker->generic_defs[i].name, name) == 0) {
-            return &checker->generic_defs[i];
+    for (int i = 0; i < checker->generics.def_count; i++) {
+        if (strcmp(checker->generics.defs[i].name, name) == 0) {
+            return &checker->generics.defs[i];
         }
     }
     return NULL;
@@ -49,9 +49,9 @@ GenericDef* lookup_generic_def(Checker* checker, const char* name) {
 
 // Look up an already-instantiated generic struct by mangled name
 GenericInstance* lookup_generic_instance(Checker* checker, const char* mangled_name) {
-    for (int i = 0; i < checker->generic_instance_count; i++) {
-        if (strcmp(checker->generic_instances[i].mangled_name, mangled_name) == 0) {
-            return &checker->generic_instances[i];
+    for (int i = 0; i < checker->generics.instance_count; i++) {
+        if (strcmp(checker->generics.instances[i].mangled_name, mangled_name) == 0) {
+            return &checker->generics.instances[i];
         }
     }
     return NULL;
@@ -59,9 +59,9 @@ GenericInstance* lookup_generic_instance(Checker* checker, const char* mangled_n
 
 // Look up an already-instantiated span type by mangled name
 static SpanInstance* lookup_span_instance(Checker* checker, const char* mangled_name) {
-    for (int i = 0; i < checker->span_instance_count; i++) {
-        if (strcmp(checker->span_instances[i].mangled_name, mangled_name) == 0) {
-            return &checker->span_instances[i];
+    for (int i = 0; i < checker->containers.span_count; i++) {
+        if (strcmp(checker->containers.spans[i].mangled_name, mangled_name) == 0) {
+            return &checker->containers.spans[i];
         }
     }
     return NULL;
@@ -70,9 +70,9 @@ static SpanInstance* lookup_span_instance(Checker* checker, const char* mangled_
 // Register an instantiated span type
 static void register_span_instance(Checker* checker, const char* mangled_name, Type* elem_type,
                                    Type* span_type) {
-    VEC_GROW(checker->span_instances, checker->span_instance_count,
-             checker->span_instance_capacity);
-    SpanInstance* inst = &checker->span_instances[checker->span_instance_count++];
+    VEC_GROW(checker->containers.spans, checker->containers.span_count,
+             checker->containers.span_capacity);
+    SpanInstance* inst = &checker->containers.spans[checker->containers.span_count++];
     inst->mangled_name = xstrdup(mangled_name);
     inst->elem_type    = elem_type;
     inst->type         = span_type;
@@ -80,9 +80,9 @@ static void register_span_instance(Checker* checker, const char* mangled_name, T
 
 // Look up an already-instantiated vec type by mangled name
 static VecInstance* lookup_vec_instance(Checker* checker, const char* mangled_name) {
-    for (int i = 0; i < checker->vec_instance_count; i++) {
-        if (strcmp(checker->vec_instances[i].mangled_name, mangled_name) == 0) {
-            return &checker->vec_instances[i];
+    for (int i = 0; i < checker->containers.vec_count; i++) {
+        if (strcmp(checker->containers.vecs[i].mangled_name, mangled_name) == 0) {
+            return &checker->containers.vecs[i];
         }
     }
     return NULL;
@@ -91,8 +91,9 @@ static VecInstance* lookup_vec_instance(Checker* checker, const char* mangled_na
 // Register an instantiated vec type
 static void register_vec_instance(Checker* checker, const char* mangled_name, Type* elem_type,
                                   Type* vec_type) {
-    VEC_GROW(checker->vec_instances, checker->vec_instance_count, checker->vec_instance_capacity);
-    VecInstance* inst  = &checker->vec_instances[checker->vec_instance_count++];
+    VEC_GROW(checker->containers.vecs, checker->containers.vec_count,
+             checker->containers.vec_capacity);
+    VecInstance* inst  = &checker->containers.vecs[checker->containers.vec_count++];
     inst->mangled_name = xstrdup(mangled_name);
     inst->elem_type    = elem_type;
     inst->type         = vec_type;
@@ -102,9 +103,9 @@ static void register_vec_instance(Checker* checker, const char* mangled_name, Ty
 static void register_generic_instance(Checker* checker, const char* mangled_name,
                                       const char* base_name, Type* type, Type** type_args,
                                       int type_arg_count) {
-    VEC_GROW(checker->generic_instances, checker->generic_instance_count,
-             checker->generic_instance_capacity);
-    GenericInstance* inst = &checker->generic_instances[checker->generic_instance_count++];
+    VEC_GROW(checker->generics.instances, checker->generics.instance_count,
+             checker->generics.instance_capacity);
+    GenericInstance* inst = &checker->generics.instances[checker->generics.instance_count++];
     inst->mangled_name    = xstrdup(mangled_name);
     inst->base_name       = xstrdup(base_name);
     inst->type            = type;
@@ -294,13 +295,13 @@ Type* instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
     register_generic_instance(checker, mangled, def->name, enum_type, resolved_args, arg_count);
 
     // Set up substitution context
-    char** old_params = checker->current_type_params;
-    Type** old_args   = checker->current_type_args;
-    int    old_count  = checker->current_type_param_count;
+    char** old_params = checker->generics.current_type_params;
+    Type** old_args   = checker->generics.current_type_args;
+    int    old_count  = checker->generics.current_type_param_count;
 
-    checker->current_type_params      = def->type_params;
-    checker->current_type_args        = resolved_args;
-    checker->current_type_param_count = def->type_param_count;
+    checker->generics.current_type_params      = def->type_params;
+    checker->generics.current_type_args        = resolved_args;
+    checker->generics.current_type_param_count = def->type_param_count;
 
     // Process enum variants
     Node* decl        = def->decl;
@@ -335,12 +336,12 @@ Type* instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
     }
 
     // Restore substitution context
-    checker->current_type_params      = old_params;
-    checker->current_type_args        = old_args;
-    checker->current_type_param_count = old_count;
+    checker->generics.current_type_params      = old_params;
+    checker->generics.current_type_args        = old_args;
+    checker->generics.current_type_param_count = old_count;
 
     // Register in symbol table
-    checker_define(checker, mangled, SYM_TYPE, enum_type, 0, 1, checker->current_module);
+    checker_define(checker, mangled, SYM_TYPE, enum_type, 0, 1, checker->modules.current_module);
 
     free(mangled);
     free(resolved_args);
@@ -438,20 +439,20 @@ static Type* resolve_generic_type_alias(Checker* checker, Node* type_node, Gener
     }
 
     // Set up substitution context
-    char** old_params = checker->current_type_params;
-    Type** old_args   = checker->current_type_args;
-    int    old_count  = checker->current_type_param_count;
+    char** old_params = checker->generics.current_type_params;
+    Type** old_args   = checker->generics.current_type_args;
+    int    old_count  = checker->generics.current_type_param_count;
 
-    checker->current_type_params      = def->type_params;
-    checker->current_type_args        = resolved_args;
-    checker->current_type_param_count = def->type_param_count;
+    checker->generics.current_type_params      = def->type_params;
+    checker->generics.current_type_args        = resolved_args;
+    checker->generics.current_type_param_count = def->type_param_count;
 
     Type* result = resolve_type(checker, def->decl->as.type_alias.target_type);
 
     // Restore context
-    checker->current_type_params      = old_params;
-    checker->current_type_args        = old_args;
-    checker->current_type_param_count = old_count;
+    checker->generics.current_type_params      = old_params;
+    checker->generics.current_type_args        = old_args;
+    checker->generics.current_type_param_count = old_count;
 
     checker->alias_depth--;
     free(resolved_args);
@@ -471,13 +472,13 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
     register_generic_instance(checker, mangled, base_name, struct_type, resolved_args, arg_count);
 
     // Set up substitution context
-    char** old_params = checker->current_type_params;
-    Type** old_args   = checker->current_type_args;
-    int    old_count  = checker->current_type_param_count;
+    char** old_params = checker->generics.current_type_params;
+    Type** old_args   = checker->generics.current_type_args;
+    int    old_count  = checker->generics.current_type_param_count;
 
-    checker->current_type_params      = def->type_params;
-    checker->current_type_args        = resolved_args;
-    checker->current_type_param_count = def->type_param_count;
+    checker->generics.current_type_params      = def->type_params;
+    checker->generics.current_type_args        = resolved_args;
+    checker->generics.current_type_param_count = def->type_param_count;
 
     // Resolve field types with substitution
     Node* decl        = def->decl;
@@ -504,9 +505,9 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
     }
 
     // Check if the base generic has a Drop trait impl and propagate to instantiation
-    for (int ti = 0; ti < checker->trait_impl_count; ti++) {
-        if (strcmp(checker->trait_impls[ti].trait_name, "Drop") == 0 &&
-            strcmp(checker->trait_impls[ti].type_name, base_name) == 0) {
+    for (int ti = 0; ti < checker->traits.impl_count; ti++) {
+        if (strcmp(checker->traits.impls[ti].trait_name, "Drop") == 0 &&
+            strcmp(checker->traits.impls[ti].type_name, base_name) == 0) {
             struct_type->as.struc.has_drop = 1;
             break;
         }
@@ -552,9 +553,9 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
         }
 
         // Set up combined substitution context
-        checker->current_type_params      = combined_params;
-        checker->current_type_args        = combined_args;
-        checker->current_type_param_count = combined_count;
+        checker->generics.current_type_params      = combined_params;
+        checker->generics.current_type_args        = combined_args;
+        checker->generics.current_type_param_count = combined_count;
 
         // Build function type with substituted types
         int    param_count = mfdn->params.count;
@@ -587,10 +588,10 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
             Type* old_return             = checker->current_func_return;
             checker->current_func_return = return_type;
 
-            char** old_accessible_modules             = checker->current_accessible_modules;
-            int    old_accessible_modules_count       = checker->current_accessible_modules_count;
-            checker->current_accessible_modules       = mfdn->accessible_modules;
-            checker->current_accessible_modules_count = mfdn->accessible_modules_count;
+            char** old_accessible_modules       = checker->modules.current_accessible_modules;
+            int    old_accessible_modules_count = checker->modules.current_accessible_modules_count;
+            checker->modules.current_accessible_modules       = mfdn->accessible_modules;
+            checker->modules.current_accessible_modules_count = mfdn->accessible_modules_count;
 
             // Inject 'self' into scope
             checker_define(checker, "self", SYM_VAR, struct_type, mfdn->receiver_is_const, 0, NULL);
@@ -607,16 +608,16 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
                 check_statement(checker, body_clone->as.block.stmts.nodes[s]);
             }
 
-            checker->current_accessible_modules       = old_accessible_modules;
-            checker->current_accessible_modules_count = old_accessible_modules_count;
-            checker->current_func_return              = old_return;
+            checker->modules.current_accessible_modules       = old_accessible_modules;
+            checker->modules.current_accessible_modules_count = old_accessible_modules_count;
+            checker->current_func_return                      = old_return;
             checker_pop_scope(checker);
         }
 
         // Restore struct-only context
-        checker->current_type_params      = def->type_params;
-        checker->current_type_args        = resolved_args;
-        checker->current_type_param_count = def->type_param_count;
+        checker->generics.current_type_params      = def->type_params;
+        checker->generics.current_type_args        = resolved_args;
+        checker->generics.current_type_param_count = def->type_param_count;
 
         // Free combined arrays (but not the strings - they're borrowed or will be freed later)
         free(combined_params);
@@ -650,19 +651,19 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
         snprintf(full_method_name, method_name_len, "%s_%s", method_mangled, mfdn->name);
 
         checker_define(checker, full_method_name, SYM_FUNC, method_type, 1, mfdn->is_public,
-                       checker->current_module);
+                       checker->modules.current_module);
 
         free(method_mangled);
         free(full_method_name);
     }
 
     // Restore substitution context
-    checker->current_type_params      = old_params;
-    checker->current_type_args        = old_args;
-    checker->current_type_param_count = old_count;
+    checker->generics.current_type_params      = old_params;
+    checker->generics.current_type_args        = old_args;
+    checker->generics.current_type_param_count = old_count;
 
     // Register in symbol table so it can be looked up
-    checker_define(checker, mangled, SYM_TYPE, struct_type, 0, 1, checker->current_module);
+    checker_define(checker, mangled, SYM_TYPE, struct_type, 0, 1, checker->modules.current_module);
 
     free(mangled);
     free(resolved_args);
@@ -685,10 +686,10 @@ Type* resolve_type(Checker* checker, Node* type_node) {
             return builtin;
 
         // Check for type parameter substitution (when instantiating generics)
-        if (checker->current_type_params) {
-            for (int i = 0; i < checker->current_type_param_count; i++) {
-                if (strcmp(checker->current_type_params[i], name) == 0) {
-                    return checker->current_type_args[i];
+        if (checker->generics.current_type_params) {
+            for (int i = 0; i < checker->generics.current_type_param_count; i++) {
+                if (strcmp(checker->generics.current_type_params[i], name) == 0) {
+                    return checker->generics.current_type_args[i];
                 }
             }
         }
@@ -755,9 +756,9 @@ Type* resolve_type(Checker* checker, Node* type_node) {
                 }
                 int satisfied = 0;
                 if (arg_type_name_str) {
-                    for (int t = 0; t < checker->trait_impl_count; t++) {
-                        if (strcmp(checker->trait_impls[t].trait_name, bound) == 0 &&
-                            strcmp(checker->trait_impls[t].type_name, arg_type_name_str) == 0) {
+                    for (int t = 0; t < checker->traits.impl_count; t++) {
+                        if (strcmp(checker->traits.impls[t].trait_name, bound) == 0 &&
+                            strcmp(checker->traits.impls[t].type_name, arg_type_name_str) == 0) {
                             satisfied = 1;
                             break;
                         }

--- a/w0/main.c
+++ b/w0/main.c
@@ -43,14 +43,14 @@ static int compile_to_c(const char* source, const char* source_path, const char*
     CodeGen gen;
     codegen_init(&gen, out,
                  (CodeGenChecker){
-                     .instances      = checker.generic_instances,
-                     .instance_count = checker.generic_instance_count,
-                     .spans          = checker.span_instances,
-                     .span_count     = checker.span_instance_count,
-                     .vecs           = checker.vec_instances,
-                     .vec_count      = checker.vec_instance_count,
-                     .traits         = checker.trait_impls,
-                     .trait_count    = checker.trait_impl_count,
+                     .instances      = checker.generics.instances,
+                     .instance_count = checker.generics.instance_count,
+                     .spans          = checker.containers.spans,
+                     .span_count     = checker.containers.span_count,
+                     .vecs           = checker.containers.vecs,
+                     .vec_count      = checker.containers.vec_count,
+                     .traits         = checker.traits.impls,
+                     .trait_count    = checker.traits.impl_count,
                  },
                  rc_debug);
     codegen_emit(&gen, ast);
@@ -369,14 +369,14 @@ int main(int argc, char** argv) {
                 CodeGen gen;
                 codegen_init(&gen, out,
                              (CodeGenChecker){
-                                 .instances      = checker.generic_instances,
-                                 .instance_count = checker.generic_instance_count,
-                                 .spans          = checker.span_instances,
-                                 .span_count     = checker.span_instance_count,
-                                 .vecs           = checker.vec_instances,
-                                 .vec_count      = checker.vec_instance_count,
-                                 .traits         = checker.trait_impls,
-                                 .trait_count    = checker.trait_impl_count,
+                                 .instances      = checker.generics.instances,
+                                 .instance_count = checker.generics.instance_count,
+                                 .spans          = checker.containers.spans,
+                                 .span_count     = checker.containers.span_count,
+                                 .vecs           = checker.containers.vecs,
+                                 .vec_count      = checker.containers.vec_count,
+                                 .traits         = checker.traits.impls,
+                                 .trait_count    = checker.traits.impl_count,
                              },
                              rc_debug);
                 codegen_emit(&gen, ast);


### PR DESCRIPTION
## Summary
- Groups the Checker struct's 27 flat fields into 4 logical sub-structures: `CheckerModules`, `CheckerGenerics`, `CheckerContainers`, `CheckerTraits`
- Mirrors the sub-structuring pattern already applied to the `CodeGen` struct
- Purely mechanical rename refactoring — no semantic changes

Closes #128

## Test plan
- [x] `make` compiles cleanly with no warnings
- [x] `make test` — all 155/155 tests pass
- [x] `make format` — code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)