### PR TITLE
fix(checker): propagate const through member access chains

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -450,8 +450,15 @@ static Type* check_member_expr(Checker* checker, Node* node) {
     // Find field first
     for (int i = 0; i < object->as.struc.field_count; i++) {
         if (strcmp(object->as.struc.field_names[i], member_name) == 0) {
+            int object_is_const = 0;
+            if (node->as.member.object->type == NODE_IDENT) {
+                Symbol* sym = checker_lookup(checker, node->as.member.object->as.ident.name);
+                object_is_const = (sym && sym->is_const);
+            } else if (node->as.member.object->type == NODE_MEMBER) {
+                object_is_const = node->as.member.object->as.member.is_const_access;
+            }
             node->as.member.struct_name     = NULL;
-            node->as.member.is_const_access = object->as.struc.field_is_const[i];
+            node->as.member.is_const_access = object->as.struc.field_is_const[i] || object_is_const;
             return object->as.struc.field_types[i];
         }
     }

--- a/w0/test/const_binding_field_const_method.w
+++ b/w0/test/const_binding_field_const_method.w
@@ -1,0 +1,21 @@
+// Valid: const methods remain callable through fields of const bindings
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+struct Wrap {
+    p: Point,
+}
+
+func (const Point) sum(): i64 {
+    return self.x + self.y;
+}
+
+func main(): i32 {
+    const w = new Wrap { p: new Point { x: 10, y: 20 } };
+    var s = w.p.sum();
+    var x = w.p.x;
+    return 0;
+}

--- a/w0/test/error_const_binding_field_chain_method.w
+++ b/w0/test/error_const_binding_field_chain_method.w
@@ -1,0 +1,16 @@
+// ERROR TEST: const binding propagation is transitive through member chains
+// Expected error: Cannot call mutating method 'push' on const 'v'
+
+struct Box {
+    v: Vec<i32>,
+}
+
+struct Outer {
+    box: Box,
+}
+
+func main(): i32 {
+    const o = new Outer { box: new Box { v: new Vec<i32>{} } };
+    o.box.v.push(1);
+    return 0;
+}

--- a/w0/test/error_const_binding_field_index.w
+++ b/w0/test/error_const_binding_field_index.w
@@ -1,0 +1,12 @@
+// ERROR TEST: const binding prevents index write through field access
+// Expected error: Cannot write to index of const 'v'
+
+struct Box {
+    v: Vec<i32>,
+}
+
+func main(): i32 {
+    const b = new Box { v: new Vec<i32>{} };
+    b.v[0] = 5;
+    return 0;
+}

--- a/w0/test/error_const_binding_field_method.w
+++ b/w0/test/error_const_binding_field_method.w
@@ -1,0 +1,12 @@
+// ERROR TEST: const binding prevents mutating method through field access
+// Expected error: Cannot call mutating method 'push' on const 'v'
+
+struct Box {
+    v: Vec<i32>,
+}
+
+func main(): i32 {
+    const b = new Box { v: new Vec<i32>{} };
+    b.v.push(1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- propagate `is_const_access` through struct member access when the object is const
- preserve existing field-level const behavior by combining `field_is_const || object_is_const`
- allow transitive propagation across nested member chains

## Tests
- add `error_const_binding_field_method.w`
- add `error_const_binding_field_index.w`
- add `error_const_binding_field_chain_method.w`
- add `const_binding_field_const_method.w`
- run `cd w0 && make`
- run `cd w0 && ./scripts/run_tests.sh --valid --errors`

Closes #142