### PR TITLE
feat(prelude): add value(), expect(), value_or(), error() on Option and Result

### DIFF
--- a/lib/include/whist_runtime.h
+++ b/lib/include/whist_runtime.h
@@ -110,6 +110,12 @@ static inline void __w0_vec_check(int64_t count, int64_t idx, int line, int col)
     }
 }
 
+/* --- Panic --- */
+static inline void __whist_panic(const char* msg) {
+    fprintf(stderr, "Panic: %s\n", msg);
+    exit(1);
+}
+
 /* --- String helpers --- */
 static inline int64_t __String_length(const char* s) {
     return (int64_t)strlen(s);

--- a/lib/prelude.w
+++ b/lib/prelude.w
@@ -1,6 +1,10 @@
 // Whist prelude — implicitly imported into every compilation unit.
 // Provides fundamental types and traits without requiring explicit import.
 
+private extern whist_runtime {
+    func __whist_panic(msg: string): void as panic;
+}
+
 enum Option<T> {
     Some(T),
     None,
@@ -15,6 +19,31 @@ func (const Option<T>) has_value(): bool {
     match (self) {
         Some(_) => return true;
         None => return false;
+    }
+}
+
+func (const Option<T>) value(): T {
+    match (self) {
+        Some(v) => return v;
+        None => {
+            panic("Option.value() called on None");
+        }
+    }
+}
+
+func (const Option<T>) expect(msg: string): T {
+    match (self) {
+        Some(v) => return v;
+        None => {
+            panic(msg);
+        }
+    }
+}
+
+func (const Option<T>) value_or(def: T): T {
+    match (self) {
+        Some(v) => return v;
+        None => return def;
     }
 }
 
@@ -36,6 +65,40 @@ func (const Result<T, E>) is_err(): bool {
     match (self) {
         Ok(_) => return false;
         Err(_) => return true;
+    }
+}
+
+func (const Result<T, E>) value(): T {
+    match (self) {
+        Ok(v) => return v;
+        Err(_) => {
+            panic("Result.value() called on Err");
+        }
+    }
+}
+
+func (const Result<T, E>) expect(msg: string): T {
+    match (self) {
+        Ok(v) => return v;
+        Err(_) => {
+            panic(msg);
+        }
+    }
+}
+
+func (const Result<T, E>) value_or(def: T): T {
+    match (self) {
+        Ok(v) => return v;
+        Err(_) => return def;
+    }
+}
+
+func (const Result<T, E>) error(): E {
+    match (self) {
+        Ok(_) => {
+            panic("Result.error() called on Ok");
+        }
+        Err(e) => return e;
     }
 }
 

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -43,6 +43,7 @@ static void check_trait_decl(Checker* checker, Node* node);
 static void check_type_alias_decl(Checker* checker, Node* node);
 static void check_impl_decl(Checker* checker, Node* node);
 static void check_use_decl(Checker* checker, Node* node);
+static int  is_prelude_symbol(Symbol* sym);
 
 // =============================================================================
 // Utility functions
@@ -1132,8 +1133,9 @@ static void check_func_decl(Checker* checker, Node* node) {
         }
     }
 
-    // Check for redefinition
-    if (checker_lookup(checker, mangled_name)) {
+    // Check for redefinition (allow shadowing prelude symbols)
+    Symbol* existing = checker_lookup(checker, mangled_name);
+    if (existing && !is_prelude_symbol(existing)) {
         check_error(checker, node->line, node->column, "Redefinition of '%s'", mangled_name);
         free(mangled_name);
         return;

--- a/w0/test/prelude_value_methods.w
+++ b/w0/test/prelude_value_methods.w
@@ -1,0 +1,45 @@
+// Test type-checking for Option/Result extraction methods from prelude
+
+func test_option(): i32 {
+    var opt_some: Option<i64> = Option::Some(42);
+    var opt_none: Option<i64> = Option::None;
+
+    // value() returns T
+    var v1: i64 = opt_some.value();
+
+    // expect() returns T
+    var v2: i64 = opt_some.expect("should not panic");
+
+    // value_or() returns T
+    var v3: i64 = opt_none.value_or(99);
+
+    return 0;
+}
+
+func test_result(): i32 {
+    var res_ok: Result<i64, string> = Result::Ok(42);
+    var res_err: Result<i64, string> = Result::Err("bad");
+
+    // value() returns T
+    var v1: i64 = res_ok.value();
+
+    // expect() returns T
+    var v2: i64 = res_ok.expect("should not panic");
+
+    // value_or() returns T
+    var v3: i64 = res_err.value_or(99);
+
+    // error() returns E
+    var e1: string = res_err.error();
+
+    return 0;
+}
+
+func test_panic(): void {
+    // panic is available without import
+    // (not calling it here since --check only type-checks)
+}
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/rc_runtime/prelude_value_extract.w
+++ b/w0/test/rc_runtime/prelude_value_extract.w
@@ -1,0 +1,64 @@
+// Test Option/Result extraction methods at runtime
+
+func main(): i32 {
+    // Option.value() on Some
+    var opt_some: Option<i64> = Option::Some(42);
+    if (opt_some.value() != 42) {
+        return 1;
+    }
+
+    // Option.expect() on Some
+    if (opt_some.expect("unreachable") != 42) {
+        return 2;
+    }
+
+    // Option.value_or() on Some returns inner value
+    if (opt_some.value_or(99) != 42) {
+        return 3;
+    }
+
+    // Option.value_or() on None returns default
+    var opt_none: Option<i64> = Option::None;
+    if (opt_none.value_or(99) != 99) {
+        return 4;
+    }
+
+    // Result.value() on Ok
+    var res_ok: Result<i64, string> = Result::Ok(100);
+    if (res_ok.value() != 100) {
+        return 5;
+    }
+
+    // Result.expect() on Ok
+    if (res_ok.expect("unreachable") != 100) {
+        return 6;
+    }
+
+    // Result.value_or() on Ok returns inner value
+    if (res_ok.value_or(0) != 100) {
+        return 7;
+    }
+
+    // Result.value_or() on Err returns default
+    var res_err: Result<i64, string> = Result::Err("bad");
+    if (res_err.value_or(0) != 0) {
+        return 8;
+    }
+
+    // Result.error() on Err
+    var res_err2: Result<i64, string> = Result::Err("error_msg");
+    var e: string = res_err2.error();
+
+    // Option with string type
+    var opt_str: Option<string> = Option::Some("hello");
+    if (opt_str.value_or("default") != "hello") {
+        return 10;
+    }
+
+    var opt_str_none: Option<string> = Option::None;
+    if (opt_str_none.value_or("default") != "default") {
+        return 11;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add extraction methods to prelude's `Option<T>` and `Result<T, E>`, complementing existing query methods (`has_value`, `is_ok`, `is_err`)
  - **Option\<T\>**: `value()`, `expect(msg)`, `value_or(def)`
  - **Result\<T, E\>**: `value()`, `expect(msg)`, `value_or(def)`, `error()`
- Add `__whist_panic` to the runtime, exposed as `panic()` in the prelude via extern alias — available without importing std
- Fix checker to allow library modules (e.g. std) to shadow prelude function symbols (matching existing behavior for types)

## Test plan

- [x] `make && make test` — 211/211 tests pass
- [x] `test/prelude_value_methods.w` — type-check validation for all new methods
- [x] `test/rc_runtime/prelude_value_extract.w` — runtime verification of correct extraction values

Closes #149