### PR TITLE
feat: embed cleanup function pointer in RC header

### DIFF
--- a/lib/include/whist_runtime.h
+++ b/lib/include/whist_runtime.h
@@ -29,17 +29,19 @@ extern char** __w0_argv;
 /* --- RC core --- */
 typedef struct {
     size_t refcount;
+    void (*cleanup)(void*);
 } __RcHeader;
 
 #ifdef WHIST_RC_DEBUG
 
-static inline void* __rc_alloc(size_t size) {
+static inline void* __rc_alloc(size_t size, void (*cleanup)(void*)) {
     __RcHeader* h = (__RcHeader*)malloc(sizeof(__RcHeader) + size);
     if (!h) {
         fprintf(stderr, "Panic: out of memory\n");
         exit(1);
     }
     h->refcount = 1;
+    h->cleanup  = cleanup;
     void* ptr   = (void*)(h + 1);
     fprintf(stderr, "RC_ALLOC: %p (size=%zu, rc=1)\n", ptr, size);
     return ptr;
@@ -58,6 +60,8 @@ static inline void __rc_dec(void* ptr) {
         return;
     __RcHeader* h = (__RcHeader*)ptr - 1;
     if (--h->refcount == 0) {
+        if (h->cleanup)
+            h->cleanup(ptr);
         fprintf(stderr, "RC_FREE: %p\n", ptr);
         free(h);
     } else {
@@ -67,13 +71,14 @@ static inline void __rc_dec(void* ptr) {
 
 #else /* !WHIST_RC_DEBUG */
 
-static inline void* __rc_alloc(size_t size) {
+static inline void* __rc_alloc(size_t size, void (*cleanup)(void*)) {
     __RcHeader* h = (__RcHeader*)malloc(sizeof(__RcHeader) + size);
     if (!h) {
         fprintf(stderr, "Panic: out of memory\n");
         exit(1);
     }
     h->refcount = 1;
+    h->cleanup  = cleanup;
     return (void*)(h + 1);
 }
 
@@ -87,8 +92,11 @@ static inline void __rc_dec(void* ptr) {
     if (!ptr)
         return;
     __RcHeader* h = (__RcHeader*)ptr - 1;
-    if (--h->refcount == 0)
+    if (--h->refcount == 0) {
+        if (h->cleanup)
+            h->cleanup(ptr);
         free(h);
+    }
 }
 
 #endif /* WHIST_RC_DEBUG */
@@ -226,14 +234,9 @@ static inline const char* __StringBuilder_to_string(__StringBuilder* self) {
     return r;
 }
 
-static inline void __rc_dec_StringBuilder(__StringBuilder* ptr) {
-    if (!ptr)
-        return;
-    __RcHeader* h = (__RcHeader*)ptr - 1;
-    if (--h->refcount == 0) {
-        free(ptr->data);
-        free(h);
-    }
+static inline void __StringBuilder_cleanup(void* raw) {
+    __StringBuilder* ptr = (__StringBuilder*)raw;
+    free(ptr->data);
 }
 
 #endif /* WHIST_RUNTIME_H */

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -520,7 +520,6 @@ void codegen_free(CodeGen* gen) {
     free(gen->defer.stack);
     for (int i = 0; i < gen->rc.count; i++) {
         free(gen->rc.vars[i].name);
-        free(gen->rc.vars[i].dec_func);
     }
     free(gen->rc.vars);
     for (int i = 0; i < gen->enums.count; i++) {
@@ -1135,10 +1134,9 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit_struct_body_typedefs(gen, ast);
     emit_function_forward_decls(gen, ast);
     emit_enum_eq_helpers(gen, ast);
-    emit_struct_rc_dec_forward_decls(gen, ast);
-    emit_vec_rc_dec(gen);
+    emit_vec_cleanup(gen);
     emit_vec_methods(gen);
-    emit_struct_rc_dec(gen, ast);
+    emit_struct_cleanup(gen, ast);
     emit_declarations(gen, ast);
     emit_generic_method_impls(gen, ast);
     if (gen->test_mode) {

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -17,8 +17,7 @@ typedef struct {
 // RC-managed variable tracking entry
 typedef struct {
     char* name;
-    char* dec_func; // "__rc_dec" or "__rc_dec_TypeName"
-    Type* type;     // Type* for the RC variable (not owned)
+    Type* type; // Type* for the RC variable (not owned)
     int   scope_depth;
 } RcVar;
 

--- a/w0/codegen_emit.h
+++ b/w0/codegen_emit.h
@@ -40,9 +40,8 @@ void emit_enum_eq_helpers(CodeGen* gen, Node* ast);
 // RC emission (defined in codegen_rc.c)
 void emit_rc_runtime(CodeGen* gen);
 void emit_enum_rc_helpers(CodeGen* gen, Node* ast);
-void emit_struct_rc_dec_forward_decls(CodeGen* gen, Node* ast);
-void emit_struct_rc_dec(CodeGen* gen, Node* ast);
+void emit_struct_cleanup(CodeGen* gen, Node* ast);
 void emit_vec_methods(CodeGen* gen);
-void emit_vec_rc_dec(CodeGen* gen);
+void emit_vec_cleanup(CodeGen* gen);
 
 #endif

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -104,61 +104,6 @@ static char* resolve_generic_method_target(CodeGen* gen, Node* member) {
     return mangled;
 }
 
-// Build the __rc_dec function name for a field type AST node in a generic method body.
-// Returns a malloc'd string, or NULL if the field is not RC-managed. Caller must free.
-char* resolve_generic_field_dec_func(CodeGen* gen, Node* field_type_node) {
-    if (!field_type_node)
-        return NULL;
-    if (field_type_node->type == NODE_GENERIC_TYPE) {
-        const char* base = field_type_node->as.generic_type.base_name;
-        if (strcmp(base, "Vec") == 0) {
-            // Vec<T> → __rc_dec_Vec_T
-            Node* elem = field_type_node->as.generic_type.type_args.nodes[0];
-            char  buf[256];
-            if (elem->type == NODE_IDENT) {
-                const char* elem_name = elem->as.ident.name;
-                Type*       resolved  = subst_lookup(gen, elem_name);
-                if (resolved) {
-                    snprintf(buf, sizeof(buf), "__rc_dec_Vec_%s", type_name(resolved));
-                } else {
-                    snprintf(buf, sizeof(buf), "__rc_dec_Vec_%s", elem_name);
-                }
-                return xstrdup(buf);
-            } else if (elem->type == NODE_GENERIC_TYPE) {
-                char* mangled = build_mangled_name_from_generic_node(gen, elem);
-                snprintf(buf, sizeof(buf), "__rc_dec_Vec_%s", mangled);
-                free(mangled);
-                return xstrdup(buf);
-            }
-            return NULL;
-        }
-        if (strcmp(base, "Span") == 0)
-            return NULL; // Spans are value types, not RC
-        // Generic struct → __rc_dec_MangledName
-        char* mangled = build_mangled_name_from_generic_node(gen, field_type_node);
-        char  buf[256];
-        snprintf(buf, sizeof(buf), "__rc_dec_%s", mangled);
-        free(mangled);
-        return xstrdup(buf);
-    }
-    if (field_type_node->type == NODE_IDENT) {
-        const char* name     = field_type_node->as.ident.name;
-        Type*       resolved = subst_lookup(gen, name);
-        if (resolved) {
-            if (resolved->kind == TYPE_STRUCT)
-                return (char*)get_dec_func_for_type(resolved);
-            return NULL;
-        }
-        // Non-generic struct field
-        if (!type_is_builtin_name(name) && !is_enum_type_name(gen, name)) {
-            char buf[256];
-            snprintf(buf, sizeof(buf), "__rc_dec_%s", name);
-            return xstrdup(buf);
-        }
-    }
-    return NULL;
-}
-
 // Emit a string literal with C escape sequences
 static void emit_string_lit(CodeGen* gen, Node* node) {
     emit(gen, "\"");
@@ -693,7 +638,7 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
         int tmp = gen->out.temp_count++;
         emit(gen,
              "({ __StringBuilder* __rc_tmp%d = (__StringBuilder*)__rc_alloc("
-             "sizeof(__StringBuilder)); "
+             "sizeof(__StringBuilder), __StringBuilder_cleanup); "
              "__rc_tmp%d->data = NULL; __rc_tmp%d->count = 0; __rc_tmp%d->capacity = 0; "
              "__rc_tmp%d; })",
              tmp, tmp, tmp, tmp, tmp);
@@ -704,9 +649,10 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
         const char* elem_tname = type_mangle_name(rtype->as.vec.elem);
         int         tmp        = gen->out.temp_count++;
         emit(gen,
-             "({ __Vec_%s* __rc_tmp%d = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s)); "
+             "({ __Vec_%s* __rc_tmp%d = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s), "
+             "__Vec_%s_cleanup); "
              "__rc_tmp%d->data = NULL; __rc_tmp%d->count = 0; __rc_tmp%d->capacity = 0;",
-             elem_tname, tmp, elem_tname, elem_tname, tmp, tmp, tmp);
+             elem_tname, tmp, elem_tname, elem_tname, elem_tname, tmp, tmp, tmp);
         // Push initial elements
         Node* init = node->as.new_expr.init;
         for (int i = 0; i < init->as.struct_init.fields.count; i++) {
@@ -720,10 +666,17 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
         emit(gen, " __rc_tmp%d; })", tmp);
     } else {
         // new Type { fields } as inline expression using GCC statement expression
-        const char* tname = rtype->as.struc.name;
-        int         tmp   = gen->out.temp_count++;
-        emit(gen, "({ %s* __rc_tmp%d = (%s*)__rc_alloc(sizeof(%s)); *__rc_tmp%d = (%s)", tname, tmp,
-             tname, tname, tmp, tname);
+        const char* tname   = rtype->as.struc.name;
+        char*       cleanup = get_cleanup_func_for_type(rtype);
+        int         tmp     = gen->out.temp_count++;
+        if (cleanup) {
+            emit(gen, "({ %s* __rc_tmp%d = (%s*)__rc_alloc(sizeof(%s), %s); *__rc_tmp%d = (%s)",
+                 tname, tmp, tname, tname, cleanup, tmp, tname);
+        } else {
+            emit(gen, "({ %s* __rc_tmp%d = (%s*)__rc_alloc(sizeof(%s), NULL); *__rc_tmp%d = (%s)",
+                 tname, tmp, tname, tname, tmp, tname);
+        }
+        free(cleanup);
         emit_struct_init(gen, node->as.new_expr.init);
         emit(gen, ";");
         // Increment refcount for any RC-tracked idents stored in struct fields
@@ -919,7 +872,12 @@ static void emit_try_expr(CodeGen* gen, Node* node) {
 
     // Inline RC cleanup (no newlines, stay inside statement expr)
     for (int i = 0; i < gen->rc.count; i++) {
-        emit(gen, "%s(%s); ", gen->rc.vars[i].dec_func, gen->rc.vars[i].name);
+        Type* t = gen->rc.vars[i].type;
+        if (t && t->kind == TYPE_ENUM && t->as.enm.has_rc_fields) {
+            emit(gen, "__rc_dec_%s(%s); ", t->as.enm.name, gen->rc.vars[i].name);
+        } else {
+            emit(gen, "__rc_dec(%s); ", gen->rc.vars[i].name);
+        }
     }
 
     // Early return with error/none value

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -15,12 +15,11 @@ const char* unary_op_str(TokenType op);
 const char* assign_op_str(TokenType op);
 
 // --- From codegen_rc.c: RC variable tracking ---
-const char* get_dec_func_for_type(Type* t);
+char*       get_cleanup_func_for_type(Type* t);
 const char* get_inc_func_for_type(Type* t);
-void        rc_push_var(CodeGen* gen, const char* name, const char* dec_func, Type* type);
+void        rc_push_var(CodeGen* gen, const char* name, Type* type);
 void        rc_cleanup_scope(CodeGen* gen, int depth);
 void        rc_cleanup_all(CodeGen* gen, const char* skip_name);
-const char* rc_get_dec_func(CodeGen* gen, const char* name);
 Type*       rc_get_var_type(CodeGen* gen, const char* name);
 int         rc_is_tracked(CodeGen* gen, const char* name);
 
@@ -30,7 +29,6 @@ void  emit_struct_init(CodeGen* gen, Node* node);
 void  emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* temp_prefix,
                             int is_const);
 Node* lookup_generic_template_field_type(CodeGen* gen, const char* field_name);
-char* resolve_generic_field_dec_func(CodeGen* gen, Node* field_type_node);
 
 // --- From codegen_stmt.c: statement emission ---
 void emit_block_contents(CodeGen* gen, Node* block);

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -27,32 +27,26 @@
 // rc_cleanup_all is used before early returns in conditional branches where
 // the var list must remain intact for the non-returning path.
 
-// Return the appropriate __rc_dec function name for a type (type-specific or generic)
-const char* get_dec_func_for_type(Type* t) {
+// Return the cleanup function name for a type, or NULL if none needed.
+// Returns a malloc'd string. Caller must free.
+char* get_cleanup_func_for_type(Type* t) {
     if (t && t->kind == TYPE_STRUCT && (t->as.struc.has_drop || t->as.struc.has_rc_fields)) {
-        // Build "__rc_dec_TypeName"
-        size_t len = strlen("__rc_dec_") + strlen(t->as.struc.name) + 1;
+        size_t len = strlen("__") + strlen(t->as.struc.name) + strlen("_cleanup") + 1;
         char*  buf = xmalloc(len);
-        snprintf(buf, len, "__rc_dec_%s", t->as.struc.name);
-        return buf;
-    }
-    if (t && t->kind == TYPE_ENUM && t->as.enm.has_rc_fields) {
-        size_t len = strlen("__rc_dec_") + strlen(t->as.enm.name) + 1;
-        char*  buf = xmalloc(len);
-        snprintf(buf, len, "__rc_dec_%s", t->as.enm.name);
+        snprintf(buf, len, "__%s_cleanup", t->as.struc.name);
         return buf;
     }
     if (t && t->kind == TYPE_STRINGBUILDER) {
-        return xstrdup("__rc_dec_StringBuilder");
+        return xstrdup("__StringBuilder_cleanup");
     }
     if (t && t->kind == TYPE_VEC) {
         const char* elem_tname = type_mangle_name(t->as.vec.elem);
-        size_t      len        = strlen("__rc_dec_Vec_") + strlen(elem_tname) + 1;
+        size_t      len        = strlen("__Vec_") + strlen(elem_tname) + strlen("_cleanup") + 1;
         char*       buf        = xmalloc(len);
-        snprintf(buf, len, "__rc_dec_Vec_%s", elem_tname);
+        snprintf(buf, len, "__Vec_%s_cleanup", elem_tname);
         return buf;
     }
-    return xstrdup("__rc_dec");
+    return NULL;
 }
 
 // Return the appropriate __rc_inc function name for a type (enum-specific or generic)
@@ -67,13 +61,22 @@ const char* get_inc_func_for_type(Type* t) {
 }
 
 // Register an RC-managed variable for scope-based cleanup tracking
-void rc_push_var(CodeGen* gen, const char* name, const char* dec_func, Type* type) {
+void rc_push_var(CodeGen* gen, const char* name, Type* type) {
     VEC_GROW(gen->rc.vars, gen->rc.count, gen->rc.capacity);
     gen->rc.vars[gen->rc.count].name        = xstrdup(name);
-    gen->rc.vars[gen->rc.count].dec_func    = xstrdup(dec_func);
     gen->rc.vars[gen->rc.count].type        = type;
     gen->rc.vars[gen->rc.count].scope_depth = gen->rc.depth;
     gen->rc.count++;
+}
+
+// Emit the appropriate dec call for an RC variable (enum value types need type-specific dec)
+static void emit_rc_dec_var(CodeGen* gen, RcVar* var) {
+    Type* t = var->type;
+    if (t && t->kind == TYPE_ENUM && t->as.enm.has_rc_fields) {
+        emit(gen, "__rc_dec_%s(%s)", t->as.enm.name, var->name);
+    } else {
+        emit(gen, "__rc_dec(%s)", var->name);
+    }
 }
 
 // Emit dec for vars at the given depth, remove them from list
@@ -82,9 +85,9 @@ void rc_cleanup_scope(CodeGen* gen, int depth) {
     for (int i = 0; i < gen->rc.count; i++) {
         if (gen->rc.vars[i].scope_depth == depth) {
             emit_indent(gen);
-            emit(gen, "%s(%s);\n", gen->rc.vars[i].dec_func, gen->rc.vars[i].name);
+            emit_rc_dec_var(gen, &gen->rc.vars[i]);
+            emit(gen, ";\n");
             free(gen->rc.vars[i].name);
-            free(gen->rc.vars[i].dec_func);
         } else {
             gen->rc.vars[dst++] = gen->rc.vars[i];
         }
@@ -99,7 +102,8 @@ void rc_cleanup_all(CodeGen* gen, const char* skip_name) {
             continue;
         }
         emit_indent(gen);
-        emit(gen, "%s(%s);\n", gen->rc.vars[i].dec_func, gen->rc.vars[i].name);
+        emit_rc_dec_var(gen, &gen->rc.vars[i]);
+        emit(gen, ";\n");
     }
 }
 
@@ -107,19 +111,9 @@ void rc_cleanup_all(CodeGen* gen, const char* skip_name) {
 void rc_clear_all(CodeGen* gen) {
     for (int i = 0; i < gen->rc.count; i++) {
         free(gen->rc.vars[i].name);
-        free(gen->rc.vars[i].dec_func);
     }
     gen->rc.count = 0;
     gen->rc.depth = 0;
-}
-
-// Look up the stored dec_func for a tracked RC variable
-const char* rc_get_dec_func(CodeGen* gen, const char* name) {
-    for (int i = 0; i < gen->rc.count; i++) {
-        if (strcmp(gen->rc.vars[i].name, name) == 0)
-            return gen->rc.vars[i].dec_func;
-    }
-    return "__rc_dec";
 }
 
 // Look up the stored Type* for a tracked RC variable
@@ -320,83 +314,6 @@ static int collect_rc_field_info(CodeGen* gen, Node* struct_decl, RcFieldInfo** 
     return count;
 }
 
-// Check if a field type needs a type-specific __rc_dec_TypeName (has Drop or RC fields)
-static int field_needs_custom_dec(CodeGen* gen, const char* field_type_name, Node* ast) {
-    if (!field_type_name)
-        return 0;
-    if (struct_implements_drop(gen, field_type_name))
-        return 1;
-    // Check if field type has RC fields (scan non-generic structs)
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int i = 0; i < mod->as.module.decls.count; i++) {
-            Node* decl = mod->as.module.decls.nodes[i];
-            if (decl->type == NODE_STRUCT_DECL && decl->as.struct_decl.type_param_count == 0 &&
-                strcmp(decl->as.struct_decl.name, field_type_name) == 0) {
-                for (int f = 0; f < decl->as.struct_decl.fields.count; f++) {
-                    Node* field = decl->as.struct_decl.fields.nodes[f];
-                    if (field->as.field.type && type_node_has_rc(gen, field->as.field.type))
-                        return 1;
-                }
-                return 0;
-            }
-        }
-    }
-    // Check generic instances (e.g., field type "Box_Inner")
-    for (int i = 0; i < gen->checker.instance_count; i++) {
-        if (strcmp(gen->checker.instances[i].mangled_name, field_type_name) == 0) {
-            Type* t = gen->checker.instances[i].type;
-            if (t && t->kind == TYPE_STRUCT && (t->as.struc.has_drop || t->as.struc.has_rc_fields))
-                return 1;
-            return 0;
-        }
-    }
-    return 0;
-}
-
-// Emit forward declarations for __rc_dec_TypeName functions (needed for cross-references)
-void emit_struct_rc_dec_forward_decls(CodeGen* gen, Node* ast) {
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int i = 0; i < mod->as.module.decls.count; i++) {
-            Node* decl = mod->as.module.decls.nodes[i];
-            if (decl->type != NODE_STRUCT_DECL)
-                continue;
-            if (decl->as.struct_decl.type_param_count > 0)
-                continue;
-            const char* sname     = decl->as.struct_decl.name;
-            int         needs_dec = struct_implements_drop(gen, sname);
-            if (!needs_dec) {
-                for (int f = 0; f < decl->as.struct_decl.fields.count; f++) {
-                    Node* field = decl->as.struct_decl.fields.nodes[f];
-                    if (field->as.field.type && type_node_has_rc(gen, field->as.field.type)) {
-                        needs_dec = 1;
-                        break;
-                    }
-                }
-            }
-            if (needs_dec) {
-                emit(gen, "static inline void __rc_dec_%s(%s* ptr);\n", sname, sname);
-            }
-        }
-    }
-    for (int i = 0; i < gen->checker.instance_count; i++) {
-        GenericInstance* info = &gen->checker.instances[i];
-        Type*            t    = info->type;
-        if (!t || t->kind != TYPE_STRUCT)
-            continue;
-        if (struct_implements_drop(gen, info->base_name) || t->as.struc.has_rc_fields) {
-            emit(gen, "static inline void __rc_dec_%s(%s* ptr);\n", info->mangled_name,
-                 info->mangled_name);
-        }
-    }
-    emit(gen, "\n");
-}
-
 // Emit push, pop, insert, remove, swap_remove, clear, reserve, shrink_to_fit, contains, sort,
 // first, and last method implementations for each Vec type instance
 void emit_vec_methods(CodeGen* gen) {
@@ -579,15 +496,7 @@ void emit_vec_methods(CodeGen* gen) {
         emit(gen, "static inline void __Vec_%s_clear(__Vec_%s* self) {\n", elem_tname, elem_tname);
         if (elem_is_ptr) {
             emit(gen, "    for (int64_t i = 0; i < self->count; i++) {\n");
-            if (elem_type->kind == TYPE_VEC) {
-                emit(gen, "        __rc_dec_Vec_%s(self->data[i]);\n",
-                     type_mangle_name(elem_type->as.vec.elem));
-            } else if (elem_type->kind == TYPE_STRUCT &&
-                       (elem_type->as.struc.has_drop || elem_type->as.struc.has_rc_fields)) {
-                emit(gen, "        __rc_dec_%s(self->data[i]);\n", elem_type->as.struc.name);
-            } else {
-                emit(gen, "        __rc_dec(self->data[i]);\n");
-            }
+            emit(gen, "        __rc_dec(self->data[i]);\n");
             emit(gen, "    }\n");
         }
         emit(gen, "    self->count = 0;\n");
@@ -671,57 +580,29 @@ void emit_vec_methods(CodeGen* gen) {
     }
 }
 
-// Emit __rc_dec_Vec_T functions that free Vec elements and the Vec itself
-void emit_vec_rc_dec(CodeGen* gen) {
-    for (int i = 0; i < gen->checker.vec_count; i++) {
-        VecInstance* inst       = &gen->checker.vecs[i];
-        const char*  elem_tname = type_mangle_name(inst->elem_type);
-        emit(gen, "static inline void __rc_dec_Vec_%s(__Vec_%s* ptr);\n", elem_tname, elem_tname);
-    }
-
-    // Emit __rc_dec_Vec_* definitions
+// Emit __Vec_T_cleanup functions that free Vec elements and data array
+void emit_vec_cleanup(CodeGen* gen) {
     for (int i = 0; i < gen->checker.vec_count; i++) {
         VecInstance* inst        = &gen->checker.vecs[i];
         Type*        elem_type   = inst->elem_type;
         const char*  elem_tname  = type_mangle_name(elem_type);
         int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
 
-        emit(gen, "static inline void __rc_dec_Vec_%s(__Vec_%s* ptr) {\n", elem_tname, elem_tname);
-        emit(gen, "    if (!ptr) return;\n");
-        emit(gen, "    __RcHeader* h = (__RcHeader*)ptr - 1;\n");
-        emit(gen, "    if (--h->refcount == 0) {\n");
+        emit(gen, "static inline void __Vec_%s_cleanup(void* raw) {\n", elem_tname);
+        emit(gen, "    __Vec_%s* ptr = (__Vec_%s*)raw;\n", elem_tname, elem_tname);
         if (elem_is_ptr) {
-            emit(gen, "        for (int64_t i = 0; i < ptr->count; i++) {\n");
-            if (elem_type->kind == TYPE_VEC) {
-                emit(gen, "            __rc_dec_Vec_%s(ptr->data[i]);\n",
-                     type_mangle_name(elem_type->as.vec.elem));
-            } else if (elem_type->kind == TYPE_STRUCT &&
-                       (elem_type->as.struc.has_drop || elem_type->as.struc.has_rc_fields)) {
-                emit(gen, "            __rc_dec_%s(ptr->data[i]);\n", elem_type->as.struc.name);
-            } else {
-                emit(gen, "            __rc_dec(ptr->data[i]);\n");
-            }
-            emit(gen, "        }\n");
+            emit(gen, "    for (int64_t i = 0; i < ptr->count; i++) {\n");
+            emit(gen, "        __rc_dec(ptr->data[i]);\n");
+            emit(gen, "    }\n");
         }
-        emit(gen, "        free(ptr->data);\n");
-        if (gen->rc.debug) {
-            emit(gen, "        fprintf(stderr, \"RC_FREE: %%p\\n\", (void*)ptr);\n");
-        }
-        emit(gen, "        free(h);\n");
-        if (gen->rc.debug) {
-            emit(gen, "    } else {\n");
-            emit(gen, "        fprintf(stderr, \"RC_DEC: %%p (rc=%%zu)\\n\", (void*)ptr, "
-                      "h->refcount);\n");
-        }
-        emit(gen, "    }\n");
+        emit(gen, "    free(ptr->data);\n");
         emit(gen, "}\n\n");
     }
 }
 
-// Emit __rc_dec_TypeName definitions for structs with Drop or RC-managed fields
-void emit_struct_rc_dec(CodeGen* gen, Node* ast) {
-    // Emit type-specific __rc_dec_TypeName functions for structs with Drop or RC fields
-    // Non-generic structs: scan modules for struct decls with resolved types
+// Emit __TypeName_cleanup definitions for structs with Drop or RC-managed fields
+void emit_struct_cleanup(CodeGen* gen, Node* ast) {
+    // Non-generic structs
     for (int m = 0; m < ast->as.program.modules.count; m++) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
@@ -742,35 +623,19 @@ void emit_struct_rc_dec(CodeGen* gen, Node* ast) {
             if (!has_drop && rc_field_count == 0)
                 continue;
 
-            emit(gen, "static inline void __rc_dec_%s(%s* ptr) {\n", sname, sname);
-            emit(gen, "    if (!ptr) return;\n");
-            emit(gen, "    __RcHeader* h = (__RcHeader*)ptr - 1;\n");
-            emit(gen, "    if (--h->refcount == 0) {\n");
+            emit(gen, "static inline void __%s_cleanup(void* raw) {\n", sname);
+            emit(gen, "    %s* ptr = (%s*)raw;\n", sname, sname);
             if (has_drop) {
-                emit(gen, "        %s_drop(ptr);\n", sname);
+                emit(gen, "    %s_drop(ptr);\n", sname);
             }
             for (int f = 0; f < rc_field_count; f++) {
-                const char* field_tname = rc_fields[f].type_name;
                 if (rc_fields[f].is_enum) {
-                    emit(gen, "        __rc_dec_%s(ptr->%s);\n", field_tname,
-                         rc_fields[f].field_name);
-                } else if (field_needs_custom_dec(gen, field_tname, ast)) {
-                    emit(gen, "        __rc_dec_%s(ptr->%s);\n", field_tname,
+                    emit(gen, "    __rc_dec_%s(ptr->%s);\n", rc_fields[f].type_name,
                          rc_fields[f].field_name);
                 } else {
-                    emit(gen, "        __rc_dec(ptr->%s);\n", rc_fields[f].field_name);
+                    emit(gen, "    __rc_dec(ptr->%s);\n", rc_fields[f].field_name);
                 }
             }
-            if (gen->rc.debug) {
-                emit(gen, "        fprintf(stderr, \"RC_FREE: %%p\\n\", (void*)ptr);\n");
-            }
-            emit(gen, "        free(h);\n");
-            if (gen->rc.debug) {
-                emit(gen, "    } else {\n");
-                emit(gen, "        fprintf(stderr, \"RC_DEC: %%p (rc=%%zu)\\n\", (void*)ptr, "
-                          "h->refcount);\n");
-            }
-            emit(gen, "    }\n");
             emit(gen, "}\n\n");
 
             for (int f = 0; f < rc_field_count; f++) {
@@ -781,7 +646,7 @@ void emit_struct_rc_dec(CodeGen* gen, Node* ast) {
         }
     }
 
-    // Generic instances: emit __rc_dec_MangledName for those with Drop or RC fields
+    // Generic instances
     for (int i = 0; i < gen->checker.instance_count; i++) {
         GenericInstance* info = &gen->checker.instances[i];
         Type*            t    = info->type;
@@ -795,37 +660,19 @@ void emit_struct_rc_dec(CodeGen* gen, Node* ast) {
             continue;
 
         const char* mname = info->mangled_name;
-        emit(gen, "static inline void __rc_dec_%s(%s* ptr) {\n", mname, mname);
-        emit(gen, "    if (!ptr) return;\n");
-        emit(gen, "    __RcHeader* h = (__RcHeader*)ptr - 1;\n");
-        emit(gen, "    if (--h->refcount == 0) {\n");
+        emit(gen, "static inline void __%s_cleanup(void* raw) {\n", mname);
+        emit(gen, "    %s* ptr = (%s*)raw;\n", mname, mname);
         if (has_drop) {
-            emit(gen, "        %s_drop(ptr);\n", mname);
+            emit(gen, "    %s_drop(ptr);\n", mname);
         }
         for (int f = 0; f < t->as.struc.field_count; f++) {
             Type* ft = t->as.struc.field_types[f];
             if (ft && ft->kind == TYPE_STRUCT) {
-                if (ft->as.struc.has_drop || ft->as.struc.has_rc_fields) {
-                    emit(gen, "        __rc_dec_%s(ptr->%s);\n", ft->as.struc.name,
-                         t->as.struc.field_names[f]);
-                } else {
-                    emit(gen, "        __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
-                }
+                emit(gen, "    __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
             } else if (ft && ft->kind == TYPE_VEC) {
-                emit(gen, "        __rc_dec_Vec_%s(ptr->%s);\n", type_mangle_name(ft->as.vec.elem),
-                     t->as.struc.field_names[f]);
+                emit(gen, "    __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
             }
         }
-        if (gen->rc.debug) {
-            emit(gen, "        fprintf(stderr, \"RC_FREE: %%p\\n\", (void*)ptr);\n");
-        }
-        emit(gen, "        free(h);\n");
-        if (gen->rc.debug) {
-            emit(gen, "    } else {\n");
-            emit(gen, "        fprintf(stderr, \"RC_DEC: %%p (rc=%%zu)\\n\", (void*)ptr, "
-                      "h->refcount);\n");
-        }
-        emit(gen, "    }\n");
         emit(gen, "}\n\n");
     }
 }

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -82,7 +82,7 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
         emit_indent(gen);
         emit(gen, "__rc_inc(__rc_tmp%d);\n", temp_id);
         emit_indent(gen);
-        emit(gen, "%s(%s);\n", rc_get_dec_func(gen, var_name), var_name);
+        emit(gen, "__rc_dec(%s);\n", var_name);
         emit_indent(gen);
         emit(gen, "%s = __rc_tmp%d;\n", var_name, temp_id);
         return;
@@ -133,10 +133,7 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
                                rc_is_tracked(gen, expr->as.assign.value->as.ident.name)) ||
                               expr->as.assign.value->type == NODE_NEW_EXPR;
             if (value_is_rc && field_ty && field_ty->kind == TYPE_STRUCT) {
-                // Determine the dec function for the field's type
-                char*       member_dec_owned = (char*)get_dec_func_for_type(field_ty);
-                const char* member_dec       = member_dec_owned;
-                int         tmp              = gen->out.temp_count++;
+                int tmp = gen->out.temp_count++;
                 emit_indent(gen);
                 emit(gen, "void* __rc_tmp%d = (void*)", tmp);
                 emit_expr(gen, expr->as.assign.value);
@@ -144,30 +141,23 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
                 emit_indent(gen);
                 emit(gen, "__rc_inc(__rc_tmp%d);\n", tmp);
                 emit_indent(gen);
-                emit(gen, "%s(", member_dec);
+                emit(gen, "__rc_dec(");
                 emit_expr(gen, member);
                 emit(gen, ");\n");
                 emit_indent(gen);
                 emit_expr(gen, member);
                 emit(gen, " = __rc_tmp%d;\n", tmp);
-                free(member_dec_owned);
                 return;
             }
         }
         // Handle self.field = new_value in method bodies (self is not RC-tracked)
         if (!obj_is_rc && member->as.member.object->type == NODE_IDENT &&
             strcmp(member->as.member.object->as.ident.name, "self") == 0) {
-            int   value_is_rc = expr->as.assign.value->type == NODE_NEW_EXPR;
-            char* dec_fn      = NULL;
-            if (value_is_rc && gen->generics.tmpl) {
-                // Generic method: look up field type from template
-                Node* ftype = lookup_generic_template_field_type(gen, member->as.member.name);
-                dec_fn      = resolve_generic_field_dec_func(gen, ftype);
-            }
-            if (dec_fn) {
+            int value_is_rc = expr->as.assign.value->type == NODE_NEW_EXPR;
+            if (value_is_rc) {
                 // Dec the old field value, then assign the new one
                 emit_indent(gen);
-                emit(gen, "%s(", dec_fn);
+                emit(gen, "__rc_dec(");
                 emit_expr(gen, member);
                 emit(gen, ");\n");
                 emit_indent(gen);
@@ -175,7 +165,6 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
                 emit(gen, " = ");
                 emit_expr(gen, expr->as.assign.value);
                 emit(gen, ";\n");
-                free(dec_fn);
                 return;
             }
         }
@@ -209,8 +198,8 @@ static void emit_var_decl_rc_new_vec(CodeGen* gen, Node* node) {
     Type*       rtype      = node->as.var_decl.init->as.new_expr.resolved_type;
     const char* elem_tname = type_mangle_name(rtype->as.vec.elem);
     emit_indent(gen);
-    emit(gen, "__Vec_%s* %s = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s));\n", elem_tname,
-         node->as.var_decl.name, elem_tname, elem_tname);
+    emit(gen, "__Vec_%s* %s = (__Vec_%s*)__rc_alloc(sizeof(__Vec_%s), __Vec_%s_cleanup);\n",
+         elem_tname, node->as.var_decl.name, elem_tname, elem_tname, elem_tname);
     emit_indent(gen);
     emit(gen, "%s->data = NULL; %s->count = 0; %s->capacity = 0;\n", node->as.var_decl.name,
          node->as.var_decl.name, node->as.var_decl.name);
@@ -224,30 +213,37 @@ static void emit_var_decl_rc_new_vec(CodeGen* gen, Node* node) {
             emit(gen, ");\n");
         }
     }
-    char dec_buf[256];
-    snprintf(dec_buf, sizeof(dec_buf), "__rc_dec_Vec_%s", elem_tname);
-    rc_push_var(gen, node->as.var_decl.name, dec_buf, rtype);
+    rc_push_var(gen, node->as.var_decl.name, rtype);
 }
 
 // Emit an RC-managed StringBuilder declaration: var sb = new StringBuilder{}
 static void emit_var_decl_rc_new_stringbuilder(CodeGen* gen, Node* node) {
     emit_indent(gen);
-    emit(gen, "__StringBuilder* %s = (__StringBuilder*)__rc_alloc(sizeof(__StringBuilder));\n",
+    emit(gen,
+         "__StringBuilder* %s = (__StringBuilder*)__rc_alloc(sizeof(__StringBuilder), "
+         "__StringBuilder_cleanup);\n",
          node->as.var_decl.name);
     emit_indent(gen);
     emit(gen, "%s->data = NULL; %s->count = 0; %s->capacity = 0;\n", node->as.var_decl.name,
          node->as.var_decl.name, node->as.var_decl.name);
     Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
-    rc_push_var(gen, node->as.var_decl.name, "__rc_dec_StringBuilder", rtype);
+    rc_push_var(gen, node->as.var_decl.name, rtype);
 }
 
 // Emit an RC-managed struct declaration: var p = new Point { x: 1, y: 2 }
 static void emit_var_decl_rc_new_struct(CodeGen* gen, Node* node) {
-    Type*       rtype = node->as.var_decl.init->as.new_expr.resolved_type;
-    const char* tname = rtype->as.struc.name;
+    Type*       rtype   = node->as.var_decl.init->as.new_expr.resolved_type;
+    const char* tname   = rtype->as.struc.name;
+    char*       cleanup = get_cleanup_func_for_type(rtype);
     emit_indent(gen);
-    emit(gen, "%s* %s = (%s*)__rc_alloc(sizeof(%s));\n", tname, node->as.var_decl.name, tname,
-         tname);
+    if (cleanup) {
+        emit(gen, "%s* %s = (%s*)__rc_alloc(sizeof(%s), %s);\n", tname, node->as.var_decl.name,
+             tname, tname, cleanup);
+    } else {
+        emit(gen, "%s* %s = (%s*)__rc_alloc(sizeof(%s), NULL);\n", tname, node->as.var_decl.name,
+             tname, tname);
+    }
+    free(cleanup);
     emit_indent(gen);
     emit(gen, "*%s = (%s)", node->as.var_decl.name, tname);
     emit_struct_init(gen, node->as.var_decl.init->as.new_expr.init);
@@ -267,9 +263,7 @@ static void emit_var_decl_rc_new_struct(CodeGen* gen, Node* node) {
             free((char*)inc_fn);
         }
     }
-    const char* dec_fn = get_dec_func_for_type(rtype);
-    rc_push_var(gen, node->as.var_decl.name, dec_fn, rtype);
-    free((char*)dec_fn);
+    rc_push_var(gen, node->as.var_decl.name, rtype);
 }
 
 // Emit an RC copy or ownership transfer: var x = existing_rc_var or func_call()
@@ -302,9 +296,7 @@ static void emit_var_decl_rc_copy(CodeGen* gen, Node* node) {
         emit(gen, "%s(%s);\n", inc_fn, node->as.var_decl.name);
         free((char*)inc_fn);
     }
-    const char* dec_fn = get_dec_func_for_type(rc_type);
-    rc_push_var(gen, node->as.var_decl.name, dec_fn, rc_type);
-    free((char*)dec_fn);
+    rc_push_var(gen, node->as.var_decl.name, rc_type);
 }
 
 // Emit a type-and-name declaration inferred from the initializer expression.


### PR DESCRIPTION
## Summary

Closes #202

- Embeds a `void (*cleanup)(void*)` function pointer in `__RcHeader`, stored at allocation time via `__rc_alloc(size, cleanup)`
- Makes `__rc_dec` universal — it calls the cleanup pointer (if any) then frees, eliminating per-variable dec function tracking
- Replaces type-specific `__rc_dec_TypeName` functions with `__TypeName_cleanup(void* raw)` cleanup functions that handle Drop + field cleanup without refcount logic
- Removes `dec_func` from `RcVar`, deletes `get_dec_func_for_type`, `rc_get_dec_func`, `field_needs_custom_dec`, `resolve_generic_field_dec_func`, and struct RC dec forward declarations
- Enum value types (not heap-allocated) continue to use `__rc_dec_EnumName` via an `emit_rc_dec_var` helper
- Net deletion of ~200 lines of codegen complexity

This is a prerequisite for `dyn Trait` (#201) where the concrete type is unknown at the dec call site.

## Test plan

- [x] `make` — builds successfully
- [x] `make test` — all 249/249 tests pass
- [x] Spot-checked generated C output for correct cleanup function names, Drop ordering, and NULL for types without cleanup