### PR TITLE
refactor: extract module loader from parser.c

### DIFF
--- a/w0/Makefile
+++ b/w0/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -Wall -Wextra -std=c11 -g -D_POSIX_C_SOURCE=200809L -MMD -MP
 LDFLAGS =
 
-SRC = main.c lexer.c parser.c ast.c types.c checker.c checker_types.c checker_expr.c codegen.c codegen_types.c codegen_emit.c codegen_rc.c codegen_expr.c codegen_stmt.c print_ast.c
+SRC = main.c lexer.c parser.c module_loader.c ast.c types.c checker.c checker_types.c checker_expr.c codegen.c codegen_types.c codegen_emit.c codegen_rc.c codegen_expr.c codegen_stmt.c print_ast.c
 OBJ = $(SRC:.c=.o)
 DEPS = $(SRC:.c=.d)
 BIN = bin

--- a/w0/main.c
+++ b/w0/main.c
@@ -8,6 +8,7 @@
 #include "checker.h"
 #include "codegen.h"
 #include "lexer.h"
+#include "module_loader.h"
 #include "parser.h"
 #include "print_ast.h"
 #include "util.h"
@@ -16,20 +17,24 @@
 // Returns 0 on success, 1 on error.
 static int compile_to_c(const char* source, const char* source_path, const char* lib_path,
                         int rc_debug, FILE* out) {
+    ModuleLoader loader;
+    module_loader_init(&loader, lib_path);
+
     Parser parser;
-    parser_init_with_path(&parser, source, source_path, lib_path);
+    parser_init_with_loader(&parser, source, source_path, &loader);
     Node* ast = parser_parse(&parser);
 
     if (parser.had_error) {
         fprintf(stderr, "Parse failed\n");
         node_free(ast);
         parser_free(&parser);
+        module_loader_free(&loader);
         return 1;
     }
 
     Checker checker;
     checker_init(&checker);
-    checker_set_direct_imports(&checker, parser.direct_imports, parser.direct_imports_count);
+    checker_set_direct_imports(&checker, loader.direct_imports, loader.direct_imports_count);
     int ok = checker_check(&checker, ast);
 
     if (!ok) {
@@ -37,6 +42,7 @@ static int compile_to_c(const char* source, const char* source_path, const char*
         fprintf(stderr, "Type check failed\n");
         node_free(ast);
         parser_free(&parser);
+        module_loader_free(&loader);
         return 1;
     }
 
@@ -58,6 +64,7 @@ static int compile_to_c(const char* source, const char* source_path, const char*
     checker_free(&checker);
     node_free(ast);
     parser_free(&parser);
+    module_loader_free(&loader);
     return 0;
 }
 
@@ -313,14 +320,18 @@ int main(int argc, char** argv) {
         return result;
     } else {
         // Debug modes: --parse, --check, --ast
+        ModuleLoader loader;
+        module_loader_init(&loader, lib_path);
+
         Parser parser;
-        parser_init_with_path(&parser, source, source_file, lib_path);
+        parser_init_with_loader(&parser, source, source_file, &loader);
         Node* ast = parser_parse(&parser);
 
         if (parser.had_error) {
             fprintf(stderr, "Parse failed\n");
             node_free(ast);
             parser_free(&parser);
+            module_loader_free(&loader);
             if (free_source)
                 free(source);
             return 1;
@@ -336,8 +347,8 @@ int main(int argc, char** argv) {
         if (!parse_only) {
             Checker checker;
             checker_init(&checker);
-            checker_set_direct_imports(&checker, parser.direct_imports,
-                                       parser.direct_imports_count);
+            checker_set_direct_imports(&checker, loader.direct_imports,
+                                       loader.direct_imports_count);
             int ok = checker_check(&checker, ast);
 
             if (!ok) {
@@ -345,6 +356,7 @@ int main(int argc, char** argv) {
                 fprintf(stderr, "Type check failed\n");
                 node_free(ast);
                 parser_free(&parser);
+                module_loader_free(&loader);
                 if (free_source)
                     free(source);
                 return 1;
@@ -360,6 +372,7 @@ int main(int argc, char** argv) {
                         fprintf(stderr, "Could not open output file: %s\n", output_file);
                         node_free(ast);
                         parser_free(&parser);
+                        module_loader_free(&loader);
                         if (free_source)
                             free(source);
                         return 1;
@@ -394,6 +407,7 @@ int main(int argc, char** argv) {
 
         node_free(ast);
         parser_free(&parser);
+        module_loader_free(&loader);
     }
 
     if (free_source)

--- a/w0/module_loader.c
+++ b/w0/module_loader.c
@@ -1,0 +1,267 @@
+#include "module_loader.h"
+
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "alloc.h"
+#include "parser.h"
+#include "util.h"
+#include "vec.h"
+
+void module_loader_init(ModuleLoader* loader, const char* lib_path) {
+    loader->lib_path = lib_path;
+
+    loader->imported_sources          = NULL;
+    loader->imported_sources_count    = 0;
+    loader->imported_sources_capacity = 0;
+
+    loader->imported_modules          = NULL;
+    loader->imported_modules_count    = 0;
+    loader->imported_modules_capacity = 0;
+
+    loader->direct_imports          = NULL;
+    loader->direct_imports_count    = 0;
+    loader->direct_imports_capacity = 0;
+
+    loader->file_imports          = NULL;
+    loader->file_imports_count    = 0;
+    loader->file_imports_capacity = 0;
+
+    loader->import_depth = 0;
+}
+
+void module_loader_free(ModuleLoader* loader) {
+    for (int i = 0; i < loader->imported_sources_count; i++) {
+        free(loader->imported_sources[i]);
+    }
+    free(loader->imported_sources);
+
+    for (int i = 0; i < loader->imported_modules_count; i++) {
+        free(loader->imported_modules[i]);
+    }
+    free(loader->imported_modules);
+
+    for (int i = 0; i < loader->direct_imports_count; i++) {
+        free(loader->direct_imports[i]);
+    }
+    free(loader->direct_imports);
+
+    for (int i = 0; i < loader->file_imports_count; i++) {
+        free(loader->file_imports[i]);
+    }
+    free(loader->file_imports);
+}
+
+int module_loader_is_imported(ModuleLoader* loader, const char* name, size_t len) {
+    for (int i = 0; i < loader->imported_modules_count; i++) {
+        if (strlen(loader->imported_modules[i]) == len &&
+            strncmp(loader->imported_modules[i], name, len) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void module_loader_add_module(ModuleLoader* loader, const char* name, size_t len) {
+    VEC_GROW(loader->imported_modules, loader->imported_modules_count,
+             loader->imported_modules_capacity);
+
+    char* name_copy = xmalloc(len + 1);
+    memcpy(name_copy, name, len);
+    name_copy[len]                                             = '\0';
+    loader->imported_modules[loader->imported_modules_count++] = name_copy;
+}
+
+void module_loader_add_source(ModuleLoader* loader, char* source) {
+    VEC_GROW(loader->imported_sources, loader->imported_sources_count,
+             loader->imported_sources_capacity);
+    loader->imported_sources[loader->imported_sources_count++] = source;
+}
+
+void module_loader_add_direct_import(ModuleLoader* loader, const char* name, size_t len) {
+    VEC_GROW(loader->direct_imports, loader->direct_imports_count, loader->direct_imports_capacity);
+
+    char* name_copy = xmalloc(len + 1);
+    memcpy(name_copy, name, len);
+    name_copy[len]                                         = '\0';
+    loader->direct_imports[loader->direct_imports_count++] = name_copy;
+}
+
+static void add_file_import(ModuleLoader* loader, const char* name, size_t len) {
+    VEC_GROW(loader->file_imports, loader->file_imports_count, loader->file_imports_capacity);
+
+    char* name_copy = xmalloc(len + 1);
+    memcpy(name_copy, name, len);
+    name_copy[len]                                     = '\0';
+    loader->file_imports[loader->file_imports_count++] = name_copy;
+}
+
+int module_loader_file_exists(const char* path) {
+    FILE* f = fopen(path, "r");
+    if (f) {
+        fclose(f);
+        return 1;
+    }
+    return 0;
+}
+
+int module_loader_is_relative_path(const char* path, size_t len) {
+    if (len >= 2 && path[0] == '.' && path[1] == '/') {
+        return 1;
+    }
+    if (len >= 3 && path[0] == '.' && path[1] == '.' && path[2] == '/') {
+        return 1;
+    }
+    return 0;
+}
+
+void module_loader_build_path(ModuleLoader* loader, const char* source_path, char* path,
+                              size_t path_size, const char* module_name, size_t module_length,
+                              int is_relative) {
+    if (is_relative) {
+        if (source_path) {
+            char* path_copy = xstrdup(source_path);
+            char* dir       = dirname(path_copy);
+            snprintf(path, path_size, "%s/%.*s", dir, (int)module_length, module_name);
+            free(path_copy);
+            return;
+        }
+        snprintf(path, path_size, "%.*s", (int)module_length, module_name);
+        return;
+    }
+
+    // Standard library import: try lib/ directories
+    if (loader->lib_path) {
+        snprintf(path, path_size, "%s/%.*s.w", loader->lib_path, (int)module_length, module_name);
+        if (module_loader_file_exists(path)) {
+            return;
+        }
+    }
+
+    if (source_path) {
+        char* path_copy = xstrdup(source_path);
+        char* dir       = dirname(path_copy);
+        snprintf(path, path_size, "%s/lib/%.*s.w", dir, (int)module_length, module_name);
+        free(path_copy);
+        if (module_loader_file_exists(path)) {
+            return;
+        }
+    }
+    // Fallback: use lib/ relative to current working directory
+    snprintf(path, path_size, "lib/%.*s.w", (int)module_length, module_name);
+}
+
+int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, Node* current_module,
+                         const char* module_name, size_t module_length, int is_relative) {
+    // Build path to import file
+    char path[1024];
+    module_loader_build_path(loader, parser->source_path, path, sizeof(path), module_name,
+                             module_length, is_relative);
+
+    // For relative imports, use resolved path as module key for duplicate detection
+    const char* module_key        = is_relative ? path : module_name;
+    size_t      module_key_length = is_relative ? strlen(path) : module_length;
+
+    // Check if already imported
+    if (module_loader_is_imported(loader, module_key, module_key_length)) {
+        // Still track for visibility
+        if (!is_relative) {
+            add_file_import(loader, module_name, module_length);
+            if (loader->import_depth == 0) {
+                module_loader_add_direct_import(loader, module_name, module_length);
+            }
+        }
+        return 1;
+    }
+
+    // Mark as imported before parsing (prevents cycles)
+    module_loader_add_module(loader, module_key, module_key_length);
+
+    // Read the imported file
+    char* source = read_file(path);
+    if (!source) {
+        char error_msg[256];
+        snprintf(error_msg, sizeof(error_msg), "Could not read import file: %s", path);
+        parse_error(parser, error_msg);
+        return 0;
+    }
+
+    // Store source buffer to keep it alive
+    module_loader_add_source(loader, source);
+
+    // Track file-level and root-level imports
+    if (!is_relative) {
+        add_file_import(loader, module_name, module_length);
+        if (loader->import_depth == 0) {
+            module_loader_add_direct_import(loader, module_name, module_length);
+        }
+    }
+
+    // Parse the imported file with the shared loader.
+    // Save/restore file_imports so each file sees only its own imports.
+    int saved_file_imports_count = loader->file_imports_count;
+    loader->file_imports_count   = 0;
+
+    Parser import_parser;
+    parser_init_with_loader(&import_parser, source, path, loader);
+
+    loader->import_depth++;
+    Node* import_ast = parser_parse(&import_parser);
+    loader->import_depth--;
+
+    // Free sub-file's file_imports entries and restore
+    for (int i = 0; i < loader->file_imports_count; i++) {
+        free(loader->file_imports[i]);
+    }
+    loader->file_imports_count = saved_file_imports_count;
+
+    if (import_parser.had_error) {
+        fprintf(stderr, "Failed to parse imported file: %s\n", path);
+        node_free(import_ast);
+        return 0;
+    }
+
+    // Handle the imported AST based on import type
+    if (import_ast && import_ast->type == NODE_PROGRAM) {
+        if (is_relative) {
+            // Relative import: merge main module's declarations into current_module
+            // Keep library modules as separate modules in the program
+            for (int m = 0; m < import_ast->as.program.modules.count; m++) {
+                Node* imported_module = import_ast->as.program.modules.nodes[m];
+                if (imported_module && imported_module->type == NODE_MODULE) {
+                    if (strcmp(imported_module->as.module.name, "main") == 0) {
+                        for (int i = 0; i < imported_module->as.module.decls.count; i++) {
+                            Node* decl = imported_module->as.module.decls.nodes[i];
+                            nodelist_push(&current_module->as.module.decls, decl);
+                        }
+                        imported_module->as.module.decls.count = 0;
+                    } else {
+                        nodelist_push(&program->as.program.modules, imported_module);
+                    }
+                }
+            }
+            import_ast->as.program.modules.count = 0;
+        } else {
+            // Library import: rename main module to library name
+            for (int m = 0; m < import_ast->as.program.modules.count; m++) {
+                Node* imported_module = import_ast->as.program.modules.nodes[m];
+                if (imported_module && imported_module->type == NODE_MODULE) {
+                    if (strcmp(imported_module->as.module.name, "main") == 0) {
+                        free(imported_module->as.module.name);
+                        imported_module->as.module.name = xmalloc(module_length + 1);
+                        memcpy(imported_module->as.module.name, module_name, module_length);
+                        imported_module->as.module.name[module_length] = '\0';
+                        imported_module->as.module.name_length         = (int)module_length;
+                    }
+                    nodelist_push(&program->as.program.modules, imported_module);
+                }
+            }
+            import_ast->as.program.modules.count = 0;
+        }
+    }
+
+    node_free(import_ast);
+    return 1;
+}

--- a/w0/module_loader.h
+++ b/w0/module_loader.h
@@ -1,0 +1,59 @@
+#ifndef MODULE_LOADER_H
+#define MODULE_LOADER_H
+
+#include <stddef.h>
+
+#include "ast.h"
+
+typedef struct Parser Parser;
+
+typedef struct {
+    const char* lib_path;
+
+    // Imported source buffers (kept alive for AST string references)
+    char** imported_sources;
+    int    imported_sources_count;
+    int    imported_sources_capacity;
+
+    // Imported module names (to prevent duplicate imports)
+    char** imported_modules;
+    int    imported_modules_count;
+    int    imported_modules_capacity;
+
+    // Library modules directly imported by the root file (for checker visibility)
+    char** direct_imports;
+    int    direct_imports_count;
+    int    direct_imports_capacity;
+
+    // Library modules imported by the currently-parsing file (for func accessible_modules).
+    // Saved/restored around sub-parser calls so each file sees only its own imports.
+    char** file_imports;
+    int    file_imports_count;
+    int    file_imports_capacity;
+
+    // 0 = root file, >0 = transitive import
+    int import_depth;
+} ModuleLoader;
+
+// Lifecycle
+void module_loader_init(ModuleLoader* loader, const char* lib_path);
+void module_loader_free(ModuleLoader* loader);
+
+// Module tracking
+int  module_loader_is_imported(ModuleLoader* loader, const char* name, size_t len);
+void module_loader_add_module(ModuleLoader* loader, const char* name, size_t len);
+void module_loader_add_source(ModuleLoader* loader, char* source);
+void module_loader_add_direct_import(ModuleLoader* loader, const char* name, size_t len);
+
+// Path utilities
+int  module_loader_file_exists(const char* path);
+int  module_loader_is_relative_path(const char* path, size_t len);
+void module_loader_build_path(ModuleLoader* loader, const char* source_path, char* path,
+                              size_t path_size, const char* module_name, size_t module_length,
+                              int is_relative);
+
+// Import orchestration
+int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, Node* current_module,
+                         const char* module_name, size_t module_length, int is_relative);
+
+#endif // MODULE_LOADER_H

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1,15 +1,11 @@
 #include "parser.h"
 
 #include <errno.h>
-#include <libgen.h>
-#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "alloc.h"
-#include "util.h"
-#include "vec.h"
 
 // ============================================================================
 // Parser Utilities
@@ -1547,13 +1543,15 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
     consume_token(parser, TOK_LBRACE, "Expected '{' before function body");
     fdn->body = parse_block(parser);
 
-    // Copy current file's direct imports to accessible_modules
+    // Copy current file's imports to accessible_modules
     // This determines which library modules this function can access
-    fdn->accessible_modules_count = parser->direct_imports_count;
-    if (parser->direct_imports_count > 0) {
-        fdn->accessible_modules = xmalloc(parser->direct_imports_count * sizeof(char*));
-        for (int i = 0; i < parser->direct_imports_count; i++) {
-            fdn->accessible_modules[i] = xstrdup(parser->direct_imports[i]);
+    ModuleLoader* loader          = parser->loader;
+    int           fi_count        = loader ? loader->file_imports_count : 0;
+    fdn->accessible_modules_count = fi_count;
+    if (fi_count > 0) {
+        fdn->accessible_modules = xmalloc(fi_count * sizeof(char*));
+        for (int i = 0; i < fi_count; i++) {
+            fdn->accessible_modules[i] = xstrdup(loader->file_imports[i]);
         }
     } else {
         fdn->accessible_modules = NULL;
@@ -1931,111 +1929,6 @@ static Node* parse_extern_decls(Parser* parser, int is_public) {
 // Import Handling
 // ============================================================================
 
-// Check if a module has already been imported
-static int is_module_imported(Parser* parser, const char* module_name, size_t length) {
-    for (int i = 0; i < parser->imported_modules_count; i++) {
-        if (strlen(parser->imported_modules[i]) == length &&
-            strncmp(parser->imported_modules[i], module_name, length) == 0) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-// Add a module name to the imported list
-static void add_imported_module(Parser* parser, const char* module_name, size_t length) {
-    VEC_GROW(parser->imported_modules, parser->imported_modules_count,
-             parser->imported_modules_capacity);
-
-    // Copy the module name
-    char* name_copy = xmalloc(length + 1);
-    memcpy(name_copy, module_name, length);
-    name_copy[length]                                          = '\0';
-    parser->imported_modules[parser->imported_modules_count++] = name_copy;
-}
-
-// Add source buffer to parser's list (keeps it alive for AST references)
-static void add_imported_source(Parser* parser, char* source) {
-    VEC_GROW(parser->imported_sources, parser->imported_sources_count,
-             parser->imported_sources_capacity);
-    parser->imported_sources[parser->imported_sources_count++] = source;
-}
-
-// Add a direct import (library module directly imported by current file)
-static void add_direct_import(Parser* parser, const char* module_name, size_t length) {
-    VEC_GROW(parser->direct_imports, parser->direct_imports_count, parser->direct_imports_capacity);
-
-    // Copy the module name
-    char* name_copy = xmalloc(length + 1);
-    memcpy(name_copy, module_name, length);
-    name_copy[length]                                      = '\0';
-    parser->direct_imports[parser->direct_imports_count++] = name_copy;
-}
-
-// Check if file exists
-static int file_exists(const char* path) {
-    FILE* f = fopen(path, "r");
-    if (f) {
-        fclose(f);
-        return 1;
-    }
-    return 0;
-}
-
-// Check if path is a relative import (starts with ./ or ../)
-static int is_relative_path(const char* path, size_t length) {
-    if (length >= 2 && path[0] == '.' && path[1] == '/') {
-        return 1;
-    }
-    if (length >= 3 && path[0] == '.' && path[1] == '.' && path[2] == '/') {
-        return 1;
-    }
-    return 0;
-}
-
-// Build path to imported module
-// For relative paths (./ or ../), resolves relative to source file
-// For module names, tries source-relative lib/ first, then falls back to cwd-relative lib/
-static void build_import_path(Parser* parser, char* path, size_t path_size, const char* module_name,
-                              size_t module_length, int is_relative) {
-    if (is_relative) {
-        // Relative import: resolve relative to source file's directory
-        if (parser->source_path) {
-            char* path_copy = xstrdup(parser->source_path);
-            char* dir       = dirname(path_copy);
-            snprintf(path, path_size, "%s/%.*s", dir, (int)module_length, module_name);
-            free(path_copy);
-            return;
-        }
-        // Fallback if no source path: use path as-is relative to cwd
-        snprintf(path, path_size, "%.*s", (int)module_length, module_name);
-        return;
-    }
-
-    // Standard library import: try lib/ directories
-    // Highest priority: --lib-path flag
-    if (parser->lib_path) {
-        snprintf(path, path_size, "%s/%.*s.w", parser->lib_path, (int)module_length, module_name);
-        if (file_exists(path)) {
-            return;
-        }
-    }
-
-    if (parser->source_path) {
-        // Make a copy because dirname may modify its argument
-        char* path_copy = xstrdup(parser->source_path);
-        char* dir       = dirname(path_copy);
-        snprintf(path, path_size, "%s/lib/%.*s.w", dir, (int)module_length, module_name);
-        free(path_copy);
-        if (file_exists(path)) {
-            return;
-        }
-        // Fall through to try cwd-relative path
-    }
-    // Fallback: use lib/ relative to current working directory
-    snprintf(path, path_size, "lib/%.*s.w", (int)module_length, module_name);
-}
-
 // Parse a use statement: use module.symbol; or use module.{sym1, sym2};
 static Node* parse_use_stmt(Parser* parser) {
     Token module_token = parser->current;
@@ -2088,25 +1981,21 @@ static Node* parse_use_stmt(Parser* parser) {
 }
 
 static int parse_import_stmt(Parser* parser, Node* program, Node* current_module) {
-    // Expect identifier or string after 'import'
     Token       import_token = parser->current;
     const char* module_name;
     size_t      module_length;
     int         is_relative = 0;
 
     if (parser->current.type == TOK_STRING) {
-        // String import: "./path/to/file.w" or "../path/to/file.w"
         advance_token(parser);
-        // Extract path without quotes
         module_name   = import_token.start + 1;
         module_length = import_token.length - 2;
-        is_relative   = is_relative_path(module_name, module_length);
+        is_relative   = module_loader_is_relative_path(module_name, module_length);
         if (!is_relative) {
             parse_error(parser, "String imports must be relative paths (start with ./ or ../)");
             return 0;
         }
     } else if (parser->current.type == TOK_IDENT) {
-        // Identifier import: std
         advance_token(parser);
         module_name   = import_token.start;
         module_length = import_token.length;
@@ -2115,140 +2004,10 @@ static int parse_import_stmt(Parser* parser, Node* program, Node* current_module
         return 0;
     }
 
-    // Expect semicolon
     consume_token(parser, TOK_SEMICOLON, "Expected ';' after import statement");
 
-    // Build path to import file first (needed for duplicate detection with relative paths)
-    char path[1024];
-    build_import_path(parser, path, sizeof(path), module_name, module_length, is_relative);
-
-    // For relative imports, use the resolved path as the module key for duplicate detection
-    const char* module_key        = is_relative ? path : module_name;
-    size_t      module_key_length = is_relative ? strlen(path) : module_length;
-
-    // Check if already imported
-    if (is_module_imported(parser, module_key, module_key_length)) {
-        // Module already imported - but still track as direct import if it's a library import
-        // This allows this file to access the module's symbols even if a dependency imported it
-        // first
-        if (!is_relative) {
-            add_direct_import(parser, module_name, module_length);
-        }
-        return 1; // Already imported, nothing more to do
-    }
-
-    // Mark as imported before parsing (prevents cycles)
-    add_imported_module(parser, module_key, module_key_length);
-
-    // Read the imported file
-    char* source = read_file(path);
-    if (!source) {
-        char error_msg[256];
-        snprintf(error_msg, sizeof(error_msg), "Could not read import file: %s", path);
-        parse_error(parser, error_msg);
-        return 0;
-    }
-
-    // Store source buffer to keep it alive (AST nodes reference strings in it)
-    add_imported_source(parser, source);
-
-    // Parse the imported file (inherits source_path for nested imports)
-    Parser import_parser;
-    parser_init_with_path(&import_parser, source, path, parser->lib_path);
-
-    // Share the imported modules list with the sub-parser to handle transitive imports
-    import_parser.imported_modules          = parser->imported_modules;
-    import_parser.imported_modules_count    = parser->imported_modules_count;
-    import_parser.imported_modules_capacity = parser->imported_modules_capacity;
-
-    Node* import_ast = parser_parse(&import_parser);
-
-    // Update parent parser's imported modules list (sub-parser may have added more)
-    parser->imported_modules          = import_parser.imported_modules;
-    parser->imported_modules_count    = import_parser.imported_modules_count;
-    parser->imported_modules_capacity = import_parser.imported_modules_capacity;
-
-    // Move any imported sources from sub-parser to parent
-    for (int i = 0; i < import_parser.imported_sources_count; i++) {
-        add_imported_source(parser, import_parser.imported_sources[i]);
-    }
-    // Clear sub-parser's list (don't free, ownership transferred)
-    free(import_parser.imported_sources);
-    import_parser.imported_sources       = NULL;
-    import_parser.imported_sources_count = 0;
-
-    // Clear the imported_modules in sub-parser to prevent double-free
-    import_parser.imported_modules       = NULL;
-    import_parser.imported_modules_count = 0;
-
-    // Free sub-parser's direct_imports (not needed - each file tracks its own imports via
-    // source_file)
-    for (int i = 0; i < import_parser.direct_imports_count; i++) {
-        free(import_parser.direct_imports[i]);
-    }
-    free(import_parser.direct_imports);
-    import_parser.direct_imports       = NULL;
-    import_parser.direct_imports_count = 0;
-
-    if (import_parser.had_error) {
-        fprintf(stderr, "Failed to parse imported file: %s\n", path);
-        node_free(import_ast);
-        return 0;
-    }
-
-    // For library imports, track as direct import
-    if (!is_relative) {
-        add_direct_import(parser, module_name, module_length);
-    }
-
-    // Handle the imported AST based on import type
-    if (import_ast && import_ast->type == NODE_PROGRAM) {
-        if (is_relative) {
-            // Relative import: merge only the "main" module's declarations into current_module
-            // Keep library modules (non-main) as separate modules in the program
-            for (int m = 0; m < import_ast->as.program.modules.count; m++) {
-                Node* imported_module = import_ast->as.program.modules.nodes[m];
-                if (imported_module && imported_module->type == NODE_MODULE) {
-                    if (strcmp(imported_module->as.module.name, "main") == 0) {
-                        // Merge main module's declarations into current module
-                        for (int i = 0; i < imported_module->as.module.decls.count; i++) {
-                            Node* decl = imported_module->as.module.decls.nodes[i];
-                            nodelist_push(&current_module->as.module.decls, decl);
-                        }
-                        // Clear to prevent double-free
-                        imported_module->as.module.decls.count = 0;
-                    } else {
-                        // Keep library modules as separate modules
-                        nodelist_push(&program->as.program.modules, imported_module);
-                    }
-                }
-            }
-            // Clear to prevent double-free (only main was freed, others moved)
-            import_ast->as.program.modules.count = 0;
-        } else {
-            // Library import: move modules from imported AST to program
-            // The first module (main) of the library becomes a module named after the import
-            for (int m = 0; m < import_ast->as.program.modules.count; m++) {
-                Node* imported_module = import_ast->as.program.modules.nodes[m];
-                if (imported_module && imported_module->type == NODE_MODULE) {
-                    // Rename "main" module to the library name
-                    if (strcmp(imported_module->as.module.name, "main") == 0) {
-                        free(imported_module->as.module.name);
-                        imported_module->as.module.name = xmalloc(module_length + 1);
-                        memcpy(imported_module->as.module.name, module_name, module_length);
-                        imported_module->as.module.name[module_length] = '\0';
-                        imported_module->as.module.name_length         = (int)module_length;
-                    }
-                    nodelist_push(&program->as.program.modules, imported_module);
-                }
-            }
-            // Clear to prevent double-free
-            import_ast->as.program.modules.count = 0;
-        }
-    }
-
-    node_free(import_ast);
-    return 1;
+    return module_loader_import(parser->loader, parser, program, current_module, module_name,
+                                module_length, is_relative);
 }
 
 // ============================================================================
@@ -2301,56 +2060,25 @@ static Node* parse_declaration(Parser* parser) {
 // ============================================================================
 
 void parser_init(Parser* parser, const char* source) {
-    parser_init_with_path(parser, source, NULL, NULL);
+    parser_init_with_loader(parser, source, NULL, NULL);
 }
 
-void parser_init_with_path(Parser* parser, const char* source, const char* source_path,
-                           const char* lib_path) {
+void parser_init_with_loader(Parser* parser, const char* source, const char* source_path,
+                             ModuleLoader* loader) {
     lexer_init(&parser->lexer, source);
     parser->had_error    = 0;
     parser->panic_mode   = 0;
     parser->error_msg[0] = '\0';
-    parser->parse_depth  = 0; // Reset recursion depth
+    parser->parse_depth  = 0;
 
     parser->source_path = source_path;
-    parser->lib_path    = lib_path;
+    parser->loader      = loader;
 
-    // Initialize imported sources tracking
-    parser->imported_sources          = NULL;
-    parser->imported_sources_count    = 0;
-    parser->imported_sources_capacity = 0;
-
-    // Initialize imported modules tracking
-    parser->imported_modules          = NULL;
-    parser->imported_modules_count    = 0;
-    parser->imported_modules_capacity = 0;
-
-    // Initialize direct imports tracking (library modules directly imported by this file)
-    parser->direct_imports          = NULL;
-    parser->direct_imports_count    = 0;
-    parser->direct_imports_capacity = 0;
-
-    advance_token(parser); // Prime the parser
+    advance_token(parser);
 }
 
 void parser_free(Parser* parser) {
-    // Free all imported source buffers
-    for (int i = 0; i < parser->imported_sources_count; i++) {
-        free(parser->imported_sources[i]);
-    }
-    free(parser->imported_sources);
-
-    // Free all imported module names
-    for (int i = 0; i < parser->imported_modules_count; i++) {
-        free(parser->imported_modules[i]);
-    }
-    free(parser->imported_modules);
-
-    // Free all direct import names
-    for (int i = 0; i < parser->direct_imports_count; i++) {
-        free(parser->direct_imports[i]);
-    }
-    free(parser->direct_imports);
+    (void)parser;
 }
 
 Node* parser_parse(Parser* parser) {

--- a/w0/parser.h
+++ b/w0/parser.h
@@ -3,8 +3,9 @@
 
 #include "ast.h"
 #include "lexer.h"
+#include "module_loader.h"
 
-typedef struct {
+typedef struct Parser {
     Lexer lexer;
     Token current;
     Token previous;
@@ -15,23 +16,8 @@ typedef struct {
     // Source file path for resolving imports
     const char* source_path;
 
-    // Library path for resolving module imports (--lib-path flag)
-    const char* lib_path;
-
-    // Imported source buffers (kept alive for AST string references)
-    char** imported_sources;
-    int    imported_sources_count;
-    int    imported_sources_capacity;
-
-    // Imported module names (to prevent duplicate imports)
-    char** imported_modules;
-    int    imported_modules_count;
-    int    imported_modules_capacity;
-
-    // Library modules directly imported by the root file (for visibility checking)
-    char** direct_imports;
-    int    direct_imports_count;
-    int    direct_imports_capacity;
+    // Shared module loader (not owned by parser)
+    ModuleLoader* loader;
 
     // Current recursion depth for expression parsing
     int parse_depth;
@@ -57,8 +43,8 @@ typedef enum {
 
 // Parser lifecycle
 void  parser_init(Parser* parser, const char* source);
-void  parser_init_with_path(Parser* parser, const char* source, const char* source_path,
-                            const char* lib_path);
+void  parser_init_with_loader(Parser* parser, const char* source, const char* source_path,
+                              ModuleLoader* loader);
 void  parser_free(Parser* parser);
 Node* parser_parse(Parser* parser);
 


### PR DESCRIPTION
## Summary
- Extracts ~270 lines of import handling (path resolution, file I/O, module tracking, AST merging) from `parser.c` into a new `ModuleLoader` struct in `module_loader.c`/`.h`
- A single `ModuleLoader` is shared by pointer across all parsers in the import tree, eliminating the error-prone pointer-swapping and ownership-transfer pattern between parent/sub-parsers
- Parser struct loses 9 import-related fields, gains one `ModuleLoader*` pointer; `parser_init_with_path` replaced by `parser_init_with_loader`

Closes #130

## Test plan
- [x] `make clean && make` — zero warnings
- [x] `make test` — all 155/155 tests pass (including import, relative import chain, and module visibility tests)
- [x] `make format` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)