### PR TITLE
feat(prelude): add implicit prelude module with Option, Result, Drop

### DIFF
--- a/lib/prelude.w
+++ b/lib/prelude.w
@@ -1,0 +1,16 @@
+// Whist prelude — implicitly imported into every compilation unit.
+// Provides fundamental types and traits without requiring explicit import.
+
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+trait Drop {
+    func drop(): void;
+}

--- a/lib/std.w
+++ b/lib/std.w
@@ -1,9 +1,5 @@
 // Standard library for Whist
-
-enum Result<T, E> {
-    Ok(T),
-    Err(E),
-}
+// Note: Result<T, E> is now provided by the prelude (auto-imported).
 
 private extern stdio {
     func printf(fmt: string, ...): i32;

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -179,6 +179,7 @@ void checker_free(Checker* checker) {
         }
         free(checker->generics.defs[i].type_params);
         free(checker->generics.defs[i].type_param_bounds);
+        free((void*)checker->generics.defs[i].source_module);
         // Note: methods array contains pointers to AST nodes, don't free them
         free(checker->generics.defs[i].methods);
     }
@@ -230,6 +231,10 @@ Symbol* checker_define(Checker* checker, const char* name, SymbolKind kind, Type
     // Check for redefinition in current scope
     for (Symbol* sym = scope->symbols[index]; sym; sym = sym->next) {
         if (strcmp(sym->name, name) == 0) {
+            // Allow shadowing prelude symbols
+            if (sym->source_module && strcmp(sym->source_module, "prelude") == 0) {
+                continue;
+            }
             return NULL; // Already defined
         }
     }
@@ -250,6 +255,11 @@ Symbol* checker_define(Checker* checker, const char* name, SymbolKind kind, Type
 static int is_module_accessible(Checker* checker, const char* source_module) {
     // NULL source_module means same module - always accessible
     if (!source_module) {
+        return 1;
+    }
+
+    // Prelude symbols are always accessible from any context
+    if (strcmp(source_module, "prelude") == 0) {
         return 1;
     }
 
@@ -280,6 +290,11 @@ static int is_module_accessible(Checker* checker, const char* source_module) {
 
 // Check if a name is a directly imported library module
 int is_imported_module(Checker* checker, const char* name) {
+    // Prelude is always considered imported
+    if (strcmp(name, "prelude") == 0) {
+        return 1;
+    }
+
     // Use current function's accessible modules if set, otherwise use global direct_imports
     char** modules = checker->modules.current_accessible_modules;
     int    count   = checker->modules.current_accessible_modules_count;
@@ -326,13 +341,15 @@ Symbol* checker_lookup(Checker* checker, const char* name) {
                 if (!is_module_accessible(checker, sym->source_module)) {
                     continue; // Symbol exists but not accessible from this module
                 }
+                // Prelude symbols are accessible without module qualification
+                int is_prelude = sym->source_module && strcmp(sym->source_module, "prelude") == 0;
                 // Symbols from library imports require module qualification
                 // Skip them here - they must be accessed via module.symbol syntax
                 int same_module =
                     (sym->source_module == NULL && checker->modules.current_module == NULL) ||
                     (sym->source_module && checker->modules.current_module &&
                      strcmp(sym->source_module, checker->modules.current_module) == 0);
-                if (sym->source_module && !same_module) {
+                if (sym->source_module && !same_module && !is_prelude) {
                     continue; // Library symbol - require module qualification
                 }
                 return sym;
@@ -1235,11 +1252,16 @@ static void check_func_decl(Checker* checker, Node* node) {
 }
 
 // Type-check a struct declaration: resolve fields, detect RC fields, or register generic template
+static int is_prelude_symbol(Symbol* sym) {
+    return sym && sym->source_module && strcmp(sym->source_module, "prelude") == 0;
+}
+
 static void check_struct_decl(Checker* checker, Node* node) {
     const char* name = node->as.struct_decl.name;
 
-    // Check for redefinition
-    if (checker_lookup(checker, name)) {
+    // Check for redefinition (allow shadowing prelude symbols)
+    Symbol* existing = checker_lookup(checker, name);
+    if (existing && !is_prelude_symbol(existing)) {
         check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
         return;
     }
@@ -1287,7 +1309,9 @@ static void check_enum_decl(Checker* checker, Node* node) {
     const char* name        = node->as.enum_decl.name;
     int         value_count = node->as.enum_decl.values.count;
 
-    if (checker_lookup(checker, name)) {
+    // Check for redefinition (allow shadowing prelude symbols)
+    Symbol* existing = checker_lookup(checker, name);
+    if (existing && !is_prelude_symbol(existing)) {
         check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
         return;
     }
@@ -1354,8 +1378,9 @@ static void check_enum_decl(Checker* checker, Node* node) {
 static void check_trait_decl(Checker* checker, Node* node) {
     const char* name = node->as.trait_decl.name;
 
-    // Check for redefinition
-    if (checker_lookup(checker, name)) {
+    // Check for redefinition (allow shadowing prelude symbols)
+    Symbol* existing = checker_lookup(checker, name);
+    if (existing && !is_prelude_symbol(existing)) {
         check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
         return;
     }

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -49,12 +49,13 @@ typedef struct {
 
 // Generic struct definition (template)
 typedef struct {
-    char*  name;              // "Box", "Pair"
-    char** type_params;       // ["T"] or ["K", "V"]
-    char** type_param_bounds; // Trait bounds (NULL entries = unbounded)
-    int    type_param_count;
-    Node*  decl;          // Original AST node for field type resolution
-    int    is_type_alias; // 1 if this is a generic type alias, 0 for struct/enum
+    char*       name;              // "Box", "Pair"
+    char**      type_params;       // ["T"] or ["K", "V"]
+    char**      type_param_bounds; // Trait bounds (NULL entries = unbounded)
+    int         type_param_count;
+    Node*       decl;          // Original AST node for field type resolution
+    int         is_type_alias; // 1 if this is a generic type alias, 0 for struct/enum
+    const char* source_module; // "prelude" or NULL — for shadowing support
     // Methods on the generic struct
     Node** methods; // Array of NODE_FUNC_DECL
     int    method_count;

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -10,11 +10,10 @@
 // Generic struct helpers
 // =============================================================================
 
-// Register a generic struct definition
-void register_generic_def(Checker* checker, const char* name, char** type_params,
-                          char** type_param_bounds, int type_param_count, Node* decl) {
-    VEC_GROW(checker->generics.defs, checker->generics.def_count, checker->generics.def_capacity);
-    GenericDef* def        = &checker->generics.defs[checker->generics.def_count++];
+// Initialize a GenericDef entry with the given parameters
+static void init_generic_def(GenericDef* def, const char* name, char** type_params,
+                             char** type_param_bounds, int type_param_count, Node* decl,
+                             const char* source_module) {
     def->name              = xstrdup(name);
     def->type_params       = xmalloc(type_param_count * sizeof(char*));
     def->type_param_bounds = xmalloc(type_param_count * sizeof(char*));
@@ -26,9 +25,49 @@ void register_generic_def(Checker* checker, const char* name, char** type_params
     def->type_param_count = type_param_count;
     def->decl             = decl;
     def->is_type_alias    = 0;
+    def->source_module    = source_module ? xstrdup(source_module) : NULL;
     def->methods          = NULL;
     def->method_count     = 0;
     def->method_capacity  = 0;
+}
+
+// Free the owned fields of a GenericDef (but not the struct itself)
+static void free_generic_def_fields(GenericDef* def) {
+    free(def->name);
+    for (int j = 0; j < def->type_param_count; j++) {
+        free(def->type_params[j]);
+        free(def->type_param_bounds[j]);
+    }
+    free(def->type_params);
+    free(def->type_param_bounds);
+    free((void*)def->source_module);
+    free(def->methods);
+}
+
+// Register a generic struct definition
+void register_generic_def(Checker* checker, const char* name, char** type_params,
+                          char** type_param_bounds, int type_param_count, Node* decl) {
+    const char* source_module = checker->modules.current_module;
+
+    // Check if a prelude entry with the same name exists and replace it
+    for (int i = 0; i < checker->generics.def_count; i++) {
+        if (strcmp(checker->generics.defs[i].name, name) == 0) {
+            if (checker->generics.defs[i].source_module &&
+                strcmp(checker->generics.defs[i].source_module, "prelude") == 0) {
+                // Replace prelude definition with user's
+                free_generic_def_fields(&checker->generics.defs[i]);
+                init_generic_def(&checker->generics.defs[i], name, type_params, type_param_bounds,
+                                 type_param_count, decl, source_module);
+                return;
+            }
+            return; // Already registered (non-prelude), skip
+        }
+    }
+
+    VEC_GROW(checker->generics.defs, checker->generics.def_count, checker->generics.def_capacity);
+    GenericDef* def = &checker->generics.defs[checker->generics.def_count++];
+    init_generic_def(def, name, type_params, type_param_bounds, type_param_count, decl,
+                     source_module);
 }
 
 // Register a method on a generic struct definition

--- a/w0/module_loader.c
+++ b/w0/module_loader.c
@@ -193,16 +193,22 @@ int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, No
 
     // Track file-level and root-level imports
     if (!is_relative) {
-        add_file_import(loader, module_name, module_length);
         if (loader->import_depth == 0) {
             module_loader_add_direct_import(loader, module_name, module_length);
         }
     }
 
     // Parse the imported file with the shared loader.
-    // Save/restore file_imports so each file sees only its own imports.
-    int saved_file_imports_count = loader->file_imports_count;
-    loader->file_imports_count   = 0;
+    // Save/restore the entire file_imports array so each file sees only its own
+    // imports. Saving just the count is insufficient because sub-parses overwrite
+    // array entries at the same indices.
+    char** saved_file_imports          = loader->file_imports;
+    int    saved_file_imports_count    = loader->file_imports_count;
+    int    saved_file_imports_capacity = loader->file_imports_capacity;
+
+    loader->file_imports          = NULL;
+    loader->file_imports_count    = 0;
+    loader->file_imports_capacity = 0;
 
     Parser import_parser;
     parser_init_with_loader(&import_parser, source, path, loader);
@@ -211,11 +217,20 @@ int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, No
     Node* import_ast = parser_parse(&import_parser);
     loader->import_depth--;
 
-    // Free sub-file's file_imports entries and restore
+    // Free sub-file's file_imports and restore parent's
     for (int i = 0; i < loader->file_imports_count; i++) {
         free(loader->file_imports[i]);
     }
-    loader->file_imports_count = saved_file_imports_count;
+    free(loader->file_imports);
+
+    loader->file_imports          = saved_file_imports;
+    loader->file_imports_count    = saved_file_imports_count;
+    loader->file_imports_capacity = saved_file_imports_capacity;
+
+    // Add this module to the current file's imports
+    if (!is_relative) {
+        add_file_import(loader, module_name, module_length);
+    }
 
     if (import_parser.had_error) {
         fprintf(stderr, "Failed to parse imported file: %s\n", path);
@@ -264,4 +279,19 @@ int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, No
 
     node_free(import_ast);
     return 1;
+}
+
+void module_loader_import_prelude(ModuleLoader* loader, Parser* parser, Node* program,
+                                  Node* main_module) {
+    if (!loader || !loader->lib_path) {
+        return;
+    }
+
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/prelude.w", loader->lib_path);
+    if (!module_loader_file_exists(path)) {
+        return;
+    }
+
+    module_loader_import(loader, parser, program, main_module, "prelude", 7, 0);
 }

--- a/w0/module_loader.h
+++ b/w0/module_loader.h
@@ -56,4 +56,8 @@ void module_loader_build_path(ModuleLoader* loader, const char* source_path, cha
 int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, Node* current_module,
                          const char* module_name, size_t module_length, int is_relative);
 
+// Auto-import the prelude module (if lib_path is set and prelude.w exists)
+void module_loader_import_prelude(ModuleLoader* loader, Parser* parser, Node* program,
+                                  Node* main_module);
+
 #endif // MODULE_LOADER_H

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -2166,6 +2166,13 @@ Node* parser_parse(Parser* parser) {
     main_module->as.module.name        = xstrdup("main");
     main_module->as.module.name_length = 4;
     nodelist_init(&main_module->as.module.decls);
+
+    // Auto-import prelude before adding main module, so prelude types
+    // are defined first in the checker (main module can then shadow them)
+    if (parser->loader) {
+        module_loader_import_prelude(parser->loader, parser, program, main_module);
+    }
+
     nodelist_push(&program->as.program.modules, main_module);
 
     while (!check_token(parser, TOK_EOF)) {

--- a/w0/test/prelude_basic.w
+++ b/w0/test/prelude_basic.w
@@ -1,0 +1,43 @@
+// Test that prelude types are available without import or local definition
+
+func maybe_parse(s: string): Option<i64> {
+    if (s == "42") {
+        return Option::Some(42);
+    }
+    return Option::None;
+}
+
+func try_parse(s: string): Result<i64, string> {
+    if (s == "42") {
+        return Result::Ok(42);
+    }
+    return Result::Err("bad");
+}
+
+func main(): i32 {
+    var opt = maybe_parse("42");
+    match (opt) {
+        Some(val) => {
+            if (val != 42) {
+                return 1;
+            }
+        },
+        None => {
+            return 2;
+        },
+    }
+
+    var res = try_parse("abc");
+    match (res) {
+        Ok(val) => {
+            return 3;
+        },
+        Err(msg) => {
+            if (msg != "bad") {
+                return 4;
+            }
+        },
+    }
+
+    return 0;
+}

--- a/w0/test/prelude_shadow.w
+++ b/w0/test/prelude_shadow.w
@@ -1,0 +1,21 @@
+// Test that local definitions shadow prelude types
+
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+trait Drop {
+    func drop(): void;
+}
+
+func main(): i32 {
+    var x: Option<i64> = Option::Some(42);
+    var y: Result<i64, string> = Result::Ok(1);
+    return 0;
+}

--- a/w0/test/std_result.w
+++ b/w0/test/std_result.w
@@ -1,4 +1,4 @@
-// Test std.Result<T, E> — return Ok and Err, match on both
+// Test Result<T, E> from prelude — return Ok and Err, match on both
 import std;
 
 func parse_number(s: string): Result<i64, string> {


### PR DESCRIPTION
## Summary

Implements Phase 2 of the builtins restructuring plan (#161): an implicit prelude module that is auto-imported into every compilation unit when `--lib-path` is set.

- **`lib/prelude.w`** provides `Option<T>`, `Result<T,E>`, and `Drop` trait — available without explicit import or local definition
- Prelude symbols are accessible without module qualification (no `prelude.Result` needed)
- User definitions shadow prelude types seamlessly (all 27 existing tests that define Option/Result/Drop locally continue to pass)
- `Result<T,E>` moved from `lib/std.w` to the prelude — no longer requires `import std;`
- Fixed a latent use-after-free bug in `module_loader` `file_imports` save/restore (exposed by the prelude's recursive sub-parse)

## Test plan

- [x] `make test` — all 193/193 tests pass (111 valid + 69 error + 13 RC runtime)
- [x] New `prelude_basic.w` — Option and Result work without import or local definition
- [x] New `prelude_shadow.w` — local Option/Result/Drop definitions shadow prelude
- [x] `std_result.w` — Result still works (now from prelude instead of std)
- [x] ASAN clean — no memory errors with AddressSanitizer

Closes #161