### PR TITLE
feat(std): implement std.args() from process argv

### DIFF
--- a/lib/include/std_args.h
+++ b/lib/include/std_args.h
@@ -1,0 +1,9 @@
+#ifndef WHIST_STD_ARGS_H
+#define WHIST_STD_ARGS_H
+
+#include <stdint.h>
+
+int64_t     std__argc(void);
+const char* std__argv(int64_t i);
+
+#endif

--- a/lib/std.w
+++ b/lib/std.w
@@ -14,6 +14,11 @@ private extern stdlib {
     func system(cmd: string): i32 as _system;
 }
 
+private extern std_args {
+    func std__argc(): i64;
+    func std__argv(i: i64): string;
+}
+
 func print(s: string): void {
     printf("%s", s);
 }
@@ -28,6 +33,19 @@ func exit(status: i32): void {
 
 func system(cmd: string): i32 {
     return _system(cmd);
+}
+
+func args(): Vec<string> {
+    var args = new Vec<string>{};
+
+    var count = std__argc();
+    var i: i64 = 0;
+    while (i < count) {
+        args.push(std__argv(i));
+        i = i + 1;
+    }
+
+    return args;
 }
 
 func panic(s: string): void {

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -534,6 +534,44 @@ static void emit_c_headers(CodeGen* gen) {
     emit(gen, "#include <string.h>\n");
     emit(gen, "#include <stdarg.h>\n");
     emit(gen, "\n");
+    emit(gen, "static int __w0_argc = 0;\n");
+    emit(gen, "static char** __w0_argv = NULL;\n");
+    emit(gen, "int64_t std__argc(void) { return (int64_t)__w0_argc; }\n");
+    emit(gen, "const char* std__argv(int64_t i) {\n");
+    emit(gen, "    if (i < 0 || i >= (int64_t)__w0_argc) return \"\";\n");
+    emit(gen, "    return (const char*)__w0_argv[i];\n");
+    emit(gen, "}\n\n");
+}
+
+// Return 1 if the program declares a top-level `main` function in the main module.
+static int program_has_user_main(Node* ast) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        if (strcmp(mod->as.module.name, "main") != 0)
+            continue;
+
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (!decl || decl->type != NODE_FUNC_DECL)
+                continue;
+            if (decl->as.func_decl.receiver_type != NULL)
+                continue;
+            if (strcmp(decl->as.func_decl.name, "main") == 0)
+                return 1;
+        }
+    }
+    return 0;
+}
+
+// Emit the real C entrypoint wrapper that captures argc/argv for std.args().
+static void emit_main_wrapper(CodeGen* gen) {
+    emit(gen, "int main(int argc, char** argv) {\n");
+    emit(gen, "    __w0_argc = argc;\n");
+    emit(gen, "    __w0_argv = argv;\n");
+    emit(gen, "    return __w0_user_main();\n");
+    emit(gen, "}\n\n");
 }
 
 // Build the list of all enum type names (non-generic and generic instances)
@@ -780,6 +818,8 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     if (!ast || ast->type != NODE_PROGRAM)
         return;
 
+    int has_user_main = program_has_user_main(ast);
+
     collect_types_and_aliases(gen, ast);
     emit_c_headers(gen);
     emit_rc_runtime(gen);
@@ -802,4 +842,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit_struct_rc_dec(gen, ast);
     emit_declarations(gen, ast);
     emit_generic_method_impls(gen, ast);
+    if (has_user_main) {
+        emit_main_wrapper(gen);
+    }
 }

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -121,6 +121,9 @@ void emit_function_name(CodeGen* gen, const char* func_name, const char* receive
     if (receiver_type != NULL) {
         // Method: prefix with struct name
         emit(gen, " %s_%s(", receiver_type, func_name);
+    } else if (module_name == NULL && strcmp(func_name, "main") == 0) {
+        // User main is lowered to an internal symbol; wrapper C main is emitted separately.
+        emit(gen, " __w0_user_main(");
     } else if (module_name != NULL) {
         // Library function: prefix with module name
         emit(gen, " %s_%s(", module_name, func_name);

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -379,8 +379,14 @@ static void emit_call_expr(CodeGen* gen, Node* node) {
                     emit(gen, "%s_", gen->current_module);
                 }
             }
-            emit_expr(gen, func);
-            emit(gen, "(");
+            if (func->type == NODE_IDENT && gen->current_module == NULL &&
+                strncmp(func->as.ident.name, "main", func->as.ident.length) == 0 &&
+                func->as.ident.length == 4) {
+                emit(gen, "__w0_user_main(");
+            } else {
+                emit_expr(gen, func);
+                emit(gen, "(");
+            }
         }
         for (int i = 0; i < node->as.call.args.count; i++) {
             if (i > 0)

--- a/w0/test/rc_runtime/std_args_basic.w
+++ b/w0/test/rc_runtime/std_args_basic.w
@@ -1,0 +1,17 @@
+// RUNTIME TEST: std.args() includes argv[0] and is non-empty.
+
+import std;
+
+func main(): i32 {
+    var args = std.args();
+
+    if (args.count < 1) {
+        return 1;
+    }
+
+    if (args[0].length() == 0) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/w0/test/std_args.w
+++ b/w0/test/std_args.w
@@ -1,0 +1,15 @@
+import std;
+
+func main(): i32 {
+    var args = std.args();
+
+    if (args.count < 1) {
+        return 1;
+    }
+
+    if (args[0].length() == 0) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add generated C arg bridge (`std__argc`/`std__argv`) and a C `main(argc, argv)` wrapper that passes through to lowered user main
- add `std.args(): Vec<string>` in `lib/std.w` (includes `argv[0]`, returns a fresh Vec)
- add coverage in `w0/test/std_args.w` and `w0/test/rc_runtime/std_args_basic.w`

## Testing
- cd w0 && ./scripts/run_tests.sh --valid --errors

Closes #89
