### PR TITLE
feat: add per-field const declarations on struct definitions

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -402,9 +402,10 @@ Node* node_clone(Node* node) {
         c->as.member.name   = xstrdup(node->as.member.name);
         c->as.member.length = node->as.member.length;
         // Reset checker flags
-        c->as.member.is_ref      = 0;
-        c->as.member.struct_name = NULL;
-        c->as.member.module_name = NULL;
+        c->as.member.is_ref          = 0;
+        c->as.member.is_const_access = 0;
+        c->as.member.struct_name     = NULL;
+        c->as.member.module_name     = NULL;
         break;
     case NODE_ASSIGN:
         c->as.assign.op     = node->as.assign.op;
@@ -550,6 +551,7 @@ Node* node_clone(Node* node) {
         c->as.field.name        = xstrdup(node->as.field.name);
         c->as.field.name_length = node->as.field.name_length;
         c->as.field.type        = node_clone(node->as.field.type);
+        c->as.field.is_const    = node->as.field.is_const;
         break;
     default:
         fprintf(stderr, "node_clone: unhandled node type %d\n", node->type);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -228,9 +228,10 @@ struct Node {
             Node* object;
             char* name;
             int   length;
-            int   is_ref;      // Set by checker: 1 if object is a struct reference
-            char* struct_name; // Set by checker if this is a method access (NULL otherwise)
-            char* module_name; // Set by checker for module-qualified access (e.g., "std")
+            int   is_ref;          // Set by checker: 1 if object is a struct reference
+            int   is_const_access; // Set by checker: 1 if accessing a const field
+            char* struct_name;     // Set by checker if this is a method access (NULL otherwise)
+            char* module_name;     // Set by checker for module-qualified access (e.g., "std")
         } member;
 
         // Assignment
@@ -420,6 +421,7 @@ struct Node {
             char* name;
             int   name_length;
             Node* type;
+            int   is_const;
         } field;
 
         // Enum declaration

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1185,14 +1185,16 @@ static void check_struct_decl(Checker* checker, Node* node) {
     Type* struct_type = type_struct(name);
     int   field_count = node->as.struct_decl.fields.count;
 
-    struct_type->as.struc.field_count = field_count;
-    struct_type->as.struc.field_names = xmalloc(field_count * sizeof(char*));
-    struct_type->as.struc.field_types = xmalloc(field_count * sizeof(Type*));
+    struct_type->as.struc.field_count    = field_count;
+    struct_type->as.struc.field_names    = xmalloc(field_count * sizeof(char*));
+    struct_type->as.struc.field_types    = xmalloc(field_count * sizeof(Type*));
+    struct_type->as.struc.field_is_const = xmalloc(field_count * sizeof(int));
 
     for (int i = 0; i < field_count; i++) {
-        Node* field                          = node->as.struct_decl.fields.nodes[i];
-        struct_type->as.struc.field_names[i] = xstrdup(field->as.field.name);
-        struct_type->as.struc.field_types[i] = resolve_type(checker, field->as.field.type);
+        Node* field                             = node->as.struct_decl.fields.nodes[i];
+        struct_type->as.struc.field_names[i]    = xstrdup(field->as.field.name);
+        struct_type->as.struc.field_types[i]    = resolve_type(checker, field->as.field.type);
+        struct_type->as.struc.field_is_const[i] = field->as.field.is_const;
     }
 
     // Check if any field is an RC-managed type (struct, Vec, or enum with RC fields)

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -8,13 +8,15 @@
 // Forward declaration for check_struct_init (called by check_new_expr)
 static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
 
-// Return the const variable name if node is a NODE_IDENT referring to a const symbol, else NULL
+// Return the const variable/field name if node is a const binding or const field access, else NULL
 static const char* get_const_binding_name(Checker* checker, Node* node) {
     if (node && node->type == NODE_IDENT) {
         Symbol* sym = checker_lookup(checker, node->as.ident.name);
         if (sym && sym->is_const)
             return node->as.ident.name;
     }
+    if (node && node->type == NODE_MEMBER && node->as.member.is_const_access)
+        return node->as.member.name;
     return NULL;
 }
 
@@ -448,7 +450,8 @@ static Type* check_member_expr(Checker* checker, Node* node) {
     // Find field first
     for (int i = 0; i < object->as.struc.field_count; i++) {
         if (strcmp(object->as.struc.field_names[i], member_name) == 0) {
-            node->as.member.struct_name = NULL;
+            node->as.member.struct_name     = NULL;
+            node->as.member.is_const_access = object->as.struc.field_is_const[i];
             return object->as.struc.field_types[i];
         }
     }
@@ -528,6 +531,11 @@ static Type* check_assign_expr(Checker* checker, Node* node) {
                             obj->as.ident.name);
                 return type_error;
             }
+        }
+        if (t->as.member.is_const_access) {
+            check_error(checker, node->line, node->column, "Cannot assign to const field '%s'",
+                        t->as.member.name);
+            return type_error;
         }
     } else if (t->type == NODE_INDEX) {
         const char* const_name = get_const_binding_name(checker, t->as.index.object);

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -484,14 +484,16 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
     Node* decl        = def->decl;
     int   field_count = decl->as.struct_decl.fields.count;
 
-    struct_type->as.struc.field_count = field_count;
-    struct_type->as.struc.field_names = xmalloc(field_count * sizeof(char*));
-    struct_type->as.struc.field_types = xmalloc(field_count * sizeof(Type*));
+    struct_type->as.struc.field_count    = field_count;
+    struct_type->as.struc.field_names    = xmalloc(field_count * sizeof(char*));
+    struct_type->as.struc.field_types    = xmalloc(field_count * sizeof(Type*));
+    struct_type->as.struc.field_is_const = xmalloc(field_count * sizeof(int));
 
     for (int i = 0; i < field_count; i++) {
-        Node* field                          = decl->as.struct_decl.fields.nodes[i];
-        struct_type->as.struc.field_names[i] = xstrdup(field->as.field.name);
-        struct_type->as.struc.field_types[i] = resolve_type(checker, field->as.field.type);
+        Node* field                             = decl->as.struct_decl.fields.nodes[i];
+        struct_type->as.struc.field_names[i]    = xstrdup(field->as.field.name);
+        struct_type->as.struc.field_types[i]    = resolve_type(checker, field->as.field.type);
+        struct_type->as.struc.field_is_const[i] = field->as.field.is_const;
     }
 
     // Check if any field is an RC-managed type (struct, Vec, or enum with RC fields)

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1617,12 +1617,18 @@ static Node* parse_struct_decl(Parser* parser, int is_public) {
     consume_token(parser, TOK_LBRACE, "Expected '{' after struct name");
 
     while (!check_token(parser, TOK_RBRACE) && !check_token(parser, TOK_EOF)) {
+        int field_is_const = 0;
+        if (match_token(parser, TOK_CONST)) {
+            field_is_const = 1;
+        }
+
         Token field_name = parser->current;
         consume_token(parser, TOK_IDENT, "Expected field name");
 
         Node* field                 = node_new(NODE_FIELD, field_name.line, field_name.column);
         field->as.field.name        = copy_token_string(&field_name);
         field->as.field.name_length = field_name.length;
+        field->as.field.is_const    = field_is_const;
 
         consume_token(parser, TOK_COLON, "Expected ':' after field name");
         field->as.field.type = parse_type(parser);

--- a/w0/test/const_field_valid.w
+++ b/w0/test/const_field_valid.w
@@ -1,0 +1,13 @@
+// Valid: const field can be set at construction and read
+
+struct Box {
+    const v: i64,
+    name: string,
+}
+
+func main(): i32 {
+    var b = new Box { v: 42, name: "hello" };
+    var x = b.v;
+    b.name = "world";
+    return 0;
+}

--- a/w0/test/error_const_field_assign.w
+++ b/w0/test/error_const_field_assign.w
@@ -1,0 +1,12 @@
+// ERROR TEST: Cannot assign to const field
+// Expected error: Cannot assign to const field 'v'
+
+struct Box {
+    const v: i64,
+}
+
+func main(): i32 {
+    var b = new Box { v: 42 };
+    b.v = 99;
+    return 0;
+}

--- a/w0/test/error_const_field_index.w
+++ b/w0/test/error_const_field_index.w
@@ -1,0 +1,12 @@
+// ERROR TEST: Cannot write to index of const field
+// Expected error: Cannot write to index of const 'v'
+
+struct Box {
+    const v: Vec<i32>,
+}
+
+func main(): i32 {
+    var b = new Box { v: new Vec<i32>{} };
+    b.v[0] = 5;
+    return 0;
+}

--- a/w0/test/error_const_field_method.w
+++ b/w0/test/error_const_field_method.w
@@ -1,0 +1,12 @@
+// ERROR TEST: Cannot call mutating method on const field
+// Expected error: Cannot call mutating method 'push' on const 'v'
+
+struct Box {
+    const v: Vec<i32>,
+}
+
+func main(): i32 {
+    var b = new Box { v: new Vec<i32>{} };
+    b.v.push(1);
+    return 0;
+}

--- a/w0/test/error_const_field_uplift.w
+++ b/w0/test/error_const_field_uplift.w
@@ -1,0 +1,17 @@
+// ERROR TEST: const field prevents mutating method even without const binding
+// Expected error: Cannot call mutating method 'push' on const 'v'
+
+import std;
+use std.println;
+
+struct Box {
+    const v: Vec<i32>,
+}
+
+func main(): i32 {
+    var b = new Box { v: new Vec<i32>{} };
+
+    b.v.push(1);
+
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -86,6 +86,7 @@ Type* type_struct(const char* name) {
     type->as.struc.name            = xstrdup(name);
     type->as.struc.field_names     = NULL;
     type->as.struc.field_types     = NULL;
+    type->as.struc.field_is_const  = NULL;
     type->as.struc.field_count     = 0;
     type->as.struc.method_names    = NULL;
     type->as.struc.method_types    = NULL;
@@ -170,6 +171,7 @@ void type_free(Type* type) {
         }
         free(type->as.struc.field_names);
         free(type->as.struc.field_types);
+        free(type->as.struc.field_is_const);
         for (int i = 0; i < type->as.struc.method_count; i++) {
             free(type->as.struc.method_names[i]);
         }

--- a/w0/types.h
+++ b/w0/types.h
@@ -68,6 +68,7 @@ struct Type {
             char*  name;
             char** field_names;
             Type** field_types;
+            int*   field_is_const;
             int    field_count;
             // Methods
             char** method_names;


### PR DESCRIPTION
## Summary

- Add `const` modifier for struct field declarations (`const v: Vec<i32>`) that makes fields immutable after construction
- Checker enforces const fields at compile time: blocks direct assignment, mutating method calls, and index writes
- Works with both concrete and generic structs

Closes #141

## Test plan

- [x] `make` builds cleanly
- [x] `make test` — all 173 tests pass (101 valid, 60 error, 12 RC runtime)
- [x] New valid test: `const_field_valid.w` — read access, construction, mutable sibling field
- [x] New error tests: `error_const_field_assign.w`, `error_const_field_method.w`, `error_const_field_index.w`
- [x] Uplift test: `error_const_field_uplift.w` — const field prevents mutation even on `var` binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)