### PR TITLE
feat: enforce deep const at call sites and index writes

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -8,6 +8,16 @@
 // Forward declaration for check_struct_init (called by check_new_expr)
 static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
 
+// Return the const variable name if node is a NODE_IDENT referring to a const symbol, else NULL
+static const char* get_const_binding_name(Checker* checker, Node* node) {
+    if (node && node->type == NODE_IDENT) {
+        Symbol* sym = checker_lookup(checker, node->as.ident.name);
+        if (sym && sym->is_const)
+            return node->as.ident.name;
+    }
+    return NULL;
+}
+
 // =============================================================================
 // Expression checking helpers
 // =============================================================================
@@ -356,6 +366,13 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         // Methods: push, pop, clear
         if (strcmp(member_name, "push") == 0 || strcmp(member_name, "pop") == 0 ||
             strcmp(member_name, "clear") == 0) {
+            const char* const_name = get_const_binding_name(checker, node->as.member.object);
+            if (const_name) {
+                check_error(checker, node->line, node->column,
+                            "Cannot call mutating method '%s' on const '%s'", member_name,
+                            const_name);
+                return type_error;
+            }
             // Build mangled vec name for method dispatch
             char mangled[256];
             snprintf(mangled, sizeof(mangled), "__Vec_%s", type_mangle_name(elem_type));
@@ -400,6 +417,16 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         for (int i = 0; i < checker->traits.primitive_method_count; i++) {
             if (strcmp(checker->traits.primitive_methods[i].type_name, prim_name) == 0 &&
                 strcmp(checker->traits.primitive_methods[i].method_name, member_name) == 0) {
+                if (!checker->traits.primitive_methods[i].is_const) {
+                    const char* const_name =
+                        get_const_binding_name(checker, node->as.member.object);
+                    if (const_name) {
+                        check_error(checker, node->line, node->column,
+                                    "Cannot call mutating method '%s' on const '%s'", member_name,
+                                    const_name);
+                        return type_error;
+                    }
+                }
                 node->as.member.is_ref      = 0;
                 node->as.member.struct_name = xstrdup(prim_name);
                 return checker->traits.primitive_methods[i].method_type;
@@ -429,6 +456,15 @@ static Type* check_member_expr(Checker* checker, Node* node) {
     // If not a field, check for method
     for (int i = 0; i < object->as.struc.method_count; i++) {
         if (strcmp(object->as.struc.method_names[i], member_name) == 0) {
+            if (!object->as.struc.method_is_const[i]) {
+                const char* const_name = get_const_binding_name(checker, node->as.member.object);
+                if (const_name) {
+                    check_error(checker, node->line, node->column,
+                                "Cannot call mutating method '%s' on const '%s'", member_name,
+                                const_name);
+                    return type_error;
+                }
+            }
             node->as.member.struct_name = xstrdup(object->as.struc.name);
             return object->as.struc.method_types[i];
         }
@@ -492,6 +528,13 @@ static Type* check_assign_expr(Checker* checker, Node* node) {
                             obj->as.ident.name);
                 return type_error;
             }
+        }
+    } else if (t->type == NODE_INDEX) {
+        const char* const_name = get_const_binding_name(checker, t->as.index.object);
+        if (const_name) {
+            check_error(checker, node->line, node->column, "Cannot write to index of const '%s'",
+                        const_name);
+            return type_error;
         }
     }
 

--- a/w0/test/const_struct_const_method.w
+++ b/w0/test/const_struct_const_method.w
@@ -1,0 +1,16 @@
+// Test that const methods can be called on const struct bindings
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+func (const Point) sum(): i64 {
+    return self.x + self.y;
+}
+
+func main(): i32 {
+    const p = new Point {x: 10, y: 20};
+    var s = p.sum();
+    return 0;
+}

--- a/w0/test/const_vec_readonly.w
+++ b/w0/test/const_vec_readonly.w
@@ -1,0 +1,8 @@
+// Test that readonly operations on const Vec are allowed
+
+func main(): i32 {
+    const v = new Vec<i64>{10, 20, 30};
+    var c = v.count;
+    var x = v[0];
+    return 0;
+}

--- a/w0/test/error_const_index_write.w
+++ b/w0/test/error_const_index_write.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot write to index of const Vec
+// Expected error: Cannot write to index of const 'v'
+
+func main(): i32 {
+    const v = new Vec<i64>{1, 2, 3};
+    v[0] = 99;
+    return 0;
+}

--- a/w0/test/error_const_struct_method.w
+++ b/w0/test/error_const_struct_method.w
@@ -1,0 +1,18 @@
+// ERROR TEST: Cannot call mutable method on const struct
+// Expected error: Cannot call mutating method 'move' on const 'p'
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+func (Point) move(dx: i64, dy: i64): void {
+    self.x = self.x + dx;
+    self.y = self.y + dy;
+}
+
+func main(): i32 {
+    const p = new Point {x: 10, y: 20};
+    p.move(5, 5);
+    return 0;
+}

--- a/w0/test/error_const_vec_clear.w
+++ b/w0/test/error_const_vec_clear.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot clear const Vec
+// Expected error: Cannot call mutating method 'clear' on const 'v'
+
+func main(): i32 {
+    const v = new Vec<i64>{};
+    v.clear();
+    return 0;
+}

--- a/w0/test/error_const_vec_pop.w
+++ b/w0/test/error_const_vec_pop.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot pop from const Vec
+// Expected error: Cannot call mutating method 'pop' on const 'v'
+
+func main(): i32 {
+    const v = new Vec<i64>{};
+    v.pop();
+    return 0;
+}

--- a/w0/test/error_const_vec_push.w
+++ b/w0/test/error_const_vec_push.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot push to const Vec
+// Expected error: Cannot call mutating method 'push' on const 'v'
+
+func main(): i32 {
+    const v = new Vec<i64>{};
+    v.push(42);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Block mutating Vec methods (`push`, `pop`, `clear`) on `const` bindings
- Block non-const struct and primitive methods on `const` bindings
- Block index writes (`v[i] = x`) through `const` bindings
- Add `get_const_binding_name` helper to consolidate const-binding lookup pattern

Closes #138

## Test plan
- [x] 5 new error tests: `error_const_vec_push`, `error_const_vec_pop`, `error_const_vec_clear`, `error_const_index_write`, `error_const_struct_method`
- [x] 2 new valid tests: `const_vec_readonly` (count/index reads allowed), `const_struct_const_method` (const methods allowed)
- [x] All 168 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)