### PR TITLE
feat(checker): support Self type in traits and impl blocks

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -125,6 +125,7 @@ void checker_init(Checker* checker) {
     checker->traits.primitive_method_capacity = 0;
     checker->alias_depth                      = 0;
     checker->enum_target_hint                 = NULL;
+    checker->self_type                        = NULL;
     checker->sem                              = sem_info_new();
     types_init();
 }
@@ -1396,12 +1397,18 @@ static void check_trait_decl(Checker* checker, Node* node) {
     trait_type->as.trait.method_types    = xmalloc(method_count * sizeof(Type*));
     trait_type->as.trait.method_is_const = xmalloc(method_count * sizeof(int));
 
+    // Set Self to a generic param placeholder so trait method types store
+    // TYPE_GENERIC_PARAM("Self")
+    checker->self_type = type_generic_param("Self");
+
     for (int i = 0; i < method_count; i++) {
         Node* method                            = node->as.trait_decl.methods.nodes[i];
         trait_type->as.trait.method_names[i]    = xstrdup(method->as.func_decl.name);
         trait_type->as.trait.method_types[i]    = get_function_type(checker, method);
         trait_type->as.trait.method_is_const[i] = method->as.func_decl.receiver_is_const;
     }
+
+    checker->self_type = NULL;
 
     checker_define(checker, name, SYM_TYPE, trait_type, 0, node->as.trait_decl.is_public,
                    checker->modules.current_module);
@@ -1446,6 +1453,13 @@ static void check_type_alias_decl(Checker* checker, Node* node) {
                    checker->modules.current_module);
 }
 
+// Substitute TYPE_GENERIC_PARAM("Self") with the concrete implementing type
+static Type* substitute_self(Type* type, Type* concrete) {
+    if (type->kind == TYPE_GENERIC_PARAM && strcmp(type->as.generic_param.name, "Self") == 0)
+        return concrete;
+    return type;
+}
+
 // Type-check an impl block: verify methods match trait signatures and register trait impl
 static void check_impl_decl(Checker* checker, Node* node) {
     const char* trait_name    = node->as.impl_decl.trait_name;
@@ -1478,6 +1492,12 @@ static void check_impl_decl(Checker* checker, Node* node) {
             return;
         }
     }
+
+    // Set Self to the concrete implementing type for method body checking
+    if (is_primitive)
+        checker->self_type = type_builtin_from_name(type_name_str);
+    else if (!is_generic)
+        checker->self_type = type_sym->type;
 
     // Process each method in the impl block
     for (int i = 0; i < node->as.impl_decl.methods.count; i++) {
@@ -1523,13 +1543,13 @@ static void check_impl_decl(Checker* checker, Node* node) {
             Type* impl_func_type  = get_function_type(checker, method);
             Type* trait_func_type = trait_type->as.trait.method_types[trait_method_idx];
 
-            // Check return type
-            if (!type_equals(impl_func_type->as.func.return_type,
-                             trait_func_type->as.func.return_type)) {
+            // Check return type (substitute Self in trait signature with concrete type)
+            Type* trait_ret =
+                substitute_self(trait_func_type->as.func.return_type, checker->self_type);
+            if (!type_equals(impl_func_type->as.func.return_type, trait_ret)) {
                 check_error(checker, method->line, method->column,
                             "Method '%s' return type mismatch: trait '%s' expects '%s', got '%s'",
-                            method_name, trait_name,
-                            type_name(trait_func_type->as.func.return_type),
+                            method_name, trait_name, type_name(trait_ret),
                             type_name(impl_func_type->as.func.return_type));
                 continue;
             }
@@ -1544,14 +1564,14 @@ static void check_impl_decl(Checker* checker, Node* node) {
             }
 
             for (int p = 0; p < trait_func_type->as.func.param_count; p++) {
-                if (!type_equals(impl_func_type->as.func.param_types[p],
-                                 trait_func_type->as.func.param_types[p])) {
+                Type* trait_param =
+                    substitute_self(trait_func_type->as.func.param_types[p], checker->self_type);
+                if (!type_equals(impl_func_type->as.func.param_types[p], trait_param)) {
                     check_error(
                         checker, method->line, method->column,
                         "Method '%s' parameter %d type mismatch: trait '%s' expects '%s', got "
                         "'%s'",
-                        method_name, p + 1, trait_name,
-                        type_name(trait_func_type->as.func.param_types[p]),
+                        method_name, p + 1, trait_name, type_name(trait_param),
                         type_name(impl_func_type->as.func.param_types[p]));
                 }
             }
@@ -1588,6 +1608,8 @@ static void check_impl_decl(Checker* checker, Node* node) {
     if (strcmp(trait_name, "Drop") == 0 && !is_generic && !is_primitive) {
         type_sym->type->as.struc.has_drop = 1;
     }
+
+    checker->self_type = NULL;
 }
 
 // Check a use declaration: validate module, look up each symbol, and register unqualified alias

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -147,6 +147,10 @@ struct Checker {
     // Hint for generic enum type inference (set by var_decl when declared type is known)
     Type* enum_target_hint;
 
+    // Self type: set to TYPE_GENERIC_PARAM("Self") in trait decls,
+    // concrete implementing type in impl blocks; NULL otherwise.
+    Type* self_type;
+
     // Sidecar semantic metadata used by checker/codegen; owned by checker.
     SemInfo* sem;
 };

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -870,6 +870,15 @@ Type* resolve_type(Checker* checker, Node* type_node) {
         if (builtin)
             return builtin;
 
+        // Check for Self type (in trait definitions and impl blocks)
+        if (strcmp(name, "Self") == 0) {
+            if (checker->self_type)
+                return checker->self_type;
+            check_error(checker, type_node->line, type_node->column,
+                        "'Self' can only be used inside trait definitions and impl blocks");
+            return type_error;
+        }
+
         // Check for type parameter substitution (when instantiating generics)
         if (checker->generics.current_type_params) {
             for (int i = 0; i < checker->generics.current_type_param_count; i++) {

--- a/w0/test/errors/error_self_outside.w
+++ b/w0/test/errors/error_self_outside.w
@@ -1,0 +1,8 @@
+// Expected error: 'Self' can only be used inside trait definitions and impl blocks
+func foo(): Self {
+    return 0;
+}
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/valid/self_type.w
+++ b/w0/test/valid/self_type.w
@@ -1,0 +1,17 @@
+trait Clonable {
+    func clone(): Self;
+}
+
+struct Point { x: i64, y: i64 }
+
+impl Clonable for Point {
+    func clone(): Point {
+        return new Point { x: 10, y: 20 };
+    }
+}
+
+func main(): i32 {
+    var p = new Point { x: 1, y: 2 };
+    var q = p.clone();
+    return 0;
+}

--- a/w0/test/valid/self_type_param.w
+++ b/w0/test/valid/self_type_param.w
@@ -1,0 +1,18 @@
+trait Combinable {
+    func combine(other: Self): Self;
+}
+
+struct Counter { value: i64 }
+
+impl Combinable for Counter {
+    func combine(other: Counter): Counter {
+        return new Counter { value: 42 };
+    }
+}
+
+func main(): i32 {
+    var a = new Counter { value: 3 };
+    var b = new Counter { value: 7 };
+    var c = a.combine(b);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add `Self` as a usable type in trait method signatures (return types and parameter types) and impl blocks, resolving to the concrete implementing type during checking
- Uses `TYPE_GENERIC_PARAM("Self")` as a placeholder in trait method types, substituted with the concrete type during impl signature comparison
- No codegen changes needed — all `Self` references are resolved to concrete types by the checker

Closes #185

## Test plan

- [x] `make` builds successfully
- [x] `make test` passes (223/224; 1 pre-existing failure unrelated to this change)
- [x] `self_type.w` — Self as return type in trait, implemented by struct
- [x] `self_type_param.w` — Self as both parameter and return type
- [x] `error_self_outside.w` — Self outside trait/impl produces correct error
- [x] End-to-end compile and run of both valid tests