### PR TITLE
feat: generic free functions with trait bounds and type inference

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -57,7 +57,7 @@ Use statements selectively bring symbols from an imported module into unqualifie
 ### Function Declaration
 
 ```bnf
-<func-decl> ::= 'func' [ <receiver> ] <identifier> '(' [ <param-list> ] ')' [ ':' <return-type> ]
+<func-decl> ::= 'func' [ <receiver> ] <identifier> [ '<' <type-param-list> '>' ] '(' [ <param-list> ] ')' [ ':' <return-type> ]
 <func-defn> ::= <func-decl> <block>
 
 <receiver> ::= '(' [ 'const' ] <identifier> [ '<' <type-arg-list> '>' ] ')'
@@ -75,6 +75,13 @@ Use statements selectively bring symbols from an imported module into unqualifie
 ```
 
 When an `extern` block has no explicit visibility modifier at top level, functions in the block default to private unless overridden per function.
+
+**Generic free functions:** Free functions (without a receiver) can have type parameters:
+- `func identity<T>(x: T): T` — single type parameter
+- `func first<A, B>(a: A, b: B): A` — multiple type parameters
+- `func get_label<T: Printable>(x: T): string` — type parameter with trait bound
+
+Type arguments are inferred from call-site argument types (no explicit type arguments at call sites). Each unique instantiation produces a monomorphized C function (e.g., `identity_i64`, `identity_string`).
 
 **Generic methods:** Methods can be defined on generic structs using type arguments in the receiver:
 - `func (Box<T>) get(): T` — method on any `Box<T>` instantiation

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -134,6 +134,7 @@ void node_free(Node* node) {
     case NODE_CALL:
         node_free(node->as.call.func);
         nodelist_free(&node->as.call.args);
+        free(node->as.call.resolved_name);
         break;
     case NODE_INDEX:
         node_free(node->as.index.object);
@@ -229,6 +230,13 @@ void node_free(Node* node) {
         nodelist_free(&node->as.func_decl.params);
         node_free(node->as.func_decl.return_type);
         node_free(node->as.func_decl.body);
+        // Free type parameters and bounds for generic free functions
+        for (int i = 0; i < node->as.func_decl.type_param_count; i++) {
+            free(node->as.func_decl.type_params[i]);
+            free(node->as.func_decl.type_param_bounds[i]);
+        }
+        free(node->as.func_decl.type_params);
+        free(node->as.func_decl.type_param_bounds);
         // Free accessible modules list
         for (int i = 0; i < node->as.func_decl.accessible_modules_count; i++) {
             free(node->as.func_decl.accessible_modules[i]);
@@ -400,6 +408,10 @@ static void node_reset_checker_flags(Node* node) {
         node->as.var_decl.is_rc            = 0;
         node->as.var_decl.resolved_type    = NULL;
         node->as.var_decl.destruct_pattern = NULL;
+        break;
+    case NODE_CALL:
+        free(node->as.call.resolved_name);
+        node->as.call.resolved_name = NULL;
         break;
     case NODE_FOREACH:
         node->as.foreach_stmt.resolved_type = NULL;

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -130,6 +130,10 @@ typedef struct {
     NodeList receiver_type_args; // Type nodes for type arguments in receiver
     char*    name;
     int      name_length;
+    // Generic type parameters for free functions: func identity<T>(x: T): T
+    char** type_params;       // ["T"] or ["T", "U"]
+    char** type_param_bounds; // Trait bounds parallel to type_params (NULL entries = unbounded)
+    int    type_param_count;
     char*    extern_name; // Original C function name (when 'as' alias used), NULL otherwise
     int      extern_name_length;
     NodeList params;
@@ -210,6 +214,7 @@ struct Node {
         struct {
             Node*    func;
             NodeList args;
+            char*    resolved_name; // Set by checker: mangled name for generic function calls
         } call;
 
         // Index expression: arr[index]

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -108,6 +108,13 @@ void checker_init(Checker* checker) {
     checker->generics.current_type_params      = NULL;
     checker->generics.current_type_args        = NULL;
     checker->generics.current_type_param_count = 0;
+    // Generic free functions
+    checker->generics.func_defs              = NULL;
+    checker->generics.func_def_count         = 0;
+    checker->generics.func_def_capacity      = 0;
+    checker->generics.func_instances         = NULL;
+    checker->generics.func_instance_count    = 0;
+    checker->generics.func_instance_capacity = 0;
     // Span support
     checker->containers.spans         = NULL;
     checker->containers.span_count    = 0;
@@ -194,6 +201,26 @@ void checker_free(Checker* checker) {
         free(checker->generics.instances[i].type_args);
     }
     free(checker->generics.instances);
+    // Free generic free function definitions
+    for (int i = 0; i < checker->generics.func_def_count; i++) {
+        free(checker->generics.func_defs[i].name);
+        for (int j = 0; j < checker->generics.func_defs[i].type_param_count; j++) {
+            free(checker->generics.func_defs[i].type_params[j]);
+            free(checker->generics.func_defs[i].type_param_bounds[j]);
+        }
+        free(checker->generics.func_defs[i].type_params);
+        free(checker->generics.func_defs[i].type_param_bounds);
+        free((void*)checker->generics.func_defs[i].source_module);
+    }
+    free(checker->generics.func_defs);
+    // Free generic free function instances
+    for (int i = 0; i < checker->generics.func_instance_count; i++) {
+        free(checker->generics.func_instances[i].mangled_name);
+        free(checker->generics.func_instances[i].base_name);
+        free(checker->generics.func_instances[i].type_args);
+        node_free(checker->generics.func_instances[i].body);
+    }
+    free(checker->generics.func_instances);
     // Free span instances
     for (int i = 0; i < checker->containers.span_count; i++) {
         free(checker->containers.spans[i].mangled_name);
@@ -1090,6 +1117,13 @@ static void check_func_decl(Checker* checker, Node* node) {
     const char* receiver_type = fdn->receiver_type;
     int         is_method     = (receiver_type != NULL);
 
+    // Generic free function: func identity<T>(x: T): T — register template, skip body
+    if (!is_method && fdn->type_param_count > 0) {
+        register_generic_func_def(checker, name, fdn->type_params, fdn->type_param_bounds,
+                                  fdn->type_param_count, node);
+        return;
+    }
+
     // Check if this is a method on a generic struct: func (Box<T>) get(): T
     // or func (Pair<i32, Box<T>>) set(): void
     if (is_method && fdn->receiver_type_args.count > 0) {
@@ -1799,16 +1833,25 @@ static int is_generic_method_decl(Node* decl) {
            decl->as.func_decl.receiver_type_args.count > 0;
 }
 
+static int is_generic_func_decl(Node* decl) {
+    if (!decl || decl->type != NODE_FUNC_DECL) {
+        return 0;
+    }
+    return decl->as.func_decl.receiver_type == NULL &&
+           decl->as.func_decl.type_param_count > 0;
+}
+
 static int is_generic_impl_decl(Node* decl) {
     return decl && decl->type == NODE_IMPL_DECL && decl->as.impl_decl.type_args.count > 0;
 }
 
 static int decl_processed_in_early_passes(Node* decl) {
-    return is_type_decl(decl) || is_generic_method_decl(decl) || is_generic_impl_decl(decl);
+    return is_type_decl(decl) || is_generic_method_decl(decl) || is_generic_impl_decl(decl) ||
+           is_generic_func_decl(decl);
 }
 
 static int is_generic_registration_decl(Node* decl) {
-    return is_generic_method_decl(decl) || is_generic_impl_decl(decl);
+    return is_generic_method_decl(decl) || is_generic_impl_decl(decl) || is_generic_func_decl(decl);
 }
 
 static int is_regular_decl(Node* decl) {

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -88,6 +88,26 @@ typedef struct {
     Type* type;         // The TYPE_VEC instance
 } VecInstance;
 
+// Generic free function definition (template)
+typedef struct {
+    char*       name;
+    char**      type_params;       // ["T"] or ["T", "U"]
+    char**      type_param_bounds; // Trait bounds parallel to type_params (NULL = unbounded)
+    int         type_param_count;
+    Node*       decl;              // Original AST node (NODE_FUNC_DECL)
+    const char* source_module;
+} GenericFuncDef;
+
+// Instantiated generic free function
+typedef struct {
+    char*  mangled_name;  // "identity_i64"
+    char*  base_name;     // "identity"
+    Type*  func_type;     // Concrete TYPE_FUNC
+    Type** type_args;
+    int    type_arg_count;
+    Node*  body;          // Cloned + type-checked body
+} GenericFuncInstance;
+
 // Module import tracking
 typedef struct {
     char**      direct_imports;
@@ -108,6 +128,13 @@ typedef struct {
     char**           current_type_params; // Type parameter names
     Type**           current_type_args;   // Concrete types for each param
     int              current_type_param_count;
+    // Generic free functions
+    GenericFuncDef*      func_defs;
+    int                  func_def_count;
+    int                  func_def_capacity;
+    GenericFuncInstance*  func_instances;
+    int                  func_instance_count;
+    int                  func_instance_capacity;
 } CheckerGenerics;
 
 // Instantiated container types (Span, Vec)

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -9,6 +9,128 @@
 // Forward declaration for check_struct_init (called by check_new_expr)
 static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
 
+// Infer type parameters from a parameter type node and the actual argument type.
+// Recursively walks the parameter type AST and binds type parameter names to
+// concrete types from the argument. `inferred` array is parallel to def->type_params.
+static void infer_type_param(Checker* checker, GenericFuncDef* def, Node* param_type, Type* arg_type,
+                             Type** inferred) {
+    if (!param_type || !arg_type || arg_type->kind == TYPE_ERROR)
+        return;
+
+    // Direct type parameter reference: T
+    if (param_type->type == NODE_IDENT) {
+        for (int i = 0; i < def->type_param_count; i++) {
+            if (strcmp(param_type->as.ident.name, def->type_params[i]) == 0) {
+                if (!inferred[i]) {
+                    inferred[i] = arg_type;
+                }
+                return;
+            }
+        }
+        return;
+    }
+
+    // Generic type: Vec<T>, Span<T>, Box<T>, Pair<K, V>, etc.
+    if (param_type->type == NODE_GENERIC_TYPE) {
+        const char* base = param_type->as.generic_type.base_name;
+
+        // Vec<T> → recurse on element type
+        if (strcmp(base, "Vec") == 0 && arg_type->kind == TYPE_VEC &&
+            param_type->as.generic_type.type_args.count == 1) {
+            infer_type_param(checker, def, param_type->as.generic_type.type_args.nodes[0],
+                             arg_type->as.vec.elem, inferred);
+            return;
+        }
+
+        // Span<T> → recurse on element type
+        if (strcmp(base, "Span") == 0 && arg_type->kind == TYPE_SPAN &&
+            param_type->as.generic_type.type_args.count == 1) {
+            infer_type_param(checker, def, param_type->as.generic_type.type_args.nodes[0],
+                             arg_type->as.span.elem, inferred);
+            return;
+        }
+
+        // User-defined generic struct: Box<T>, Pair<K, V>
+        if (arg_type->kind == TYPE_STRUCT) {
+            // Find the generic instance matching the arg type
+            for (int i = 0; i < checker->generics.instance_count; i++) {
+                GenericInstance* inst = &checker->generics.instances[i];
+                if (strcmp(inst->mangled_name, arg_type->as.struc.name) == 0) {
+                    int n = param_type->as.generic_type.type_args.count;
+                    if (n == inst->type_arg_count) {
+                        for (int j = 0; j < n; j++) {
+                            infer_type_param(checker, def,
+                                             param_type->as.generic_type.type_args.nodes[j],
+                                             inst->type_args[j], inferred);
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+
+        // Generic enum: Option<T>, Result<T, E>
+        if (arg_type->kind == TYPE_ENUM) {
+            for (int i = 0; i < checker->generics.instance_count; i++) {
+                GenericInstance* inst = &checker->generics.instances[i];
+                if (strcmp(inst->mangled_name, arg_type->as.enm.name) == 0) {
+                    int n = param_type->as.generic_type.type_args.count;
+                    if (n == inst->type_arg_count) {
+                        for (int j = 0; j < n; j++) {
+                            infer_type_param(checker, def,
+                                             param_type->as.generic_type.type_args.nodes[j],
+                                             inst->type_args[j], inferred);
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+
+        return;
+    }
+
+    // Function type: func(T1, T2): R
+    if (param_type->type == NODE_FUNC_TYPE && arg_type->kind == TYPE_FUNC) {
+        int n = param_type->as.func_type.param_types.count;
+        if (n == arg_type->as.func.param_count) {
+            for (int i = 0; i < n; i++) {
+                infer_type_param(checker, def, param_type->as.func_type.param_types.nodes[i],
+                                 arg_type->as.func.param_types[i], inferred);
+            }
+        }
+        if (param_type->as.func_type.return_type) {
+            infer_type_param(checker, def, param_type->as.func_type.return_type,
+                             arg_type->as.func.return_type, inferred);
+        }
+        return;
+    }
+
+    // Tuple type: (T1, T2, ...)
+    if (param_type->type == NODE_TUPLE_TYPE && arg_type->kind == TYPE_TUPLE) {
+        int n = param_type->as.tuple_type.elem_types.count;
+        if (n == arg_type->as.tuple.elem_count) {
+            for (int i = 0; i < n; i++) {
+                infer_type_param(checker, def, param_type->as.tuple_type.elem_types.nodes[i],
+                                 arg_type->as.tuple.elem_types[i], inferred);
+            }
+        }
+        return;
+    }
+
+    // Array type: [n]T or []T
+    if (param_type->type == NODE_ARRAY_TYPE) {
+        if (arg_type->kind == TYPE_ARRAY) {
+            infer_type_param(checker, def, param_type->as.array_type.elem_type,
+                             arg_type->as.array.elem, inferred);
+        } else if (arg_type->kind == TYPE_SPAN) {
+            infer_type_param(checker, def, param_type->as.array_type.elem_type,
+                             arg_type->as.span.elem, inferred);
+        }
+        return;
+    }
+}
+
 // Return the const variable/field name if node is a const binding or const field access, else NULL
 static const char* get_const_binding_name(Checker* checker, Node* node) {
     if (node && node->type == NODE_IDENT) {
@@ -1097,6 +1219,103 @@ static Type* check_call_expr(Checker* checker, Node* node) {
             return type_error;
         }
         return type_void;
+    }
+
+    // Check if callee is a generic free function
+    if (callee->type == NODE_IDENT) {
+        GenericFuncDef* gdef = lookup_generic_func_def(checker, callee->as.ident.name);
+        if (gdef) {
+            func_decl_node* fdn = &gdef->decl->as.func_decl;
+
+            // Check argument count
+            if (node->as.call.args.count != fdn->params.count) {
+                check_error(checker, node->line, node->column,
+                            "Generic function '%s' expects %d arguments, got %d", gdef->name,
+                            fdn->params.count, node->as.call.args.count);
+                return type_error;
+            }
+
+            // Type-check arguments
+            int    arg_count = node->as.call.args.count;
+            Type** arg_types = xmalloc(arg_count * sizeof(Type*));
+            int    has_error = 0;
+            for (int i = 0; i < arg_count; i++) {
+                arg_types[i] = check_expression(checker, node->as.call.args.nodes[i]);
+                if (arg_types[i]->kind == TYPE_ERROR) {
+                    has_error = 1;
+                }
+            }
+            if (has_error) {
+                free(arg_types);
+                return type_error;
+            }
+
+            // Infer type parameters from argument types
+            Type** inferred = xcalloc(gdef->type_param_count, sizeof(Type*));
+            for (int i = 0; i < arg_count; i++) {
+                Node* param_type_node = fdn->params.nodes[i]->as.param.type;
+                infer_type_param(checker, gdef, param_type_node, arg_types[i], inferred);
+            }
+
+            // Check all type params were inferred
+            for (int i = 0; i < gdef->type_param_count; i++) {
+                if (!inferred[i]) {
+                    check_error(checker, node->line, node->column,
+                                "Cannot infer type parameter '%s' for generic function '%s'",
+                                gdef->type_params[i], gdef->name);
+                    free(arg_types);
+                    free(inferred);
+                    return type_error;
+                }
+            }
+
+            // Check trait bounds
+            for (int i = 0; i < gdef->type_param_count; i++) {
+                if (gdef->type_param_bounds[i]) {
+                    const char* bound             = gdef->type_param_bounds[i];
+                    const char* arg_type_name_str = NULL;
+                    if (inferred[i]->kind == TYPE_STRUCT) {
+                        arg_type_name_str = inferred[i]->as.struc.name;
+                    } else {
+                        arg_type_name_str = type_name(inferred[i]);
+                    }
+                    int satisfied = 0;
+                    if (arg_type_name_str) {
+                        for (int t = 0; t < checker->traits.impl_count; t++) {
+                            if (strcmp(checker->traits.impls[t].trait_name, bound) == 0 &&
+                                strcmp(checker->traits.impls[t].type_name, arg_type_name_str) == 0) {
+                                satisfied = 1;
+                                break;
+                            }
+                        }
+                    }
+                    if (!satisfied) {
+                        check_error(checker, node->line, node->column,
+                                    "Type '%s' does not implement trait '%s' required by '%s'",
+                                    type_name(inferred[i]), bound, gdef->name);
+                        free(arg_types);
+                        free(inferred);
+                        return type_error;
+                    }
+                }
+            }
+
+            // Instantiate the generic function
+            GenericFuncInstance* inst =
+                instantiate_generic_func(checker, gdef, inferred, gdef->type_param_count,
+                                         node->line, node->column);
+            free(arg_types);
+            free(inferred);
+
+            if (!inst) {
+                return type_error;
+            }
+
+            // Set resolved name on the call node for codegen
+            node->as.call.resolved_name = xstrdup(inst->mangled_name);
+
+            return inst->func_type->as.func.return_type;
+        }
     }
 
     Type* func_type = check_expression(checker, node->as.call.func);

--- a/w0/checker_internal.h
+++ b/w0/checker_internal.h
@@ -24,6 +24,15 @@ void             register_generic_method(GenericDef* def, Node* method);
 GenericDef*      lookup_generic_def(Checker* checker, const char* name);
 GenericInstance* lookup_generic_instance(Checker* checker, const char* mangled_name);
 
+// --- From checker_types.c: generic free function management ---
+void                 register_generic_func_def(Checker* checker, const char* name, char** type_params,
+                                               char** type_param_bounds, int type_param_count,
+                                               Node* decl);
+GenericFuncDef*      lookup_generic_func_def(Checker* checker, const char* name);
+GenericFuncInstance* lookup_generic_func_instance(Checker* checker, const char* mangled_name);
+GenericFuncInstance* instantiate_generic_func(Checker* checker, GenericFuncDef* def, Type** type_args,
+                                              int type_arg_count, int line, int col);
+
 // --- From checker_expr.c: expression checking ---
 Type* check_expression(Checker* checker, Node* node);
 

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -96,6 +96,152 @@ GenericInstance* lookup_generic_instance(Checker* checker, const char* mangled_n
     return NULL;
 }
 
+// =============================================================================
+// Generic free function helpers
+// =============================================================================
+
+// Register a generic free function definition
+void register_generic_func_def(Checker* checker, const char* name, char** type_params,
+                                char** type_param_bounds, int type_param_count, Node* decl) {
+    // Check for duplicate
+    for (int i = 0; i < checker->generics.func_def_count; i++) {
+        if (strcmp(checker->generics.func_defs[i].name, name) == 0) {
+            return; // Already registered
+        }
+    }
+
+    VEC_GROW(checker->generics.func_defs, checker->generics.func_def_count,
+             checker->generics.func_def_capacity);
+    GenericFuncDef* def = &checker->generics.func_defs[checker->generics.func_def_count++];
+    def->name              = xstrdup(name);
+    def->type_params       = xmalloc(type_param_count * sizeof(char*));
+    def->type_param_bounds = xmalloc(type_param_count * sizeof(char*));
+    for (int i = 0; i < type_param_count; i++) {
+        def->type_params[i] = xstrdup(type_params[i]);
+        def->type_param_bounds[i] =
+            (type_param_bounds && type_param_bounds[i]) ? xstrdup(type_param_bounds[i]) : NULL;
+    }
+    def->type_param_count = type_param_count;
+    def->decl             = decl;
+    def->source_module    = checker->modules.current_module ? xstrdup(checker->modules.current_module)
+                                                            : NULL;
+}
+
+// Look up a generic free function definition by name
+GenericFuncDef* lookup_generic_func_def(Checker* checker, const char* name) {
+    for (int i = 0; i < checker->generics.func_def_count; i++) {
+        if (strcmp(checker->generics.func_defs[i].name, name) == 0) {
+            return &checker->generics.func_defs[i];
+        }
+    }
+    return NULL;
+}
+
+// Look up an already-instantiated generic free function by mangled name
+GenericFuncInstance* lookup_generic_func_instance(Checker* checker, const char* mangled_name) {
+    for (int i = 0; i < checker->generics.func_instance_count; i++) {
+        if (strcmp(checker->generics.func_instances[i].mangled_name, mangled_name) == 0) {
+            return &checker->generics.func_instances[i];
+        }
+    }
+    return NULL;
+}
+
+// Instantiate a generic free function with concrete type arguments
+GenericFuncInstance* instantiate_generic_func(Checker* checker, GenericFuncDef* def, Type** type_args,
+                                              int type_arg_count, int line, int col) {
+    (void)line;
+    (void)col;
+    // Generate mangled name
+    char* mangled = type_mangle_generic(def->name, type_args, type_arg_count);
+
+    // Check cache
+    GenericFuncInstance* existing = lookup_generic_func_instance(checker, mangled);
+    if (existing) {
+        free(mangled);
+        return existing;
+    }
+
+    func_decl_node* fdn = &def->decl->as.func_decl;
+
+    // Save and set up substitution context
+    char** old_params = checker->generics.current_type_params;
+    Type** old_args   = checker->generics.current_type_args;
+    int    old_count  = checker->generics.current_type_param_count;
+
+    checker->generics.current_type_params      = def->type_params;
+    checker->generics.current_type_args        = type_args;
+    checker->generics.current_type_param_count = def->type_param_count;
+
+    // Resolve concrete parameter types and return type
+    int    param_count = fdn->params.count;
+    Type** param_types = NULL;
+    if (param_count > 0) {
+        param_types = xmalloc(param_count * sizeof(Type*));
+    }
+    for (int i = 0; i < param_count; i++) {
+        Node* param = fdn->params.nodes[i];
+        param_types[i] = resolve_type(checker, param->as.param.type);
+    }
+    Type* return_type = type_void;
+    if (fdn->return_type) {
+        return_type = resolve_type(checker, fdn->return_type);
+    }
+
+    Type* func_type = type_func(param_types, param_count, return_type, fdn->is_varargs);
+
+    // Pre-declare the mangled function in the symbol table for recursion
+    checker_define(checker, mangled, SYM_FUNC, func_type, 1, fdn->is_public,
+                   checker->modules.current_module);
+
+    // Clone and type-check the body
+    Node* body = node_clone(fdn->body);
+
+    // Push scope for params
+    checker_push_scope(checker);
+    for (int i = 0; i < param_count; i++) {
+        Node* param = fdn->params.nodes[i];
+        checker_define(checker, param->as.param.name, SYM_VAR, param_types[i],
+                       param->as.param.is_const, 0, NULL);
+    }
+
+    // Set function return type context
+    Type* old_return = checker->current_func_return;
+    checker->current_func_return = return_type;
+
+    // Type-check body statements
+    if (body && body->type == NODE_BLOCK) {
+        for (int s = 0; s < body->as.block.stmts.count; s++) {
+            check_statement(checker, body->as.block.stmts.nodes[s]);
+        }
+    }
+
+    checker->current_func_return = old_return;
+    checker_pop_scope(checker);
+
+    // Restore substitution context
+    checker->generics.current_type_params      = old_params;
+    checker->generics.current_type_args        = old_args;
+    checker->generics.current_type_param_count = old_count;
+
+    // Store the instance
+    VEC_GROW(checker->generics.func_instances, checker->generics.func_instance_count,
+             checker->generics.func_instance_capacity);
+    GenericFuncInstance* inst = &checker->generics.func_instances[checker->generics.func_instance_count++];
+    inst->mangled_name  = xstrdup(mangled);
+    inst->base_name     = xstrdup(def->name);
+    inst->func_type     = func_type;
+    inst->type_args     = xmalloc(type_arg_count * sizeof(Type*));
+    for (int i = 0; i < type_arg_count; i++) {
+        inst->type_args[i] = type_args[i];
+    }
+    inst->type_arg_count = type_arg_count;
+    inst->body           = body;
+
+    free(mangled);
+    return inst;
+}
+
 // Look up an already-instantiated span type by mangled name
 static SpanInstance* lookup_span_instance(Checker* checker, const char* mangled_name) {
     for (int i = 0; i < checker->containers.span_count; i++) {

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1109,6 +1109,120 @@ static void emit_generic_method_impls(CodeGen* gen, Node* ast) {
     }
 }
 
+// Find a generic free function declaration in the AST by name
+static Node* find_generic_func_decl(Node* ast, const char* name) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int d = 0; d < mod->as.module.decls.count; d++) {
+            Node* decl = mod->as.module.decls.nodes[d];
+            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.type_param_count > 0 &&
+                strcmp(decl->as.func_decl.name, name) == 0) {
+                return decl;
+            }
+        }
+    }
+    return NULL;
+}
+
+// Emit implementations for all instantiated generic free functions
+static void emit_generic_func_impls(CodeGen* gen, Node* ast) {
+    for (int i = 0; i < gen->checker.func_instance_count; i++) {
+        GenericFuncInstance* inst = &gen->checker.func_instances[i];
+
+        // Find template
+        Node* tmpl = find_generic_func_decl(ast, inst->base_name);
+        if (!tmpl)
+            continue;
+
+        func_decl_node* fdn = &tmpl->as.func_decl;
+
+        // Set up type substitution context
+        TypeSubstContext subst_ctx;
+        subst_ctx.type_params = fdn->type_params;
+        subst_ctx.type_args   = inst->type_args;
+        subst_ctx.count       = inst->type_arg_count;
+        gen->generics.subst   = &subst_ctx;
+
+        int is_void = return_type_is_void(fdn->return_type);
+
+        // Return type
+        emit_func_return_type(gen, fdn);
+
+        // Function name
+        emit(gen, " %s(", inst->mangled_name);
+
+        // Parameters
+        if (fdn->params.count == 0) {
+            emit(gen, "void");
+        } else {
+            for (int p = 0; p < fdn->params.count; p++) {
+                if (p > 0)
+                    emit(gen, ", ");
+                Node* param = fdn->params.nodes[p];
+                if (param->as.param.is_const) {
+                    emit(gen, "const ");
+                }
+                emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+            }
+        }
+        emit(gen, ") {\n");
+
+        // Clear defer stack for this function
+        defer_clear(gen);
+        gen->defer.return_type     = fdn->return_type;
+        gen->generics.modules      = fdn->accessible_modules;
+        gen->generics.module_count = fdn->accessible_modules_count;
+
+        // First pass: count defers to know if we need __ret
+        int has_defers = 0;
+        if (inst->body) {
+            for (int s = 0; s < inst->body->as.block.stmts.count; s++) {
+                Node* stmt = inst->body->as.block.stmts.nodes[s];
+                if (stmt && stmt->type == NODE_DEFER) {
+                    has_defers = 1;
+                    break;
+                }
+            }
+        }
+
+        // Body
+        gen->out.indent++;
+
+        // Declare __ret if function has defers and is non-void
+        if (has_defers && !is_void) {
+            emit_indent(gen);
+            emit_type(gen, fdn->return_type);
+            emit(gen, " __ret;\n");
+        }
+
+        // Emit function body
+        if (inst->body) {
+            for (int s = 0; s < inst->body->as.block.stmts.count; s++) {
+                emit_stmt(gen, inst->body->as.block.stmts.nodes[s]);
+            }
+        }
+
+        // Emit any remaining defers at function end
+        if (has_defers) {
+            for (int d = gen->defer.count - 1; d >= 0; d--) {
+                emit_stmt(gen, gen->defer.stack[d]);
+            }
+        }
+
+        gen->out.indent--;
+        emit(gen, "}\n\n");
+
+        // Clear RC tracking for generic function
+        rc_clear_all(gen);
+
+        gen->generics.subst        = NULL;
+        gen->generics.modules      = NULL;
+        gen->generics.module_count = 0;
+    }
+}
+
 // Main codegen entry point: emit all C code for a program AST
 void codegen_emit(CodeGen* gen, Node* ast) {
     if (!ast || ast->type != NODE_PROGRAM)
@@ -1139,6 +1253,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit_struct_cleanup(gen, ast);
     emit_declarations(gen, ast);
     emit_generic_method_impls(gen, ast);
+    emit_generic_func_impls(gen, ast);
     if (gen->test_mode) {
         emit_test_runner(gen, ast);
     } else if (has_user_main) {

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -58,15 +58,17 @@ typedef struct {
 } CodeGenGenerics;
 
 typedef struct {
-    GenericInstance* instances;
-    int              instance_count;
-    SpanInstance*    spans;
-    int              span_count;
-    VecInstance*     vecs;
-    int              vec_count;
-    TraitImpl*       traits;
-    int              trait_count;
-    SemInfo*         sem;
+    GenericInstance*     instances;
+    int                  instance_count;
+    SpanInstance*        spans;
+    int                  span_count;
+    VecInstance*         vecs;
+    int                  vec_count;
+    TraitImpl*           traits;
+    int                  trait_count;
+    GenericFuncInstance* func_instances;
+    int                  func_instance_count;
+    SemInfo*             sem;
 } CodeGenChecker;
 // CodeGenChecker pointers are borrowed from checker state (not owned by codegen).
 

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -600,6 +600,11 @@ static void emit_func_decl(CodeGen* gen, Node* node) {
         return;
     }
 
+    // Skip generic free function templates - they get instantiated separately
+    if (!is_method && node->as.func_decl.type_param_count > 0) {
+        return;
+    }
+
     // Check if function is void
     int is_void = return_type_is_void(node->as.func_decl.return_type);
 
@@ -1311,6 +1316,11 @@ void emit_function_forward_decls(CodeGen* gen, Node* ast) {
                     continue;
                 }
 
+                // Skip generic free function templates (they get instantiated separately)
+                if (!is_method && fdn->type_param_count > 0) {
+                    continue;
+                }
+
                 // In test mode, skip user's main function
                 if (gen->test_mode && !is_method && strcmp(fdn->name, "main") == 0) {
                     continue;
@@ -1455,5 +1465,64 @@ void emit_function_forward_decls(CodeGen* gen, Node* ast) {
 
         free(methods);
     }
+
+    // Forward declarations for instantiated generic free functions
+    for (int i = 0; i < gen->checker.func_instance_count; i++) {
+        GenericFuncInstance* inst = &gen->checker.func_instances[i];
+
+        // Find the template declaration in the AST
+        Node* tmpl = NULL;
+        for (int m = 0; m < ast->as.program.modules.count; m++) {
+            Node* mod = ast->as.program.modules.nodes[m];
+            if (!mod || mod->type != NODE_MODULE)
+                continue;
+            for (int d = 0; d < mod->as.module.decls.count; d++) {
+                Node* decl = mod->as.module.decls.nodes[d];
+                if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.type_param_count > 0 &&
+                    strcmp(decl->as.func_decl.name, inst->base_name) == 0) {
+                    tmpl = decl;
+                    break;
+                }
+            }
+            if (tmpl)
+                break;
+        }
+        if (!tmpl)
+            continue;
+
+        func_decl_node* fdn = &tmpl->as.func_decl;
+
+        // Set up type substitution
+        TypeSubstContext subst_ctx;
+        subst_ctx.type_params = fdn->type_params;
+        subst_ctx.type_args   = inst->type_args;
+        subst_ctx.count       = inst->type_arg_count;
+        gen->generics.subst   = &subst_ctx;
+
+        // Return type
+        emit_func_return_type(gen, fdn);
+
+        // Function name
+        emit(gen, " %s(", inst->mangled_name);
+
+        // Parameters
+        if (fdn->params.count == 0) {
+            emit(gen, "void");
+        } else {
+            for (int p = 0; p < fdn->params.count; p++) {
+                if (p > 0)
+                    emit(gen, ", ");
+                Node* param = fdn->params.nodes[p];
+                if (param->as.param.is_const) {
+                    emit(gen, "const ");
+                }
+                emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+            }
+        }
+        emit(gen, ");\n");
+
+        gen->generics.subst = NULL;
+    }
+
     emit(gen, "\n");
 }

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -338,6 +338,14 @@ static int is_extern_call(CodeGen* gen, Node* func) {
 }
 
 static void emit_regular_call(CodeGen* gen, Node* call, Node* func) {
+    // Generic free function calls use the checker-set mangled name
+    if (call->as.call.resolved_name) {
+        emit(gen, "%s(", call->as.call.resolved_name);
+        emit_call_args(gen, call, 0);
+        emit(gen, ")");
+        return;
+    }
+
     const char* alias_name = find_call_alias(gen, func);
     if (alias_name) {
         emit(gen, "%s(", alias_name);

--- a/w0/main.c
+++ b/w0/main.c
@@ -49,15 +49,17 @@ static int compile_to_c(const char* source, const char* source_path, const char*
     CodeGen gen;
     codegen_init(&gen, out,
                  (CodeGenChecker){
-                     .instances      = checker.generics.instances,
-                     .instance_count = checker.generics.instance_count,
-                     .spans          = checker.containers.spans,
-                     .span_count     = checker.containers.span_count,
-                     .vecs           = checker.containers.vecs,
-                     .vec_count      = checker.containers.vec_count,
-                     .traits         = checker.traits.impls,
-                     .trait_count    = checker.traits.impl_count,
-                     .sem            = checker.sem,
+                     .instances            = checker.generics.instances,
+                     .instance_count       = checker.generics.instance_count,
+                     .spans                = checker.containers.spans,
+                     .span_count           = checker.containers.span_count,
+                     .vecs                 = checker.containers.vecs,
+                     .vec_count            = checker.containers.vec_count,
+                     .traits               = checker.traits.impls,
+                     .trait_count          = checker.traits.impl_count,
+                     .func_instances       = checker.generics.func_instances,
+                     .func_instance_count  = checker.generics.func_instance_count,
+                     .sem                  = checker.sem,
                  },
                  rc_debug, test_mode, source_path);
     codegen_emit(&gen, ast);
@@ -504,15 +506,17 @@ int main(int argc, char** argv) {
                 CodeGen gen;
                 codegen_init(&gen, out,
                              (CodeGenChecker){
-                                 .instances      = checker.generics.instances,
-                                 .instance_count = checker.generics.instance_count,
-                                 .spans          = checker.containers.spans,
-                                 .span_count     = checker.containers.span_count,
-                                 .vecs           = checker.containers.vecs,
-                                 .vec_count      = checker.containers.vec_count,
-                                 .traits         = checker.traits.impls,
-                                 .trait_count    = checker.traits.impl_count,
-                                 .sem            = checker.sem,
+                                 .instances            = checker.generics.instances,
+                                 .instance_count       = checker.generics.instance_count,
+                                 .spans                = checker.containers.spans,
+                                 .span_count           = checker.containers.span_count,
+                                 .vecs                 = checker.containers.vecs,
+                                 .vec_count            = checker.containers.vec_count,
+                                 .traits               = checker.traits.impls,
+                                 .trait_count          = checker.traits.impl_count,
+                                 .func_instances       = checker.generics.func_instances,
+                                 .func_instance_count  = checker.generics.func_instance_count,
+                                 .sem                  = checker.sem,
                              },
                              rc_debug, 0, source_file);
                 codegen_emit(&gen, ast);

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1553,11 +1553,50 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
     fdn->receiver_type_args = receiver_type_args;
     fdn->name               = copy_token_string(&name);
     fdn->name_length        = name.length;
+    fdn->type_params        = NULL;
+    fdn->type_param_bounds  = NULL;
+    fdn->type_param_count   = 0;
     fdn->extern_name        = NULL;
     fdn->extern_name_length = 0;
     fdn->is_varargs         = 0;
     fdn->return_is_const    = 0;
     nodelist_init(&fdn->params);
+
+    // Parse type parameters for generic free functions: func identity<T>(x: T): T
+    // Only for free functions (not methods with receivers)
+    if (!receiver_type && match_token(parser, TOK_LT)) {
+        int capacity        = 4;
+        fdn->type_params       = xmalloc(capacity * sizeof(char*));
+        fdn->type_param_bounds = xmalloc(capacity * sizeof(char*));
+
+        do {
+            Token param_name = parser->current;
+            consume_token(parser, TOK_IDENT, "Expected type parameter name");
+
+            if (fdn->type_param_count >= capacity) {
+                capacity *= 2;
+                fdn->type_params =
+                    xrealloc(fdn->type_params, capacity * sizeof(char*));
+                fdn->type_param_bounds =
+                    xrealloc(fdn->type_param_bounds, capacity * sizeof(char*));
+            }
+
+            fdn->type_params[fdn->type_param_count] = copy_token_string(&param_name);
+
+            // Check for trait bound: T: TraitName
+            if (match_token(parser, TOK_COLON)) {
+                Token bound_name = parser->current;
+                consume_token(parser, TOK_IDENT, "Expected trait name after ':'");
+                fdn->type_param_bounds[fdn->type_param_count] = copy_token_string(&bound_name);
+            } else {
+                fdn->type_param_bounds[fdn->type_param_count] = NULL;
+            }
+
+            fdn->type_param_count++;
+        } while (match_token(parser, TOK_COMMA));
+
+        consume_token(parser, TOK_GT, "Expected '>' after type parameters");
+    }
 
     consume_token(parser, TOK_LPAREN, "Expected '(' after function name");
 

--- a/w0/test/errors/error_generic_func_bound.w
+++ b/w0/test/errors/error_generic_func_bound.w
@@ -1,0 +1,18 @@
+trait Printable {
+    const func label(): string;
+}
+
+struct Cat {
+    name: string,
+}
+
+func get_label<T: Printable>(x: T): string {
+    return x.label();
+}
+
+func main(): i32 {
+    var c = new Cat{name: "Whiskers"};
+    // Expected error: Type 'Cat' does not implement trait 'Printable' required by 'get_label'
+    var s = get_label(c);
+    return 0;
+}

--- a/w0/test/errors/error_generic_func_infer.w
+++ b/w0/test/errors/error_generic_func_infer.w
@@ -1,0 +1,9 @@
+func impossible<T>(x: i64): T {
+    return x;
+}
+
+func main(): i32 {
+    // Expected error: Cannot infer type parameter 'T' for generic function 'impossible'
+    var a = impossible(42);
+    return 0;
+}

--- a/w0/test/run/types/generic_func_basic.w
+++ b/w0/test/run/types/generic_func_basic.w
@@ -1,0 +1,15 @@
+func identity<T>(x: T): T {
+    return x;
+}
+
+func main(): i32 {
+    var a = identity(42);
+    var b = identity("hello");
+    var c = identity(true);
+
+    if (a != 42) { return 1; }
+    if (b != "hello") { return 2; }
+    if (c != true) { return 3; }
+
+    return 0;
+}

--- a/w0/test/run/types/generic_func_bounds.w
+++ b/w0/test/run/types/generic_func_bounds.w
@@ -1,0 +1,24 @@
+trait Printable {
+    const func label(): string;
+}
+
+struct Dog {
+    name: string,
+}
+
+impl Printable for Dog {
+    const func label(): string {
+        return self.name;
+    }
+}
+
+func get_label<T: Printable>(x: T): string {
+    return x.label();
+}
+
+func main(): i32 {
+    var d = new Dog{name: "Rex"};
+    var s = get_label(d);
+    if (s != "Rex") { return 1; }
+    return 0;
+}

--- a/w0/test/run/types/generic_func_multi_param.w
+++ b/w0/test/run/types/generic_func_multi_param.w
@@ -1,0 +1,17 @@
+func first<A, B>(a: A, b: B): A {
+    return a;
+}
+
+func second<A, B>(a: A, b: B): B {
+    return b;
+}
+
+func main(): i32 {
+    var a = first(10, "hello");
+    var b = second(10, "world");
+
+    if (a != 10) { return 1; }
+    if (b != "world") { return 2; }
+
+    return 0;
+}

--- a/w0/test/run/types/generic_func_vec.w
+++ b/w0/test/run/types/generic_func_vec.w
@@ -1,0 +1,12 @@
+func vec_count<T>(v: Vec<T>): i64 {
+    return v.count;
+}
+
+func main(): i32 {
+    var v = new Vec<i64>{1, 2, 3};
+
+    var n = vec_count(v);
+    if (n != 3) { return 1; }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add generic free functions (`func identity<T>(x: T): T`) using monomorphization — each unique instantiation emits a concrete C function (e.g., `identity_i64`, `identity_string`)
- Type arguments are inferred from call-site argument types, supporting Vec/Span, generic structs/enums, tuples, function types, and arrays
- Trait bounds (`func get_label<T: Printable>(x: T): string`) are checked at instantiation time

Closes #163

## Changes

| Area | What changed |
|------|-------------|
| AST | `type_params`/`type_param_bounds`/`type_param_count` on `func_decl_node`; `resolved_name` on call node |
| Parser | Parse `<T, U: Bound>` after function name for free functions |
| Checker | `GenericFuncDef`/`GenericFuncInstance` types; register/lookup/instantiate; `infer_type_param` for recursive type inference; trait bound checking; multi-pass registration in Pass 2 |
| Codegen | Skip templates; emit forward decls + implementations for instances; `resolved_name` dispatch at call sites |
| Grammar | Updated `<func-decl>` BNF with optional type params |

## Test plan

- [x] All 255 tests pass (163 run + 92 error, up from 249)
- [x] `generic_func_basic.w` — identity function with i64, string, bool
- [x] `generic_func_multi_param.w` — two type params (`first<A, B>`, `second<A, B>`)
- [x] `generic_func_vec.w` — type inference through `Vec<T>` parameter
- [x] `generic_func_bounds.w` — trait-bounded function compiles and runs
- [x] `error_generic_func_bound.w` — unsatisfied trait bound produces correct error
- [x] `error_generic_func_infer.w` — uninferrable type param produces correct error