### PR TITLE
feat: allow explicit integer values on enum variants

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -99,7 +99,7 @@ Generic structs are monomorphized at compile time, generating specialized C code
 ```bnf
 <enum-decl>    ::= 'enum' <identifier> [ '<' <type-param-list> '>' ] '{' { <enum-variant> } '}'
 
-<enum-variant> ::= <identifier> [ '(' <type> { ',' <type> } ')' ] [ ',' ]
+<enum-variant> ::= <identifier> [ '(' <type> { ',' <type> } ')' ] [ '=' <integer-literal> ] [ ',' ]
 ```
 
 ### Trait Declaration

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -441,7 +441,9 @@ struct Node {
         struct {
             char*    name;
             int      name_length;
-            NodeList types; // payload type nodes (empty for simple variants)
+            NodeList types;         // payload type nodes (empty for simple variants)
+            long     int_value;     // explicit integer value (0 if not set)
+            int      has_int_value; // 1 if '= N' was specified
         } enum_variant;
 
         // Trait declaration

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1247,6 +1247,12 @@ static void check_enum_decl(Checker* checker, Node* node) {
         int type_count                           = val->as.enum_variant.types.count;
         enum_type->as.enm.variant_type_counts[i] = type_count;
 
+        if (val->as.enum_variant.has_int_value && type_count > 0) {
+            check_error(checker, val->line, val->column,
+                        "Enum variant with data cannot have explicit integer value");
+            continue;
+        }
+
         if (type_count > 0) {
             enum_type->as.enm.has_data         = 1;
             enum_type->as.enm.variant_types[i] = xmalloc(type_count * sizeof(Type*));

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -452,7 +452,7 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         if (strcmp(object->as.struc.field_names[i], member_name) == 0) {
             int object_is_const = 0;
             if (node->as.member.object->type == NODE_IDENT) {
-                Symbol* sym = checker_lookup(checker, node->as.member.object->as.ident.name);
+                Symbol* sym     = checker_lookup(checker, node->as.member.object->as.ident.name);
                 object_is_const = (sym && sym->is_const);
             } else if (node->as.member.object->type == NODE_MEMBER) {
                 object_is_const = node->as.member.object->as.member.is_const_access;

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -932,6 +932,8 @@ void emit_enum_typedefs(CodeGen* gen, Node* ast) {
                     emit_indent(gen);
                     emit(gen, "%s_%.*s", ename, var->as.enum_variant.name_length,
                          var->as.enum_variant.name);
+                    if (var->as.enum_variant.has_int_value)
+                        emit(gen, " = %ld", var->as.enum_variant.int_value);
                     if (v < value_count - 1)
                         emit(gen, ",");
                     emit(gen, "\n");
@@ -948,6 +950,8 @@ void emit_enum_typedefs(CodeGen* gen, Node* ast) {
                     emit_indent(gen);
                     emit(gen, "%s_%.*s", ename, var->as.enum_variant.name_length,
                          var->as.enum_variant.name);
+                    if (var->as.enum_variant.has_int_value)
+                        emit(gen, " = %ld", var->as.enum_variant.int_value);
                     if (v < value_count - 1)
                         emit(gen, ",");
                     emit(gen, "\n");
@@ -1030,6 +1034,8 @@ void emit_generic_enum_typedefs(CodeGen* gen, Node* ast) {
                 emit_indent(gen);
                 emit(gen, "%s_%.*s", ename, var->as.enum_variant.name_length,
                      var->as.enum_variant.name);
+                if (var->as.enum_variant.has_int_value)
+                    emit(gen, " = %ld", var->as.enum_variant.int_value);
                 if (v < value_count - 1)
                     emit(gen, ",");
                 emit(gen, "\n");
@@ -1045,6 +1051,8 @@ void emit_generic_enum_typedefs(CodeGen* gen, Node* ast) {
                 emit_indent(gen);
                 emit(gen, "%s_%.*s", ename, var->as.enum_variant.name_length,
                      var->as.enum_variant.name);
+                if (var->as.enum_variant.has_int_value)
+                    emit(gen, " = %ld", var->as.enum_variant.int_value);
                 if (v < value_count - 1)
                     emit(gen, ",");
                 emit(gen, "\n");

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1826,6 +1826,19 @@ static Node* parse_enum_decl(Parser* parser, int is_public) {
             consume_token(parser, TOK_RPAREN, "Expected ')' after variant types");
         }
 
+        // Check for explicit integer value: VariantName = 43
+        if (match_token(parser, TOK_EQ)) {
+            int negative = 0;
+            if (match_token(parser, TOK_MINUS))
+                negative = 1;
+            Token int_tok = parser->current;
+            consume_token(parser, TOK_INT, "Expected integer after '='");
+            char* endptr;
+            long  val                            = strtol(int_tok.start, &endptr, 10);
+            value->as.enum_variant.int_value     = negative ? -val : val;
+            value->as.enum_variant.has_int_value = 1;
+        }
+
         nodelist_push(&node->as.enum_decl.values, value);
 
         if (!check_token(parser, TOK_RBRACE)) {

--- a/w0/test/errors/error_enum_int_data.w
+++ b/w0/test/errors/error_enum_int_data.w
@@ -1,0 +1,8 @@
+enum Bad {
+    Foo(i32) = 1,
+}
+
+func main(): i32 {
+    return 0;
+}
+// Expected error: Enum variant with data cannot have explicit integer value

--- a/w0/test/valid/enum_int_values.w
+++ b/w0/test/valid/enum_int_values.w
@@ -1,0 +1,11 @@
+enum Ascii {
+    A = 65,
+    B = 66,
+    Plus = 43,
+    Space = 32,
+}
+
+func main(): i32 {
+    var a = Ascii::Plus;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `Variant = N` syntax to assign explicit integer values to enum variants (e.g. `Plus = 43` for ASCII codes)
- Parser accepts optional `= <integer>` (including negative) after variant name/payload types
- Checker rejects combining data payloads with explicit integer values
- Codegen emits `= N` in the C enum typedef for simple enums, data enum tags, and generic enums

Closes #94

## Test plan
- [x] `make` builds cleanly with no warnings
- [x] `make test` — all 177 tests pass (102 valid, 63 error, 12 RC runtime)
- [x] New valid test `enum_int_values.w` — enum with explicit values (A=65, Plus=43, etc.)
- [x] New error test `error_enum_int_data.w` — rejects `Foo(i32) = 1`
- [x] Manual verification: generated C output contains `Ascii_Plus = 43`

🤖 Generated with [Claude Code](https://claude.com/claude-code)