### PR TITLE
feat: Vec == and != operators

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -161,6 +161,31 @@ static Type* check_comparison_op(Checker* checker, Node* node, Type* left, Type*
         check_error(checker, node->line, node->column, "Strings only support == and != comparison");
         return type_error;
     }
+    // Vec comparison: only == and != allowed, element type must support equality
+    if (left->kind == TYPE_VEC && right->kind == TYPE_VEC) {
+        if (op == TOK_EQ_EQ || op == TOK_BANG_EQ) {
+            if (!type_equals(left->as.vec.elem, right->as.vec.elem)) {
+                check_error(checker, node->line, node->column,
+                            "Cannot compare Vec with different element types");
+                return type_error;
+            }
+            Type* elem = left->as.vec.elem;
+            if (!type_supports_equality(elem)) {
+                check_error(checker, node->line, node->column,
+                            "Vec element type '%s' does not support ==", type_name(elem));
+                return type_error;
+            }
+            char buf[256];
+            snprintf(buf, sizeof(buf), "__Vec_%s", type_mangle_name(elem));
+            node->as.binary.is_eq_op     = 1;
+            node->as.binary.eq_type_name = xstrdup(buf);
+            return type_bool;
+        }
+        check_error(checker, node->line, node->column,
+                    "Vec types only support == and != comparison");
+        return type_error;
+    }
+
     if (type_equals(left, right)) {
         // Struct == requires Eq trait impl
         if (left->kind == TYPE_STRUCT && (op == TOK_EQ_EQ || op == TOK_BANG_EQ)) {

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -578,6 +578,30 @@ void emit_vec_methods(CodeGen* gen) {
                  option_tname, option_tname);
             emit(gen, "}\n\n");
         }
+
+        // Eq
+        if (type_supports_equality(elem_type)) {
+            emit(gen, "static inline bool __Vec_%s_eq(__Vec_%s* a, __Vec_%s* b) {\n", elem_tname,
+                 elem_tname, elem_tname);
+            emit(gen, "    if (a == b) return true;\n");
+            emit(gen, "    if (a->count != b->count) return false;\n");
+            emit(gen, "    for (int64_t i = 0; i < a->count; i++) {\n");
+            if (elem_type->kind == TYPE_STRING) {
+                emit(gen, "        if (strcmp(a->data[i], b->data[i]) != 0) return false;\n");
+            } else if (elem_type->kind == TYPE_STRUCT) {
+                emit(gen, "        if (!%s_eq(a->data[i], b->data[i])) return false;\n",
+                     elem_type->as.struc.name);
+            } else if (elem_type->kind == TYPE_VEC) {
+                const char* sub_tname = type_mangle_name(elem_type->as.vec.elem);
+                emit(gen, "        if (!__Vec_%s_eq(a->data[i], b->data[i])) return false;\n",
+                     sub_tname);
+            } else {
+                emit(gen, "        if (a->data[i] != b->data[i]) return false;\n");
+            }
+            emit(gen, "    }\n");
+            emit(gen, "    return true;\n");
+            emit(gen, "}\n\n");
+        }
     }
 }
 

--- a/w0/test/run/collections/vec_eq.w
+++ b/w0/test/run/collections/vec_eq.w
@@ -1,0 +1,49 @@
+// Expected: PASS: vec_eq
+// Test Vec == and != operators
+
+struct Point { x: i64, y: i64 }
+
+impl Eq for Point {
+    func eq(other: Point): bool {
+        return self.x == other.x && self.y == other.y;
+    }
+}
+
+test "vec_eq" {
+    // Equal i64 vecs
+    var a = new Vec<i64>{1, 2, 3};
+    var b = new Vec<i64>{1, 2, 3};
+    assert(a == b);
+
+    // Unequal elements
+    var c = new Vec<i64>{1, 2, 4};
+    assert(a != c);
+
+    // Different lengths
+    var d = new Vec<i64>{1, 2};
+    assert(a != d);
+
+    // Empty vecs
+    var e = new Vec<i64>{};
+    var f = new Vec<i64>{};
+    assert(e == f);
+    assert(e != a);
+
+    // String vecs
+    var s1 = new Vec<string>{"hello", "world"};
+    var s2 = new Vec<string>{"hello", "world"};
+    var s3 = new Vec<string>{"hello", "whist"};
+    assert(s1 == s2);
+    assert(s1 != s3);
+
+    // Struct vecs (with Eq impl)
+    var p1 = new Vec<Point>{new Point{x: 1, y: 2}, new Point{x: 3, y: 4}};
+    var p2 = new Vec<Point>{new Point{x: 1, y: 2}, new Point{x: 3, y: 4}};
+    var p3 = new Vec<Point>{new Point{x: 1, y: 2}, new Point{x: 5, y: 6}};
+    assert(p1 == p2);
+    assert(p1 != p3);
+
+    // != operator
+    assert(!(a != b));
+    assert(!(a == c));
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -353,6 +353,36 @@ int type_supports_vec_sort(Type* type) {
     }
 }
 
+int type_supports_equality(Type* type) {
+    if (!type)
+        return 0;
+    switch (type->kind) {
+    case TYPE_BOOL:
+    case TYPE_INT64:
+    case TYPE_INT8:
+    case TYPE_INT16:
+    case TYPE_INT32:
+    case TYPE_UINT64:
+    case TYPE_UINT8:
+    case TYPE_UINT16:
+    case TYPE_UINT32:
+    case TYPE_F32:
+    case TYPE_F64:
+    case TYPE_CHAR:
+    case TYPE_STRING:
+    case TYPE_VOIDPTR:
+        return 1;
+    case TYPE_ENUM:
+        return !type->as.enm.has_data; // non-data enums only (for now)
+    case TYPE_STRUCT:
+        return type->as.struc.has_eq;
+    case TYPE_VEC:
+        return type_supports_equality(type->as.vec.elem); // recursive
+    default:
+        return 0;
+    }
+}
+
 // Is this type RC-managed when held as a struct field or enum variant payload?
 // Structs and Vecs are always heap-allocated (RC pointers). Enums are RC-managed
 // only if they carry RC-managed payloads themselves.

--- a/w0/types.h
+++ b/w0/types.h
@@ -176,6 +176,7 @@ int         type_is_signed_integer(Type* type);         // Is this a signed inte
 int         type_is_unsigned_integer(Type* type);       // Is this an unsigned integer type?
 int         type_supports_vec_contains(Type* type);     // Can Vec<T>.contains compare this type?
 int         type_supports_vec_sort(Type* type);         // Is this type sortable by Vec<T>.sort?
+int         type_supports_equality(Type* type);         // Can this type be compared with ==?
 const char* type_name(Type* type);
 
 // Builtin type lookup utilities


### PR DESCRIPTION
## Summary
- Add element-wise `==` and `!=` operators for `Vec<T>` types
- Reuses existing `is_eq_op` + `eq_type_name` mechanism — no new AST flags needed
- Supports primitive, string, struct (with Eq impl), and nested Vec element types

Closes #107

## Changes
- `types.h/types.c` — new `type_supports_equality()` helper (primitives, string, voidptr, non-data enums, structs with Eq, recursive for vecs)
- `checker_expr.c` — Vec case in `check_comparison_op`: validates element types match and support equality, sets `eq_type_name = "__Vec_<elem>"`
- `codegen_rc.c` — emits `__Vec_T_eq()` in `emit_vec_methods` with type-appropriate element comparison (strcmp for strings, StructName_eq for structs, __Vec_SubT_eq for nested vecs, != for primitives)
- `test/run/collections/vec_eq.w` — tests equal/unequal elements, different lengths, empty vecs, string vecs, struct vecs with Eq impl, != operator

## Test plan
- [x] `make` — builds cleanly
- [x] `make test` — 267/267 tests pass
- [x] `make format` — formatting clean