### PR TITLE
feat(vec): add reserve and shrink_to_fit methods

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -358,7 +358,7 @@ static Type* check_member_enum(Checker* checker, Node* node, Type* object) {
     return type_error;
 }
 
-// Check Vec member access (count, capacity, data, push, pop, clear)
+// Check Vec member access (count, capacity, data, push, pop, clear, reserve, shrink_to_fit)
 static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
     const char* member_name = node->as.member.name;
     sem_info_set_member_is_ref(checker->sem, node, 1); // Vec is a pointer (RC-managed)
@@ -374,9 +374,10 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
         check_error(checker, node->line, node->column, "Vec 'data' field is private; use indexing");
         return type_error;
     }
-    // Methods: push, pop, clear
+    // Methods: push, pop, clear, reserve, shrink_to_fit
     if (strcmp(member_name, "push") == 0 || strcmp(member_name, "pop") == 0 ||
-        strcmp(member_name, "clear") == 0) {
+        strcmp(member_name, "clear") == 0 || strcmp(member_name, "reserve") == 0 ||
+        strcmp(member_name, "shrink_to_fit") == 0) {
         const char* const_name = get_const_binding_name(checker, node->as.member.object);
         if (const_name) {
             check_error(checker, node->line, node->column,
@@ -395,6 +396,11 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
         }
         if (strcmp(member_name, "pop") == 0) {
             return type_func(NULL, 0, elem_type, 0);
+        }
+        if (strcmp(member_name, "reserve") == 0) {
+            Type** params = xmalloc(1 * sizeof(Type*));
+            params[0]     = type_int64;
+            return type_func(params, 1, type_void, 0);
         }
         // clear
         return type_func(NULL, 0, type_void, 0);

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -394,7 +394,8 @@ void emit_struct_rc_dec_forward_decls(CodeGen* gen, Node* ast) {
     emit(gen, "\n");
 }
 
-// Emit push, pop, and clear method implementations for each Vec type instance
+// Emit push, pop, clear, reserve, and shrink_to_fit method implementations for each Vec type
+// instance
 void emit_vec_methods(CodeGen* gen) {
     for (int i = 0; i < gen->checker.vec_count; i++) {
         VecInstance* inst        = &gen->checker.vecs[i];
@@ -415,6 +416,21 @@ void emit_vec_methods(CodeGen* gen) {
         emit(gen, "    }\n");
         emit(gen, "    self->data[self->count] = value;\n");
         emit(gen, "    self->count++;\n");
+        emit(gen, "}\n\n");
+
+        // Reserve
+        emit(gen, "static inline void __Vec_%s_reserve(__Vec_%s* self, int64_t additional) {\n",
+             elem_tname, elem_tname);
+        emit(gen, "    if (additional <= 0) {\n");
+        emit(gen, "        return;\n");
+        emit(gen, "    }\n");
+        emit(gen, "    int64_t required = self->count + additional;\n");
+        emit(gen, "    if (required > self->capacity) {\n");
+        emit(gen, "        self->data = realloc(self->data, required * sizeof(");
+        emit_resolved_type(gen, elem_type);
+        emit(gen, "));\n");
+        emit(gen, "        self->capacity = required;\n");
+        emit(gen, "    }\n");
         emit(gen, "}\n\n");
 
         // Pop
@@ -445,6 +461,23 @@ void emit_vec_methods(CodeGen* gen) {
             emit(gen, "    }\n");
         }
         emit(gen, "    self->count = 0;\n");
+        emit(gen, "}\n\n");
+
+        // Shrink to fit
+        emit(gen, "static inline void __Vec_%s_shrink_to_fit(__Vec_%s* self) {\n", elem_tname,
+             elem_tname);
+        emit(gen, "    if (self->capacity > self->count) {\n");
+        emit(gen, "        if (self->count == 0) {\n");
+        emit(gen, "            free(self->data);\n");
+        emit(gen, "            self->data = NULL;\n");
+        emit(gen, "            self->capacity = 0;\n");
+        emit(gen, "            return;\n");
+        emit(gen, "        }\n");
+        emit(gen, "        self->data = realloc(self->data, self->count * sizeof(");
+        emit_resolved_type(gen, elem_type);
+        emit(gen, "));\n");
+        emit(gen, "        self->capacity = self->count;\n");
+        emit(gen, "    }\n");
         emit(gen, "}\n\n");
     }
 }

--- a/w0/test/error_const_vec_reserve.w
+++ b/w0/test/error_const_vec_reserve.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot reserve on const Vec
+// Expected error: Cannot call mutating method 'reserve' on const 'v'
+
+func main(): i32 {
+    const v = new Vec<i64>{};
+    v.reserve(1);
+    return 0;
+}

--- a/w0/test/error_const_vec_shrink_to_fit.w
+++ b/w0/test/error_const_vec_shrink_to_fit.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot shrink_to_fit on const Vec
+// Expected error: Cannot call mutating method 'shrink_to_fit' on const 'v'
+
+func main(): i32 {
+    const v = new Vec<i64>{1, 2, 3};
+    v.shrink_to_fit();
+    return 0;
+}

--- a/w0/test/vec_reserve_shrink.w
+++ b/w0/test/vec_reserve_shrink.w
@@ -1,0 +1,57 @@
+// Test Vec reserve and shrink_to_fit behavior
+
+func main(): i32 {
+    var nums = new Vec<i64>{1, 2, 3};
+
+    if (nums.capacity != 4) {
+        return 1;
+    }
+
+    nums.reserve(5);
+    if (nums.count != 3) {
+        return 2;
+    }
+    if (nums.capacity != 8) {
+        return 3;
+    }
+
+    nums.reserve(0);
+    if (nums.capacity != 8) {
+        return 4;
+    }
+
+    nums.push(4);
+    nums.push(5);
+    nums.push(6);
+    nums.push(7);
+    nums.push(8);
+    if (nums.count != 8) {
+        return 5;
+    }
+    if (nums.capacity != 8) {
+        return 6;
+    }
+
+    nums.pop();
+    nums.pop();
+    nums.pop();
+    if (nums.count != 5) {
+        return 7;
+    }
+
+    nums.shrink_to_fit();
+    if (nums.capacity != 5) {
+        return 8;
+    }
+    if (nums[4] != 5) {
+        return 9;
+    }
+
+    nums.clear();
+    nums.shrink_to_fit();
+    if (nums.capacity != 0) {
+        return 10;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `Vec.reserve(additional)` as a mutating instance method with `i64` parameter
- add `Vec.shrink_to_fit()` as a mutating instance method
- emit `__Vec_T_reserve` and `__Vec_T_shrink_to_fit` for all instantiated vec element types
- enforce const safety for both methods in member checking

## Tests
- add `w0/test/vec_reserve_shrink.w`
- add `w0/test/error_const_vec_reserve.w`
- add `w0/test/error_const_vec_shrink_to_fit.w`
- run `cd w0 && make && ./scripts/run_tests.sh --valid --errors` (196/196 passing)

Closes #110