### PR TITLE
feat: add function pointer types

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -278,6 +278,10 @@ void node_free(Node* node) {
         free(node->as.generic_type.base_name);
         nodelist_free(&node->as.generic_type.type_args);
         break;
+    case NODE_FUNC_TYPE:
+        nodelist_free(&node->as.func_type.param_types);
+        node_free(node->as.func_type.return_type);
+        break;
     case NODE_PROGRAM:
         nodelist_free(&node->as.program.modules);
         break;
@@ -361,6 +365,7 @@ static void node_reset_checker_flags(Node* node) {
         node->as.member.is_const_access = 0;
         node->as.member.struct_name     = NULL;
         node->as.member.module_name     = NULL;
+        node->as.member.is_method_ref   = 0;
         break;
     case NODE_ENUM_VALUE:
         node->as.enum_value.is_data_enum = 0;
@@ -521,6 +526,10 @@ Node* node_clone(Node* node) {
         c->as.generic_type.base_name        = xstrdup(node->as.generic_type.base_name);
         c->as.generic_type.base_name_length = node->as.generic_type.base_name_length;
         c->as.generic_type.type_args        = nodelist_clone(&node->as.generic_type.type_args);
+        break;
+    case NODE_FUNC_TYPE:
+        c->as.func_type.param_types = nodelist_clone(&node->as.func_type.param_types);
+        c->as.func_type.return_type = node_clone(node->as.func_type.return_type);
         break;
     case NODE_EXPR_STMT:
         c->as.expr_stmt.expr = node_clone(node->as.expr_stmt.expr);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -100,6 +100,9 @@ typedef enum {
     // Generic types
     NODE_GENERIC_TYPE, // Box<i64>, Pair<K, V>
 
+    // Function type
+    NODE_FUNC_TYPE, // func(T1, T2): ReturnType
+
     // Other
     NODE_PARAM,
     NODE_FIELD,
@@ -234,6 +237,7 @@ struct Node {
             int   is_const_access; // Set by checker: 1 if accessing a const field
             char* struct_name;     // Set by checker if this is a method access (NULL otherwise)
             char* module_name;     // Set by checker for module-qualified access (e.g., "std")
+            int   is_method_ref;   // Set by checker: 1 if Type.method unbound reference
         } member;
 
         // Assignment
@@ -324,6 +328,12 @@ struct Node {
             int      base_name_length;
             NodeList type_args; // list of type nodes
         } generic_type;
+
+        // Function type: func(T1, T2): ReturnType
+        struct {
+            NodeList param_types; // Parameter type nodes
+            Node*    return_type; // Return type node (NULL for void)
+        } func_type;
 
         // Expression statement
         struct {

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -619,6 +619,11 @@ static void check_var_decl_stmt(Checker* checker, Node* node) {
         node->as.var_decl.resolved_type = init_type;
     }
 
+    // Store resolved type for function pointer inference (var fp = some_func)
+    if (!node->as.var_decl.type && init_type && init_type->kind == TYPE_FUNC) {
+        node->as.var_decl.resolved_type = init_type;
+    }
+
     // Propagate RC tracking
     if (sym && node->as.var_decl.init) {
         if (var_type && var_type->kind == TYPE_ENUM && var_type->as.enm.has_rc_fields) {

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -619,6 +619,51 @@ static Type* check_member_stringbuilder(Checker* checker, Node* node) {
     return type_error;
 }
 
+// Check for Type.method unbound method reference (e.g., Point.move)
+static Type* check_member_type_ref(Checker* checker, Node* node, Type* type_val) {
+    const char* member_name = node->as.member.name;
+    Type*       method_type = NULL;
+    const char* sname       = NULL;
+
+    if (type_val->kind == TYPE_STRUCT) {
+        for (int i = 0; i < type_val->as.struc.method_count; i++) {
+            if (strcmp(type_val->as.struc.method_names[i], member_name) == 0) {
+                method_type = type_val->as.struc.method_types[i];
+                sname       = type_val->as.struc.name;
+                break;
+            }
+        }
+    } else if (type_val->kind == TYPE_ENUM) {
+        for (int i = 0; i < type_val->as.enm.method_count; i++) {
+            if (strcmp(type_val->as.enm.method_names[i], member_name) == 0) {
+                method_type = type_val->as.enm.method_types[i];
+                sname       = type_val->as.enm.name;
+                break;
+            }
+        }
+    }
+
+    if (!method_type || method_type->kind != TYPE_FUNC) {
+        check_error(checker, node->line, node->column, "Type '%s' has no method '%s'",
+                    type_name(type_val), member_name);
+        return type_error;
+    }
+
+    // Build new TYPE_FUNC with receiver prepended as first parameter
+    int    old_count = method_type->as.func.param_count;
+    int    new_count = old_count + 1;
+    Type** params    = xmalloc(new_count * sizeof(Type*));
+    params[0]        = type_val;
+    for (int i = 0; i < old_count; i++) {
+        params[i + 1] = method_type->as.func.param_types[i];
+    }
+
+    sem_info_set_member_struct_name(checker->sem, node, sname);
+    node->as.member.is_method_ref = 1;
+
+    return type_func(params, new_count, method_type->as.func.return_type, 0);
+}
+
 // Type-check a member access: dispatch to type-specific helpers
 static Type* check_member_expr(Checker* checker, Node* node) {
     // Check for module-qualified access first (e.g., std.print)
@@ -626,6 +671,15 @@ static Type* check_member_expr(Checker* checker, Node* node) {
         const char* name = node->as.member.object->as.ident.name;
         if (is_imported_module(checker, name))
             return check_member_module(checker, node, name);
+    }
+
+    // Check for Type.method unbound method reference (e.g., Point.move)
+    if (node->as.member.object->type == NODE_IDENT) {
+        const char* name = node->as.member.object->as.ident.name;
+        Symbol*     sym  = checker_lookup(checker, name);
+        if (sym && sym->kind == SYM_TYPE) {
+            return check_member_type_ref(checker, node, sym->type);
+        }
     }
 
     Type* object = check_expression(checker, node->as.member.object);

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -1016,6 +1016,25 @@ Type* resolve_type(Checker* checker, Node* type_node) {
         }
         return type_tuple(elems, count);
     }
+    case NODE_FUNC_TYPE: {
+        int    count  = type_node->as.func_type.param_types.count;
+        Type** params = count > 0 ? xmalloc(count * sizeof(Type*)) : NULL;
+        for (int i = 0; i < count; i++) {
+            params[i] = resolve_type(checker, type_node->as.func_type.param_types.nodes[i]);
+            if (params[i] == type_error) {
+                free(params);
+                return type_error;
+            }
+        }
+        Type* ret = type_node->as.func_type.return_type
+                        ? resolve_type(checker, type_node->as.func_type.return_type)
+                        : type_void;
+        if (ret == type_error) {
+            free(params);
+            return type_error;
+        }
+        return type_func(params, count, ret, 0);
+    }
     default:
         break;
     }

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -284,6 +284,23 @@ void emit_type(CodeGen* gen, Node* type_node) {
         }
         break;
     }
+    case NODE_FUNC_TYPE: {
+        // Function pointer anonymous form: ret_type (*)(param_types)
+        if (type_node->as.func_type.return_type)
+            emit_type(gen, type_node->as.func_type.return_type);
+        else
+            emit(gen, "void");
+        emit(gen, " (*)(");
+        for (int i = 0; i < type_node->as.func_type.param_types.count; i++) {
+            if (i > 0)
+                emit(gen, ", ");
+            emit_type(gen, type_node->as.func_type.param_types.nodes[i]);
+        }
+        if (type_node->as.func_type.param_types.count == 0)
+            emit(gen, "void");
+        emit(gen, ")");
+        break;
+    }
     default:
         emit(gen, "/* unknown type */");
         break;
@@ -388,6 +405,18 @@ void emit_resolved_type(CodeGen* gen, Type* type) {
         }
         break;
     }
+    case TYPE_FUNC:
+        emit_resolved_type(gen, type->as.func.return_type);
+        emit(gen, " (*)(");
+        for (int i = 0; i < type->as.func.param_count; i++) {
+            if (i > 0)
+                emit(gen, ", ");
+            emit_resolved_type(gen, type->as.func.param_types[i]);
+        }
+        if (type->as.func.param_count == 0)
+            emit(gen, "void");
+        emit(gen, ")");
+        break;
     default:
         emit(gen, "/* unknown type */");
         break;
@@ -401,7 +430,22 @@ void emit_type_with_name(CodeGen* gen, Node* type_node, const char* name) {
         return;
     }
 
-    if (type_node->type == NODE_ARRAY_TYPE && type_node->as.array_type.size) {
+    if (type_node->type == NODE_FUNC_TYPE) {
+        // Function pointer: ret (*name)(params)
+        if (type_node->as.func_type.return_type)
+            emit_type(gen, type_node->as.func_type.return_type);
+        else
+            emit(gen, "void");
+        emit(gen, " (*%s)(", name);
+        for (int i = 0; i < type_node->as.func_type.param_types.count; i++) {
+            if (i > 0)
+                emit(gen, ", ");
+            emit_type(gen, type_node->as.func_type.param_types.nodes[i]);
+        }
+        if (type_node->as.func_type.param_types.count == 0)
+            emit(gen, "void");
+        emit(gen, ")");
+    } else if (type_node->type == NODE_ARRAY_TYPE && type_node->as.array_type.size) {
         // Array: T name[n]
         emit_type(gen, type_node->as.array_type.elem_type);
         emit(gen, " %s[", name);

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -436,7 +436,7 @@ static void emit_call_expr(CodeGen* gen, Node* node) {
         return;
     }
 
-    if (func->type == NODE_MEMBER && callee_struct_name != NULL) {
+    if (func->type == NODE_MEMBER && callee_struct_name != NULL && !func->as.member.is_method_ref) {
         emit_struct_method_call(gen, node, func, callee_struct_name);
         return;
     }
@@ -585,6 +585,13 @@ static void emit_slice_expr(CodeGen* gen, Node* node) {
 
 // Emit a member access expression using -> for struct pointers or . for value types
 static void emit_member_expr(CodeGen* gen, Node* node) {
+    // Unbound method reference: Type.method -> StructName_method
+    if (node->as.member.is_method_ref) {
+        const char* sname = member_struct_name(gen, node);
+        emit(gen, "%s_%.*s", sname, node->as.member.length, node->as.member.name);
+        return;
+    }
+
     const char* resolved_struct_name = member_struct_name(gen, node);
     const char* resolved_module_name = member_module_name(gen, node);
     int         resolved_is_ref      = member_is_ref(gen, node);

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -392,8 +392,23 @@ static void emit_var_decl_inferred_type(CodeGen* gen, Node* node) {
         break;
     default:
         if (node->as.var_decl.resolved_type) {
-            emit_resolved_type(gen, node->as.var_decl.resolved_type);
-            emit(gen, " %s", node->as.var_decl.name);
+            Type* rt = node->as.var_decl.resolved_type;
+            if (rt->kind == TYPE_FUNC) {
+                // Function pointer: name goes inside the type
+                emit_resolved_type(gen, rt->as.func.return_type);
+                emit(gen, " (*%s)(", node->as.var_decl.name);
+                for (int i = 0; i < rt->as.func.param_count; i++) {
+                    if (i > 0)
+                        emit(gen, ", ");
+                    emit_resolved_type(gen, rt->as.func.param_types[i]);
+                }
+                if (rt->as.func.param_count == 0)
+                    emit(gen, "void");
+                emit(gen, ")");
+            } else {
+                emit_resolved_type(gen, rt);
+                emit(gen, " %s", node->as.var_decl.name);
+            }
         } else {
             emit(gen, "int64_t %s", node->as.var_decl.name);
         }

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -209,6 +209,37 @@ static Node* parse_type(Parser* parser) {
         return node;
     }
 
+    // Function type: func(T1, T2): ReturnType
+    if (match_token(parser, TOK_FUNC)) {
+        Node* node = node_new(NODE_FUNC_TYPE, token.line, token.column);
+        nodelist_init(&node->as.func_type.param_types);
+        node->as.func_type.return_type = NULL;
+
+        consume_token(parser, TOK_LPAREN, "Expected '(' after 'func' in type");
+
+        if (!check_token(parser, TOK_RPAREN)) {
+            do {
+                Node* pt = parse_type(parser);
+                if (!pt) {
+                    node_free(node);
+                    return NULL;
+                }
+                nodelist_push(&node->as.func_type.param_types, pt);
+            } while (match_token(parser, TOK_COMMA));
+        }
+
+        consume_token(parser, TOK_RPAREN, "Expected ')' in function type");
+
+        if (match_token(parser, TOK_COLON)) {
+            node->as.func_type.return_type = parse_type(parser);
+            if (!node->as.func_type.return_type) {
+                node_free(node);
+                return NULL;
+            }
+        }
+        return node;
+    }
+
     // Named type (possibly generic)
     if (match_token(parser, TOK_IDENT)) {
         // Check for generic type instantiation: Name<T1, T2, ...>

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -541,6 +541,17 @@ void print_ast(Node* node, int depth) {
         printf("TupleType\n");
         print_node_list(NULL, &node->as.tuple_type.elem_types, depth);
         break;
+    case NODE_FUNC_TYPE:
+        printf("FuncType\n");
+        if (node->as.func_type.param_types.count > 0) {
+            print_node_list("Params", &node->as.func_type.param_types, depth + 1);
+        }
+        if (node->as.func_type.return_type) {
+            print_indent(depth + 1);
+            printf("ReturnType:\n");
+            print_ast(node->as.func_type.return_type, depth + 2);
+        }
+        break;
     case NODE_TUPLE_LIT:
         printf("TupleLit\n");
         print_node_list(NULL, &node->as.tuple_lit.elements, depth);

--- a/w0/test/errors/func_ptr_no_method.w
+++ b/w0/test/errors/func_ptr_no_method.w
@@ -1,0 +1,7 @@
+// Expected error: Type 'Point' has no method 'nonexistent'
+struct Point { x: i64, y: i64 }
+
+func main(): i32 {
+    var f = Point.nonexistent;
+    return 0;
+}

--- a/w0/test/errors/func_ptr_type_mismatch.w
+++ b/w0/test/errors/func_ptr_type_mismatch.w
@@ -1,0 +1,9 @@
+// Expected error: Type mismatch
+func add(a: i64, b: i64): i64 {
+    return a + b;
+}
+
+func main(): i32 {
+    var fp: func(i64): i64 = add;
+    return 0;
+}

--- a/w0/test/valid/func_ptr_basic.w
+++ b/w0/test/valid/func_ptr_basic.w
@@ -1,0 +1,9 @@
+func add(a: i64, b: i64): i64 {
+    return a + b;
+}
+
+func main(): i32 {
+    var fp: func(i64, i64): i64 = add;
+    var result = fp(2, 3);
+    return 0;
+}

--- a/w0/test/valid/func_ptr_inferred.w
+++ b/w0/test/valid/func_ptr_inferred.w
@@ -1,0 +1,13 @@
+func greet(): void {
+    return;
+}
+
+func add(a: i64, b: i64): i64 {
+    return a + b;
+}
+
+func main(): i32 {
+    var fp = add;
+    var result = fp(1, 2);
+    return 0;
+}

--- a/w0/test/valid/func_ptr_method_ref.w
+++ b/w0/test/valid/func_ptr_method_ref.w
@@ -1,0 +1,10 @@
+struct Counter { value: i64 }
+
+func (Counter) increment(): void {
+    self.value = self.value + 1;
+}
+
+func main(): i32 {
+    var f: func(Counter): void = Counter.increment;
+    return 0;
+}

--- a/w0/test/valid/func_ptr_nullable.w
+++ b/w0/test/valid/func_ptr_nullable.w
@@ -1,0 +1,9 @@
+func noop(): void {
+    return;
+}
+
+func main(): i32 {
+    var fp: func(): void = null;
+    fp = noop;
+    return 0;
+}

--- a/w0/test/valid/func_ptr_param.w
+++ b/w0/test/valid/func_ptr_param.w
@@ -1,0 +1,12 @@
+func apply(f: func(i64): i64, x: i64): i64 {
+    return f(x);
+}
+
+func twice(x: i64): i64 {
+    return x * 2;
+}
+
+func main(): i32 {
+    var result = apply(twice, 5);
+    return 0;
+}

--- a/w0/test/valid/func_ptr_struct_field.w
+++ b/w0/test/valid/func_ptr_struct_field.w
@@ -1,0 +1,11 @@
+struct Callback { handler: func(i64): i64 }
+
+func twice(x: i64): i64 {
+    return x * 2;
+}
+
+func main(): i32 {
+    var cb = new Callback { handler: twice };
+    var result = cb.handler(5);
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -405,6 +405,11 @@ int type_assignable(Type* target, Type* value) {
         return 1;
     }
 
+    // null can be assigned to function pointers
+    if (target->kind == TYPE_FUNC && value->kind == TYPE_NULL) {
+        return 1;
+    }
+
     return 0;
 }
 
@@ -488,7 +493,16 @@ const char* type_name(Type* type) {
         return type->as.trait.name;
     case TYPE_FUNC: {
         char* buf = next_type_name_buf();
-        snprintf(buf, 256, "func(...): %s", type_name(type->as.func.return_type));
+        int   n   = snprintf(buf, 256, "func(");
+        for (int i = 0; i < type->as.func.param_count && n < 255; i++) {
+            if (i > 0)
+                n += snprintf(buf + n, 256 - n, ", ");
+            n += snprintf(buf + n, 256 - n, "%s", type_name(type->as.func.param_types[i]));
+        }
+        n += snprintf(buf + n, 256 - n, ")");
+        if (type->as.func.return_type && type->as.func.return_type->kind != TYPE_VOID) {
+            snprintf(buf + n, 256 - n, ": %s", type_name(type->as.func.return_type));
+        }
         return buf;
     }
     case TYPE_TUPLE: {


### PR DESCRIPTION
## Summary

Closes #84

Adds `func(T1, T2): ReturnType` as a first-class type in Whist, enabling:
- **Function pointer variables** with explicit type annotation (`var fp: func(i64): i64 = add`)
- **Callback parameters** (`func apply(f: func(i64): i64, x: i64): i64`)
- **Type inference** for function-typed variables (`var fp = add`)
- **Nullable function pointers** (`var fp: func(): void = null`)
- **Unbound method references** (`var f: func(Point): i64 = Point.get_x`)
- **Function pointer struct fields** (`struct Callback { handler: func(i64): i64 }`)

## Changes

**AST** (`ast.h`, `ast.c`):
- `NODE_FUNC_TYPE` node with `param_types` (NodeList) and `return_type` (Node*)
- `is_method_ref` flag on member nodes for `Type.method` references
- `node_free`, `node_clone`, `node_reset_checker_flags` cases

**Parser** (`parser.c`):
- `parse_type()` handles `func(T1, T2): ReturnType` syntax

**Checker** (`checker.c`, `checker_expr.c`, `checker_types.c`, `types.c`):
- `resolve_type()` resolves `NODE_FUNC_TYPE` into `type_func()`
- `check_member_type_ref()` handles `Type.method` unbound references (prepends receiver as first param)
- `var_decl` stores `resolved_type` for TYPE_FUNC inference
- `type_assignable()` allows null-to-func assignment
- `type_name()` shows full parameter types instead of `func(...)`

**Codegen** (`codegen_emit.c`, `codegen_expr.c`, `codegen_stmt.c`):
- `emit_type()`, `emit_resolved_type()`, `emit_type_with_name()` emit correct C function pointer syntax (`ret (*name)(params)`)
- `emit_var_decl_inferred_type()` handles TYPE_FUNC (name must go inside the type)
- `emit_member_expr()` emits `StructName_method` for unbound method refs
- `emit_call_expr()` bypasses method dispatch when calling through method refs

**Tests** (8 new files):
- Valid: `func_ptr_basic`, `func_ptr_param`, `func_ptr_inferred`, `func_ptr_nullable`, `func_ptr_method_ref`, `func_ptr_struct_field`
- Errors: `func_ptr_type_mismatch`, `func_ptr_no_method`

## Test plan

- [x] `make` — clean build, no warnings
- [x] `make test` — 223/223 tests pass (all existing + 8 new)
- [x] End-to-end C compilation verified for basic, param, inferred, nullable, struct_field tests
- [x] `make format` — code formatted