### PR TITLE
feat(vec): add first() and last() methods returning Option<T>

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -358,8 +358,8 @@ static Type* check_member_enum(Checker* checker, Node* node, Type* object) {
     return type_error;
 }
 
-// Check Vec member access (count, capacity, data, push, pop, insert, remove, swap_remove,
-// clear, reserve, shrink_to_fit)
+// Check Vec member access (count, capacity, data, first, last, push, pop, insert, remove,
+// swap_remove, clear, reserve, shrink_to_fit)
 static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
     const char* member_name = node->as.member.name;
     sem_info_set_member_is_ref(checker->sem, node, 1); // Vec is a pointer (RC-managed)
@@ -375,7 +375,29 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
         check_error(checker, node->line, node->column, "Vec 'data' field is private; use indexing");
         return type_error;
     }
-    // Methods: push, pop, insert, remove, swap_remove, clear, reserve, shrink_to_fit
+    // Non-mutating methods: first, last (return Option<T>)
+    if (strcmp(member_name, "first") == 0 || strcmp(member_name, "last") == 0) {
+        char mangled[256];
+        snprintf(mangled, sizeof(mangled), "__Vec_%s", type_mangle_name(elem_type));
+        sem_info_set_member_struct_name(checker->sem, node, mangled);
+
+        // Look up or instantiate Option<elem_type>
+        GenericDef* option_def          = lookup_generic_def(checker, "Option");
+        Type**      args                = xmalloc(sizeof(Type*));
+        args[0]                         = elem_type;
+        char*            option_mangled = type_mangle_generic("Option", args, 1);
+        GenericInstance* existing       = lookup_generic_instance(checker, option_mangled);
+        Type*            option_type;
+        if (existing) {
+            option_type = existing->type;
+            free(option_mangled);
+            free(args);
+        } else {
+            option_type = instantiate_generic_enum(checker, option_def, option_mangled, args, 1);
+        }
+        return type_func(NULL, 0, option_type, 0);
+    }
+    // Mutating methods: push, pop, insert, remove, swap_remove, clear, reserve, shrink_to_fit
     if (strcmp(member_name, "push") == 0 || strcmp(member_name, "pop") == 0 ||
         strcmp(member_name, "insert") == 0 || strcmp(member_name, "remove") == 0 ||
         strcmp(member_name, "swap_remove") == 0 || strcmp(member_name, "clear") == 0 ||

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -394,8 +394,8 @@ void emit_struct_rc_dec_forward_decls(CodeGen* gen, Node* ast) {
     emit(gen, "\n");
 }
 
-// Emit push, pop, insert, remove, swap_remove, clear, reserve, and shrink_to_fit method
-// implementations for each Vec type instance
+// Emit push, pop, insert, remove, swap_remove, clear, reserve, shrink_to_fit, first, and last
+// method implementations for each Vec type instance
 void emit_vec_methods(CodeGen* gen) {
     for (int i = 0; i < gen->checker.vec_count; i++) {
         VecInstance* inst        = &gen->checker.vecs[i];
@@ -548,6 +548,51 @@ void emit_vec_methods(CodeGen* gen) {
         emit(gen, "        self->capacity = self->count;\n");
         emit(gen, "    }\n");
         emit(gen, "}\n\n");
+
+        // First/Last — only emit if Option<elem_type> was instantiated (i.e. first/last used)
+        const char* option_tname = type_mangle_name(elem_type);
+        char        option_mangled[256];
+        snprintf(option_mangled, sizeof(option_mangled), "Option_%s", option_tname);
+        int has_option = 0;
+        for (int gi = 0; gi < gen->checker.instance_count; gi++) {
+            if (strcmp(gen->checker.instances[gi].mangled_name, option_mangled) == 0) {
+                has_option = 1;
+                break;
+            }
+        }
+        if (has_option) {
+            // First — returns Option<T>, Some(v[0]) if non-empty, None if empty
+            emit(gen, "static inline Option_%s __Vec_%s_first(__Vec_%s* self) {\n", option_tname,
+                 elem_tname, elem_tname);
+            emit(gen, "    if (self->count == 0) {\n");
+            emit(gen, "        return (Option_%s){.tag = Option_%s_None};\n", option_tname,
+                 option_tname);
+            emit(gen, "    }\n");
+            if (elem_is_ptr) {
+                emit(gen, "    __rc_inc(self->data[0]);\n");
+            }
+            emit(gen,
+                 "    return (Option_%s){.tag = Option_%s_Some, .Some = {.f0 = "
+                 "self->data[0]}};\n",
+                 option_tname, option_tname);
+            emit(gen, "}\n\n");
+
+            // Last — returns Option<T>, Some(v[count-1]) if non-empty, None if empty
+            emit(gen, "static inline Option_%s __Vec_%s_last(__Vec_%s* self) {\n", option_tname,
+                 elem_tname, elem_tname);
+            emit(gen, "    if (self->count == 0) {\n");
+            emit(gen, "        return (Option_%s){.tag = Option_%s_None};\n", option_tname,
+                 option_tname);
+            emit(gen, "    }\n");
+            if (elem_is_ptr) {
+                emit(gen, "    __rc_inc(self->data[self->count - 1]);\n");
+            }
+            emit(gen,
+                 "    return (Option_%s){.tag = Option_%s_Some, "
+                 ".Some = {.f0 = self->data[self->count - 1]}};\n",
+                 option_tname, option_tname);
+            emit(gen, "}\n\n");
+        }
     }
 }
 

--- a/w0/test/rc_runtime/rc_vec_first_last.w
+++ b/w0/test/rc_runtime/rc_vec_first_last.w
@@ -1,0 +1,45 @@
+// RC RUNTIME TEST: first/last on Vec of structs — no double-free or leaks
+
+struct Item {
+    value: i64,
+}
+
+func main(): i32 {
+    var items = new Vec<Item>{};
+    items.push(new Item { value: 10 });
+    items.push(new Item { value: 20 });
+    items.push(new Item { value: 30 });
+
+    // first() returns a copy with incremented RC
+    var f = items.first();
+    match (f) {
+        Some(item) => {
+            if (item.value != 10) { return 1; }
+        },
+        None => { return 2; },
+    }
+
+    // last() returns a copy with incremented RC
+    var l = items.last();
+    match (l) {
+        Some(item) => {
+            if (item.value != 30) { return 3; }
+        },
+        None => { return 4; },
+    }
+
+    // Vec still intact after first/last
+    if (items.count != 3) { return 5; }
+    if (items[0].value != 10) { return 6; }
+    if (items[2].value != 30) { return 7; }
+
+    // Empty vec of structs
+    var empty = new Vec<Item>{};
+    var ef = empty.first();
+    match (ef) {
+        Some(item) => { return 8; },
+        None => {},
+    }
+
+    return 0;
+}

--- a/w0/test/vec_first_last.w
+++ b/w0/test/vec_first_last.w
@@ -1,0 +1,57 @@
+// Test Vec first() and last() returning Option<T>
+
+func main(): i32 {
+    var nums = new Vec<i64>{10, 20, 30};
+
+    // first() on non-empty vec
+    var f = nums.first();
+    match (f) {
+        Some(val) => {
+            if (val != 10) { return 1; }
+        },
+        None => { return 2; },
+    }
+
+    // last() on non-empty vec
+    var l = nums.last();
+    match (l) {
+        Some(val) => {
+            if (val != 30) { return 3; }
+        },
+        None => { return 4; },
+    }
+
+    // Empty vec
+    var empty = new Vec<i64>{};
+
+    var ef = empty.first();
+    match (ef) {
+        Some(val) => { return 5; },
+        None => {},
+    }
+
+    var el = empty.last();
+    match (el) {
+        Some(val) => { return 6; },
+        None => {},
+    }
+
+    // Single element: first == last
+    var one = new Vec<i64>{42};
+    var of = one.first();
+    var ol = one.last();
+    match (of) {
+        Some(val) => {
+            if (val != 42) { return 7; }
+        },
+        None => { return 8; },
+    }
+    match (ol) {
+        Some(val) => {
+            if (val != 42) { return 9; }
+        },
+        None => { return 10; },
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `first()` and `last()` non-mutating methods to `Vec<T>` that return `Option<T>` — `Some(element)` if non-empty, `None` if empty
- Properly increments RC for pointer elements (structs/vecs) since both the Vec and caller hold a reference
- Safer alternative to direct indexing when the Vec might be empty

Closes #109

## Test plan
- [x] `make` builds without errors
- [x] `make test` — all 117 valid + 74 error tests pass, plus 2 new tests
- [x] `test/vec_first_last.w` — tests first/last on non-empty, empty, and single-element Vecs using `match`
- [x] `test/rc_runtime/rc_vec_first_last.w` — tests first/last on `Vec<Item>` with `--rc-debug` confirming correct refcounting (no leaks or double-free)