### PR TITLE
feat: Vec.pop() returns Option<T> instead of panicking

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -454,12 +454,39 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
         }
         return type_func(NULL, 0, option_type, 0);
     }
-    // Mutating methods: push, pop, insert, remove, swap_remove, clear, reserve, shrink_to_fit, sort
-    if (strcmp(member_name, "push") == 0 || strcmp(member_name, "pop") == 0 ||
-        strcmp(member_name, "insert") == 0 || strcmp(member_name, "remove") == 0 ||
-        strcmp(member_name, "swap_remove") == 0 || strcmp(member_name, "clear") == 0 ||
-        strcmp(member_name, "reserve") == 0 || strcmp(member_name, "shrink_to_fit") == 0 ||
-        strcmp(member_name, "sort") == 0) {
+    // pop is mutating and returns Option<T>
+    if (strcmp(member_name, "pop") == 0) {
+        const char* const_name = get_const_binding_name(checker, node->as.member.object);
+        if (const_name) {
+            check_error(checker, node->line, node->column,
+                        "Cannot call mutating method '%s' on const '%s'", member_name, const_name);
+            return type_error;
+        }
+        char mangled[256];
+        snprintf(mangled, sizeof(mangled), "__Vec_%s", type_mangle_name(elem_type));
+        sem_info_set_member_struct_name(checker->sem, node, mangled);
+
+        // Look up or instantiate Option<elem_type>
+        GenericDef* option_def          = lookup_generic_def(checker, "Option");
+        Type**      args                = xmalloc(sizeof(Type*));
+        args[0]                         = elem_type;
+        char*            option_mangled = type_mangle_generic("Option", args, 1);
+        GenericInstance* existing       = lookup_generic_instance(checker, option_mangled);
+        Type*            option_type;
+        if (existing) {
+            option_type = existing->type;
+            free(option_mangled);
+            free(args);
+        } else {
+            option_type = instantiate_generic_enum(checker, option_def, option_mangled, args, 1);
+        }
+        return type_func(NULL, 0, option_type, 0);
+    }
+    // Mutating methods: push, insert, remove, swap_remove, clear, reserve, shrink_to_fit, sort
+    if (strcmp(member_name, "push") == 0 || strcmp(member_name, "insert") == 0 ||
+        strcmp(member_name, "remove") == 0 || strcmp(member_name, "swap_remove") == 0 ||
+        strcmp(member_name, "clear") == 0 || strcmp(member_name, "reserve") == 0 ||
+        strcmp(member_name, "shrink_to_fit") == 0 || strcmp(member_name, "sort") == 0) {
         const char* const_name = get_const_binding_name(checker, node->as.member.object);
         if (const_name) {
             check_error(checker, node->line, node->column,
@@ -481,9 +508,6 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
             Type** params = xmalloc(1 * sizeof(Type*));
             params[0]     = elem_type;
             return type_func(params, 1, type_void, 0);
-        }
-        if (strcmp(member_name, "pop") == 0) {
-            return type_func(NULL, 0, elem_type, 0);
         }
         if (strcmp(member_name, "insert") == 0) {
             Type** params = xmalloc(2 * sizeof(Type*));

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -533,18 +533,6 @@ void emit_vec_methods(CodeGen* gen) {
             emit(gen, "}\n\n");
         }
 
-        // Pop
-        emit(gen, "static inline ");
-        emit_resolved_type(gen, elem_type);
-        emit(gen, " __Vec_%s_pop(__Vec_%s* self) {\n", elem_tname, elem_tname);
-        emit(gen, "    if (self->count == 0) {\n");
-        emit(gen, "        fprintf(stderr, \"Panic: pop from empty Vec\\n\");\n");
-        emit(gen, "        exit(1);\n");
-        emit(gen, "    }\n");
-        emit(gen, "    self->count--;\n");
-        emit(gen, "    return self->data[self->count];\n");
-        emit(gen, "}\n\n");
-
         // Remove
         emit(gen, "static inline ");
         emit_resolved_type(gen, elem_type);
@@ -663,6 +651,20 @@ void emit_vec_methods(CodeGen* gen) {
             emit(gen,
                  "    return (Option_%s){.tag = Option_%s_Some, "
                  ".Some = {.f0 = self->data[self->count - 1]}};\n",
+                 option_tname, option_tname);
+            emit(gen, "}\n\n");
+
+            // Pop — returns Option<T>, transfers ownership (no __rc_inc)
+            emit(gen, "static inline Option_%s __Vec_%s_pop(__Vec_%s* self) {\n", option_tname,
+                 elem_tname, elem_tname);
+            emit(gen, "    if (self->count == 0) {\n");
+            emit(gen, "        return (Option_%s){.tag = Option_%s_None};\n", option_tname,
+                 option_tname);
+            emit(gen, "    }\n");
+            emit(gen, "    self->count--;\n");
+            emit(gen,
+                 "    return (Option_%s){.tag = Option_%s_Some, "
+                 ".Some = {.f0 = self->data[self->count]}};\n",
                  option_tname, option_tname);
             emit(gen, "}\n\n");
         }

--- a/w0/test/rc_runtime/rc_vec_pop.w
+++ b/w0/test/rc_runtime/rc_vec_pop.w
@@ -1,0 +1,50 @@
+// RC RUNTIME TEST: pop on Vec of structs — ownership transfer, no double-free
+
+struct Item {
+    value: i64,
+}
+
+func main(): i32 {
+    var items = new Vec<Item>{};
+    items.push(new Item { value: 10 });
+    items.push(new Item { value: 20 });
+    items.push(new Item { value: 30 });
+
+    // pop() transfers ownership — no __rc_inc needed
+    var p = items.pop();
+    match (p) {
+        Some(item) => {
+            if (item.value != 30) { return 1; }
+        },
+        None => { return 2; },
+    }
+
+    // Vec now has 2 elements
+    if (items.count != 2) { return 3; }
+
+    // Pop remaining elements
+    var p2 = items.pop();
+    match (p2) {
+        Some(item) => {
+            if (item.value != 20) { return 4; }
+        },
+        None => { return 5; },
+    }
+
+    var p3 = items.pop();
+    match (p3) {
+        Some(item) => {
+            if (item.value != 10) { return 6; }
+        },
+        None => { return 7; },
+    }
+
+    // Empty vec pop returns None
+    var p4 = items.pop();
+    match (p4) {
+        Some(item) => { return 8; },
+        None => {},
+    }
+
+    return 0;
+}

--- a/w0/test/vec_pop.w
+++ b/w0/test/vec_pop.w
@@ -1,29 +1,48 @@
-// Test Vec pop operation
+// Test Vec pop operation — returns Option<T>
 
 func main(): i32 {
     var nums = new Vec<i64>{10, 20, 30};
 
+    // Pop returns Some(last_element)
     var last = nums.pop();
-    if (last != 30) {
-        return 1;
+    match (last) {
+        Some(v) => {
+            if (v != 30) { return 1; }
+        },
+        None => { return 2; },
     }
 
     if (nums.count != 2) {
-        return 2;
-    }
-
-    var second = nums.pop();
-    if (second != 20) {
         return 3;
     }
 
+    // Pop second element
+    var second = nums.pop();
+    match (second) {
+        Some(v) => {
+            if (v != 20) { return 4; }
+        },
+        None => { return 5; },
+    }
+
+    // Pop first element
     var first = nums.pop();
-    if (first != 10) {
-        return 4;
+    match (first) {
+        Some(v) => {
+            if (v != 10) { return 6; }
+        },
+        None => { return 7; },
     }
 
     if (nums.count != 0) {
-        return 5;
+        return 8;
+    }
+
+    // Pop from empty Vec returns None
+    var empty_pop = nums.pop();
+    match (empty_pop) {
+        Some(v) => { return 9; },
+        None => {},
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- `Vec.pop()` now returns `Option<T>` (`Some(value)` if non-empty, `None` if empty) instead of panicking on empty Vec
- Follows the same pattern as `Vec.first()` and `Vec.last()`
- Pop transfers ownership directly (no `__rc_inc`) since the element is removed from the Vec

Closes #112

## Changes
- **Checker** (`checker_expr.c`): Moved `pop` out of the shared mutating-methods block into its own handler that instantiates `Option<T>` and returns it as the method's return type
- **Codegen** (`codegen_rc.c`): Removed old panicking pop emission; added new pop inside the `has_option` guard returning `Option<T>` without `__rc_inc` (ownership transfer)
- **Tests**: Updated `vec_pop.w` to use `match` on Option results including empty-vec test; added `rc_vec_pop.w` for RC ownership transfer verification

## Test plan
- [x] All 229 tests pass (`make test`)
- [x] `vec_pop.w` — pop returns `Some(value)`, empty pop returns `None`
- [x] `rc_vec_pop.w` — RC struct elements: ownership transfers correctly, no double-free
- [x] `error_const_vec_pop.w` — const mutation check unchanged