### PR TITLE
fix: codegen warnings and assert string escaping

### DIFF
--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -638,11 +638,28 @@ static void stringify_expr_to(Node* node, char* buf, int buf_size, int* pos) {
     case NODE_BOOL_LIT:
         APPEND(node->as.bool_lit.value ? "true" : "false");
         break;
-    case NODE_STRING_LIT:
-        APPEND("\"");
-        APPEND(node->as.string_lit.value);
-        APPEND("\"");
+    case NODE_STRING_LIT: {
+        APPEND("\\\"");
+        const char* s = node->as.string_lit.value;
+        while (*s && *pos < buf_size - 1) {
+            if (*s == '"') {
+                APPEND("\\\"");
+            } else if (*s == '\\') {
+                APPEND("\\\\");
+            } else if (*s == '\n') {
+                APPEND("\\n");
+            } else if (*s == '\t') {
+                APPEND("\\t");
+            } else if (*s == '\r') {
+                APPEND("\\r");
+            } else {
+                buf[(*pos)++] = *s;
+            }
+            s++;
+        }
+        APPEND("\\\"");
         break;
+    }
     case NODE_NULL_LIT:
         APPEND("null");
         break;

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -407,14 +407,15 @@ void emit_vec_methods(CodeGen* gen) {
         // Sort (ascending)
         if (type_supports_vec_sort(elem_type)) {
             emit(gen, "static int __Vec_%s_sort_cmp(const void* a, const void* b) {\n", elem_tname);
-            emit(gen, "    const ");
+            const char* const_prefix = (elem_type->kind == TYPE_STRING) ? "" : "const ";
+            emit(gen, "    %s", const_prefix);
             emit_resolved_type(gen, elem_type);
-            emit(gen, "* lhs = (const ");
+            emit(gen, "* lhs = (%s", const_prefix);
             emit_resolved_type(gen, elem_type);
             emit(gen, "*)a;\n");
-            emit(gen, "    const ");
+            emit(gen, "    %s", const_prefix);
             emit_resolved_type(gen, elem_type);
-            emit(gen, "* rhs = (const ");
+            emit(gen, "* rhs = (%s", const_prefix);
             emit_resolved_type(gen, elem_type);
             emit(gen, "*)b;\n");
             if (elem_type->kind == TYPE_STRING) {

--- a/w0/test/run/traits/duck_type_basic.w
+++ b/w0/test/run/traits/duck_type_basic.w
@@ -1,4 +1,4 @@
-// Expected: hello from Dog
+// Expected: PASS: duck_type_basic
 import std;
 
 trait Greetable {
@@ -19,8 +19,17 @@ func (Dog) greet(): string {
     return self.name;
 }
 
+func hello<T: Greetable>(x: T): string {
+    return x.greet();
+}
+
 func main(): i32 {
     var d = new Dog { name: "hello from Dog\n" };
-    std.print(d.greet());
+    std.print(hello(d));
     return 0;
+}
+
+test "duck_type_basic" {
+    var d = new Dog { name: "hello from Dog" };
+    assert("hello from Dog" == hello(d));
 }


### PR DESCRIPTION
## Summary
- Fix duplicate `const` warning in `__Vec_string_sort_cmp` — string element type already includes `const`, so skip the extra `const` prefix
- Fix `stringify_expr` to escape special characters (`"`, `\`, `\n`, `\t`, `\r`) in string literals, preventing broken C when assert expressions contain strings
- Update `duck_type_basic` test with generic trait-bounded function and test block

## Test plan
- [x] All 259 tests pass
- [x] `w0 test` on duck_type_basic passes
- [x] Generated C for Vec<string> sort compiles without `-Wduplicate-decl-specifier`