### PR TITLE
feat(std): add eprint and eprintln for stderr output

### DIFF
--- a/lib/include/std_io.h
+++ b/lib/include/std_io.h
@@ -1,0 +1,24 @@
+/*
+ * std_io.h — I/O helpers for the Whist standard library
+ *
+ * Functions use the std__ prefix (double underscore) to avoid
+ * colliding with the module-prefixed wrapper names (std_*) generated
+ * by the whist compiler.
+ *
+ * Usage: compile with -Ilib/include so #include <std_io.h> resolves.
+ */
+
+#ifndef WHIST_STD_IO_H
+#define WHIST_STD_IO_H
+
+#include <stdio.h>
+
+static inline void std__eprint(const char* s) {
+    fprintf(stderr, "%s", s);
+}
+
+static inline void std__eprintln(const char* s) {
+    fprintf(stderr, "%s\n", s);
+}
+
+#endif

--- a/lib/std.w
+++ b/lib/std.w
@@ -15,12 +15,25 @@ private extern std_args {
     func std__argv(i: i64): string;
 }
 
+private extern std_io {
+    func std__eprint(s: string): void;
+    func std__eprintln(s: string): void;
+}
+
 func print(s: string): void {
     printf("%s", s);
 }
 
 func println(s: string): void {
     printf("%s\n", s);
+}
+
+func eprint(s: string): void {
+    std__eprint(s);
+}
+
+func eprintln(s: string): void {
+    std__eprintln(s);
 }
 
 func exit(status: i32): void {

--- a/w0/test/std_stderr.w
+++ b/w0/test/std_stderr.w
@@ -1,0 +1,7 @@
+import std;
+
+func main(): i32 {
+    std.eprint("hello ");
+    std.eprintln("world");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `std.eprint(s)` and `std.eprintln(s)` for writing to stderr
- New `lib/include/std_io.h` C helper using `fprintf(stderr, ...)`
- Add test `w0/test/std_stderr.w`

Closes #88

## Test plan
- [x] All 219 tests pass
- [x] Runtime verified: output goes to stderr (stdout empty, stderr has content)
