### PR TITLE
feat(builtin): add StringBuilder type (#162)

### DIFF
--- a/lib/include/whist_runtime.h
+++ b/lib/include/whist_runtime.h
@@ -164,4 +164,76 @@ static inline const char* __std_format(const char* fmt, ...) {
     return buf;
 }
 
+/* --- StringBuilder --- */
+typedef struct {
+    char*   data;
+    int64_t count;
+    int64_t capacity;
+} __StringBuilder;
+
+static inline void __StringBuilder_append(__StringBuilder* self, const char* s) {
+    int64_t len = (int64_t)strlen(s);
+    if (self->count + len > self->capacity) {
+        int64_t new_cap = self->capacity == 0 ? 64 : self->capacity;
+        while (new_cap < self->count + len)
+            new_cap *= 2;
+        self->data     = (char*)realloc(self->data, new_cap + 1);
+        self->capacity = new_cap;
+    }
+    memcpy(self->data + self->count, s, len);
+    self->count += len;
+    self->data[self->count] = '\0';
+}
+
+static inline void __StringBuilder_append_char(__StringBuilder* self, char c) {
+    if (self->count + 1 > self->capacity) {
+        int64_t new_cap = self->capacity == 0 ? 64 : self->capacity * 2;
+        self->data      = (char*)realloc(self->data, new_cap + 1);
+        self->capacity  = new_cap;
+    }
+    self->data[self->count] = c;
+    self->count++;
+    self->data[self->count] = '\0';
+}
+
+static inline void __StringBuilder_append_line(__StringBuilder* self, const char* s) {
+    __StringBuilder_append(self, s);
+    __StringBuilder_append_char(self, '\n');
+}
+
+static inline int64_t __StringBuilder_len(__StringBuilder* self) {
+    return self->count;
+}
+
+static inline int64_t __StringBuilder_capacity(__StringBuilder* self) {
+    return self->capacity;
+}
+
+static inline void __StringBuilder_clear(__StringBuilder* self) {
+    self->count = 0;
+    if (self->data)
+        self->data[0] = '\0';
+}
+
+static inline const char* __StringBuilder_to_string(__StringBuilder* self) {
+    if (!self->data || self->count == 0) {
+        char* e = (char*)malloc(1);
+        e[0]    = '\0';
+        return e;
+    }
+    char* r = (char*)malloc(self->count + 1);
+    memcpy(r, self->data, self->count + 1);
+    return r;
+}
+
+static inline void __rc_dec_StringBuilder(__StringBuilder* ptr) {
+    if (!ptr)
+        return;
+    __RcHeader* h = (__RcHeader*)ptr - 1;
+    if (--h->refcount == 0) {
+        free(ptr->data);
+        free(h);
+    }
+}
+
 #endif /* WHIST_RUNTIME_H */

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -567,6 +567,58 @@ static Type* check_member_struct(Checker* checker, Node* node, Type* object) {
     return type_error;
 }
 
+// Check StringBuilder member access (append, append_char, append_line, len, capacity, clear,
+// to_string)
+static Type* check_member_stringbuilder(Checker* checker, Node* node) {
+    const char* member_name = node->as.member.name;
+    sem_info_set_member_is_ref(checker->sem, node, 1); // StringBuilder is RC-managed pointer
+    sem_info_set_member_struct_name(checker->sem, node, "__StringBuilder");
+
+    // Mutating methods
+    if (strcmp(member_name, "append") == 0 || strcmp(member_name, "append_line") == 0) {
+        const char* const_name = get_const_binding_name(checker, node->as.member.object);
+        if (const_name) {
+            check_error(checker, node->line, node->column,
+                        "Cannot call mutating method '%s' on const '%s'", member_name, const_name);
+            return type_error;
+        }
+        Type** params = xmalloc(1 * sizeof(Type*));
+        params[0]     = type_string;
+        return type_func(params, 1, type_void, 0);
+    }
+    if (strcmp(member_name, "append_char") == 0) {
+        const char* const_name = get_const_binding_name(checker, node->as.member.object);
+        if (const_name) {
+            check_error(checker, node->line, node->column,
+                        "Cannot call mutating method '%s' on const '%s'", member_name, const_name);
+            return type_error;
+        }
+        Type** params = xmalloc(1 * sizeof(Type*));
+        params[0]     = type_char;
+        return type_func(params, 1, type_void, 0);
+    }
+    if (strcmp(member_name, "clear") == 0) {
+        const char* const_name = get_const_binding_name(checker, node->as.member.object);
+        if (const_name) {
+            check_error(checker, node->line, node->column,
+                        "Cannot call mutating method '%s' on const '%s'", member_name, const_name);
+            return type_error;
+        }
+        return type_func(NULL, 0, type_void, 0);
+    }
+
+    // Non-mutating methods
+    if (strcmp(member_name, "len") == 0 || strcmp(member_name, "capacity") == 0) {
+        return type_func(NULL, 0, type_int64, 0);
+    }
+    if (strcmp(member_name, "to_string") == 0) {
+        return type_func(NULL, 0, type_string, 0);
+    }
+
+    check_error(checker, node->line, node->column, "StringBuilder has no member '%s'", member_name);
+    return type_error;
+}
+
 // Type-check a member access: dispatch to type-specific helpers
 static Type* check_member_expr(Checker* checker, Node* node) {
     // Check for module-qualified access first (e.g., std.print)
@@ -587,6 +639,8 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         return check_member_enum(checker, node, object);
     case TYPE_VEC:
         return check_member_vec(checker, node, object);
+    case TYPE_STRINGBUILDER:
+        return check_member_stringbuilder(checker, node);
     case TYPE_STRING: {
         Type* result = check_member_string(checker, node);
         if (result)
@@ -954,6 +1008,17 @@ static Type* check_new_expr(Checker* checker, Node* node) {
                 check_error_type(checker, field->line, field->column, "Vec element", elem_type,
                                  val_type);
             }
+        }
+        node->as.new_expr.resolved_type = resolved;
+        return resolved;
+    }
+    if (resolved->kind == TYPE_STRINGBUILDER) {
+        // new StringBuilder{} — no field inits allowed
+        Node* init = node->as.new_expr.init;
+        if (init->as.struct_init.fields.count > 0) {
+            check_error(checker, node->line, node->column,
+                        "StringBuilder does not accept field initializers");
+            return type_error;
         }
         node->as.new_expr.resolved_type = resolved;
         return resolved;

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -360,6 +360,9 @@ void emit_resolved_type(CodeGen* gen, Type* type) {
     case TYPE_VEC:
         emit(gen, "__Vec_%s*", type_mangle_name(type->as.vec.elem));
         break;
+    case TYPE_STRINGBUILDER:
+        emit(gen, "__StringBuilder*");
+        break;
     case TYPE_ENUM:
         emit(gen, "%s", type->as.enm.name);
         break;

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -639,6 +639,17 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
                 node->line);
         return;
     }
+    if (rtype->kind == TYPE_STRINGBUILDER) {
+        // new StringBuilder{} as inline expression using GCC statement expression
+        int tmp = gen->out.temp_count++;
+        emit(gen,
+             "({ __StringBuilder* __rc_tmp%d = (__StringBuilder*)__rc_alloc("
+             "sizeof(__StringBuilder)); "
+             "__rc_tmp%d->data = NULL; __rc_tmp%d->count = 0; __rc_tmp%d->capacity = 0; "
+             "__rc_tmp%d; })",
+             tmp, tmp, tmp, tmp, tmp);
+        return;
+    }
     if (rtype->kind == TYPE_VEC) {
         // new Vec<T>{elems} as inline expression using GCC statement expression
         const char* elem_tname = type_mangle_name(rtype->as.vec.elem);

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -42,6 +42,9 @@ const char* get_dec_func_for_type(Type* t) {
         snprintf(buf, len, "__rc_dec_%s", t->as.enm.name);
         return buf;
     }
+    if (t && t->kind == TYPE_STRINGBUILDER) {
+        return xstrdup("__rc_dec_StringBuilder");
+    }
     if (t && t->kind == TYPE_VEC) {
         const char* elem_tname = type_mangle_name(t->as.vec.elem);
         size_t      len        = strlen("__rc_dec_Vec_") + strlen(elem_tname) + 1;

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -229,6 +229,18 @@ static void emit_var_decl_rc_new_vec(CodeGen* gen, Node* node) {
     rc_push_var(gen, node->as.var_decl.name, dec_buf, rtype);
 }
 
+// Emit an RC-managed StringBuilder declaration: var sb = new StringBuilder{}
+static void emit_var_decl_rc_new_stringbuilder(CodeGen* gen, Node* node) {
+    emit_indent(gen);
+    emit(gen, "__StringBuilder* %s = (__StringBuilder*)__rc_alloc(sizeof(__StringBuilder));\n",
+         node->as.var_decl.name);
+    emit_indent(gen);
+    emit(gen, "%s->data = NULL; %s->count = 0; %s->capacity = 0;\n", node->as.var_decl.name,
+         node->as.var_decl.name, node->as.var_decl.name);
+    Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
+    rc_push_var(gen, node->as.var_decl.name, "__rc_dec_StringBuilder", rtype);
+}
+
 // Emit an RC-managed struct declaration: var p = new Point { x: 1, y: 2 }
 static void emit_var_decl_rc_new_struct(CodeGen* gen, Node* node) {
     Type*       rtype = node->as.var_decl.init->as.new_expr.resolved_type;
@@ -414,6 +426,8 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
             Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
             if (rtype && rtype->kind == TYPE_VEC) {
                 emit_var_decl_rc_new_vec(gen, node);
+            } else if (rtype && rtype->kind == TYPE_STRINGBUILDER) {
+                emit_var_decl_rc_new_stringbuilder(gen, node);
             } else {
                 emit_var_decl_rc_new_struct(gen, node);
             }

--- a/w0/test/error_stringbuilder_const.w
+++ b/w0/test/error_stringbuilder_const.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Cannot call mutating method on const StringBuilder
+// Expected error: Cannot call mutating method 'append' on const 'sb'
+
+func main(): i32 {
+    const sb = new StringBuilder{};
+    sb.append("x");
+    return 0;
+}

--- a/w0/test/error_stringbuilder_fields.w
+++ b/w0/test/error_stringbuilder_fields.w
@@ -1,0 +1,7 @@
+// ERROR TEST: StringBuilder does not accept field initializers
+// Expected error: StringBuilder does not accept field initializers
+
+func main(): i32 {
+    var sb = new StringBuilder{field: 1};
+    return 0;
+}

--- a/w0/test/rc_runtime/stringbuilder_basic.w
+++ b/w0/test/rc_runtime/stringbuilder_basic.w
@@ -1,0 +1,59 @@
+// RC RUNTIME TEST: StringBuilder basic operations
+
+import std;
+
+func main(): i32 {
+    var sb = new StringBuilder{};
+
+    // Test append
+    sb.append("hello");
+    sb.append_char(' ');
+    sb.append("world");
+
+    // Verify len
+    if (sb.len() != 11) {
+        return 1;
+    }
+
+    // Verify capacity >= len
+    if (sb.capacity() < 11) {
+        return 2;
+    }
+
+    // Verify to_string
+    var s: string = sb.to_string();
+    if (s != "hello world") {
+        return 3;
+    }
+
+    // Test append_line (appends string + newline)
+    sb.clear();
+    if (sb.len() != 0) {
+        return 4;
+    }
+
+    sb.append_line("line1");
+    sb.append("line2");
+    var s2: string = sb.to_string();
+    if (s2 != "line1\nline2") {
+        return 5;
+    }
+
+    // Test clear preserves capacity
+    var cap_before: i64 = sb.capacity();
+    sb.clear();
+    if (sb.len() != 0) {
+        return 6;
+    }
+    if (sb.capacity() != cap_before) {
+        return 7;
+    }
+
+    // Test to_string on empty builder
+    var empty: string = sb.to_string();
+    if (empty != "") {
+        return 8;
+    }
+
+    return 0;
+}

--- a/w0/test/stringbuilder.w
+++ b/w0/test/stringbuilder.w
@@ -1,0 +1,13 @@
+// Test StringBuilder: type-check basic operations
+
+func main(): i32 {
+    var sb = new StringBuilder{};
+    sb.append("hello");
+    sb.append_char(' ');
+    sb.append_line("world");
+    var s: string = sb.to_string();
+    var n: i64 = sb.len();
+    var c: i64 = sb.capacity();
+    sb.clear();
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -7,41 +7,43 @@
 #include "vec.h"
 
 // Built-in type singletons
-static Type builtin_void    = {TYPE_VOID, {{NULL}}};
-static Type builtin_bool    = {TYPE_BOOL, {{NULL}}};
-static Type builtin_int64   = {TYPE_INT64, {{NULL}}};
-static Type builtin_int8    = {TYPE_INT8, {{NULL}}};
-static Type builtin_int16   = {TYPE_INT16, {{NULL}}};
-static Type builtin_int32   = {TYPE_INT32, {{NULL}}};
-static Type builtin_uint64  = {TYPE_UINT64, {{NULL}}};
-static Type builtin_uint8   = {TYPE_UINT8, {{NULL}}};
-static Type builtin_uint16  = {TYPE_UINT16, {{NULL}}};
-static Type builtin_uint32  = {TYPE_UINT32, {{NULL}}};
-static Type builtin_f32     = {TYPE_F32, {{NULL}}};
-static Type builtin_f64     = {TYPE_F64, {{NULL}}};
-static Type builtin_char    = {TYPE_CHAR, {{NULL}}};
-static Type builtin_string  = {TYPE_STRING, {{NULL}}};
-static Type builtin_voidptr = {TYPE_VOIDPTR, {{NULL}}};
-static Type builtin_error   = {TYPE_ERROR, {{NULL}}};
-static Type builtin_null    = {TYPE_NULL, {{NULL}}};
+static Type builtin_void          = {TYPE_VOID, {{NULL}}};
+static Type builtin_bool          = {TYPE_BOOL, {{NULL}}};
+static Type builtin_int64         = {TYPE_INT64, {{NULL}}};
+static Type builtin_int8          = {TYPE_INT8, {{NULL}}};
+static Type builtin_int16         = {TYPE_INT16, {{NULL}}};
+static Type builtin_int32         = {TYPE_INT32, {{NULL}}};
+static Type builtin_uint64        = {TYPE_UINT64, {{NULL}}};
+static Type builtin_uint8         = {TYPE_UINT8, {{NULL}}};
+static Type builtin_uint16        = {TYPE_UINT16, {{NULL}}};
+static Type builtin_uint32        = {TYPE_UINT32, {{NULL}}};
+static Type builtin_f32           = {TYPE_F32, {{NULL}}};
+static Type builtin_f64           = {TYPE_F64, {{NULL}}};
+static Type builtin_char          = {TYPE_CHAR, {{NULL}}};
+static Type builtin_string        = {TYPE_STRING, {{NULL}}};
+static Type builtin_voidptr       = {TYPE_VOIDPTR, {{NULL}}};
+static Type builtin_stringbuilder = {TYPE_STRINGBUILDER, {{NULL}}};
+static Type builtin_error         = {TYPE_ERROR, {{NULL}}};
+static Type builtin_null          = {TYPE_NULL, {{NULL}}};
 
-Type* type_void    = &builtin_void;
-Type* type_bool    = &builtin_bool;
-Type* type_int64   = &builtin_int64;
-Type* type_int8    = &builtin_int8;
-Type* type_int16   = &builtin_int16;
-Type* type_int32   = &builtin_int32;
-Type* type_uint64  = &builtin_uint64;
-Type* type_uint8   = &builtin_uint8;
-Type* type_uint16  = &builtin_uint16;
-Type* type_uint32  = &builtin_uint32;
-Type* type_f32     = &builtin_f32;
-Type* type_f64     = &builtin_f64;
-Type* type_char    = &builtin_char;
-Type* type_string  = &builtin_string;
-Type* type_voidptr = &builtin_voidptr;
-Type* type_error   = &builtin_error;
-Type* type_null    = &builtin_null;
+Type* type_void          = &builtin_void;
+Type* type_bool          = &builtin_bool;
+Type* type_int64         = &builtin_int64;
+Type* type_int8          = &builtin_int8;
+Type* type_int16         = &builtin_int16;
+Type* type_int32         = &builtin_int32;
+Type* type_uint64        = &builtin_uint64;
+Type* type_uint8         = &builtin_uint8;
+Type* type_uint16        = &builtin_uint16;
+Type* type_uint32        = &builtin_uint32;
+Type* type_f32           = &builtin_f32;
+Type* type_f64           = &builtin_f64;
+Type* type_char          = &builtin_char;
+Type* type_string        = &builtin_string;
+Type* type_voidptr       = &builtin_voidptr;
+Type* type_stringbuilder = &builtin_stringbuilder;
+Type* type_error         = &builtin_error;
+Type* type_null          = &builtin_null;
 
 // Track allocated types for cleanup
 static Type** allocated_types    = NULL;
@@ -162,8 +164,8 @@ void type_free(Type* type) {
     if (type == type_void || type == type_bool || type == type_int64 || type == type_int8 ||
         type == type_int16 || type == type_int32 || type == type_uint64 || type == type_uint8 ||
         type == type_uint16 || type == type_uint32 || type == type_f32 || type == type_f64 ||
-        type == type_char || type == type_string || type == type_voidptr || type == type_error ||
-        type == type_null) {
+        type == type_char || type == type_string || type == type_voidptr ||
+        type == type_stringbuilder || type == type_error || type == type_null) {
         return;
     }
 
@@ -357,7 +359,7 @@ int type_supports_vec_sort(Type* type) {
 int type_is_rc_managed(Type* type) {
     if (!type)
         return 0;
-    if (type->kind == TYPE_STRUCT || type->kind == TYPE_VEC)
+    if (type->kind == TYPE_STRUCT || type->kind == TYPE_VEC || type->kind == TYPE_STRINGBUILDER)
         return 1;
     if (type->kind == TYPE_ENUM && type->as.enm.has_rc_fields)
         return 1;
@@ -390,6 +392,11 @@ int type_assignable(Type* target, Type* value) {
 
     // null can be assigned to vec references
     if (target->kind == TYPE_VEC && value->kind == TYPE_NULL) {
+        return 1;
+    }
+
+    // null can be assigned to StringBuilder references
+    if (target->kind == TYPE_STRINGBUILDER && value->kind == TYPE_NULL) {
         return 1;
     }
 
@@ -448,6 +455,8 @@ const char* type_name(Type* type) {
         return "string";
     case TYPE_VOIDPTR:
         return "voidptr";
+    case TYPE_STRINGBUILDER:
+        return "StringBuilder";
     case TYPE_ERROR:
         return "<error>";
     case TYPE_NULL:
@@ -516,14 +525,23 @@ static struct {
     Type**      type_ptr;
     const char* c_name;
 } builtin_types[] = {
-    {"void", &type_void, "void"},        {"bool", &type_bool, "bool"},
-    {"i64", &type_int64, "int64_t"},     {"i8", &type_int8, "int8_t"},
-    {"i16", &type_int16, "int16_t"},     {"i32", &type_int32, "int32_t"},
-    {"u64", &type_uint64, "uint64_t"},   {"u8", &type_uint8, "uint8_t"},
-    {"u16", &type_uint16, "uint16_t"},   {"u32", &type_uint32, "uint32_t"},
-    {"f32", &type_f32, "float"},         {"f64", &type_f64, "double"},
-    {"char", &type_char, "char"},        {"string", &type_string, "const char*"},
-    {"voidptr", &type_voidptr, "void*"}, {NULL, NULL, NULL},
+    {"void", &type_void, "void"},
+    {"bool", &type_bool, "bool"},
+    {"i64", &type_int64, "int64_t"},
+    {"i8", &type_int8, "int8_t"},
+    {"i16", &type_int16, "int16_t"},
+    {"i32", &type_int32, "int32_t"},
+    {"u64", &type_uint64, "uint64_t"},
+    {"u8", &type_uint8, "uint8_t"},
+    {"u16", &type_uint16, "uint16_t"},
+    {"u32", &type_uint32, "uint32_t"},
+    {"f32", &type_f32, "float"},
+    {"f64", &type_f64, "double"},
+    {"char", &type_char, "char"},
+    {"string", &type_string, "const char*"},
+    {"voidptr", &type_voidptr, "void*"},
+    {"StringBuilder", &type_stringbuilder, "__StringBuilder*"},
+    {NULL, NULL, NULL},
 };
 
 Type* type_builtin_from_name(const char* name) {
@@ -595,6 +613,8 @@ const char* type_mangle_name(Type* type) {
         return "string";
     case TYPE_VOIDPTR:
         return "voidptr";
+    case TYPE_STRINGBUILDER:
+        return "StringBuilder";
     case TYPE_SPAN: {
         char* buf = next_type_mangle_buf();
         snprintf(buf, 256, "Span_%s", type_mangle_name(type->as.span.elem));

--- a/w0/types.h
+++ b/w0/types.h
@@ -22,6 +22,7 @@ typedef enum {
     TYPE_ARRAY,
     TYPE_SPAN,
     TYPE_VEC,
+    TYPE_STRINGBUILDER,
     TYPE_STRUCT,
     TYPE_ENUM,
     TYPE_TRAIT,
@@ -141,6 +142,7 @@ extern Type* type_f64;
 extern Type* type_char;
 extern Type* type_string;
 extern Type* type_voidptr;
+extern Type* type_stringbuilder;
 extern Type* type_error;
 extern Type* type_null;
 


### PR DESCRIPTION
## Summary

- Add `StringBuilder` as a built-in RC-managed type for efficient string building via a growable buffer (amortized O(1) append vs O(n²) for string concatenation)
- Implement 7 methods: `append(string)`, `append_char(char)`, `append_line(string)`, `len()`, `capacity()`, `clear()`, `to_string()`
- Runtime implementation lives entirely in `whist_runtime.h` (non-generic, no per-program codegen needed)

Closes #162

## Changes

- **types.h/c**: Add `TYPE_STRINGBUILDER` enum, singleton, builtin table entry, RC-managed flag, null-assignable
- **checker_expr.c**: Method type-checking (`check_member_stringbuilder`), const mutation guards, `new StringBuilder{}` validation (rejects field initializers)
- **codegen_emit.c**: Emit `__StringBuilder*` C type
- **codegen_stmt.c**: Emit var decl with `__rc_alloc` + zero-init fields
- **codegen_expr.c**: Emit inline `new` via GCC statement expression
- **codegen_rc.c**: Map `TYPE_STRINGBUILDER` → `__rc_dec_StringBuilder`
- **whist_runtime.h**: `__StringBuilder` struct, 7 inline methods, `__rc_dec_StringBuilder` (frees data buffer + RC header). Doubling growth starting at 64 bytes.

## Test plan

- [x] `w0/test/stringbuilder.w` — type-check all operations pass
- [x] `w0/test/error_stringbuilder_const.w` — mutating const rejected
- [x] `w0/test/error_stringbuilder_fields.w` — field initializers rejected
- [x] `w0/test/rc_runtime/stringbuilder_basic.w` — compile+run: append, len, capacity, clear, to_string, append_line
- [x] Full test suite: 223/224 passing (1 pre-existing failure unrelated to this PR)