### PR TITLE
feat: add directory, path, and metadata operations to fs module

### DIFF
--- a/lib/fs.w
+++ b/lib/fs.w
@@ -26,6 +26,31 @@ private extern fs {
     func fs__seek(handle: voidptr, offset: i64, whence: i32): i32;
     func fs__tell(handle: voidptr): i64;
     func fs__eof(handle: voidptr): bool;
+
+    // Directory operations
+    func fs__mkdir(path: string): i32;
+    func fs__mkdir_all(path: string): i32;
+    func fs__rmdir(path: string): i32;
+    func fs__is_dir(path: string): bool;
+    func fs__is_file(path: string): bool;
+    func fs__cwd(): string;
+    func fs__chdir(path: string): i32;
+
+    // Directory iteration (handle-based)
+    func fs__open_dir(path: string): voidptr;
+    func fs__read_dir(handle: voidptr): string;
+    func fs__close_dir(handle: voidptr): i32;
+
+    // Path utilities
+    func fs__join_path(a: string, b: string): string;
+    func fs__dirname(path: string): string;
+    func fs__basename(path: string): string;
+    func fs__extension(path: string): string;
+    func fs__abs_path(path: string): string;
+
+    // Metadata & temp
+    func fs__modified_time(path: string): i64;
+    func fs__temp_dir(): string;
 }
 
 // Convenience API
@@ -90,4 +115,80 @@ func tell(handle: voidptr): i64 {
 
 func eof(handle: voidptr): bool {
     return fs__eof(handle);
+}
+
+// Directory operations
+
+func mkdir(path: string): i32 {
+    return fs__mkdir(path);
+}
+
+func mkdir_all(path: string): i32 {
+    return fs__mkdir_all(path);
+}
+
+func rmdir(path: string): i32 {
+    return fs__rmdir(path);
+}
+
+func is_dir(path: string): bool {
+    return fs__is_dir(path);
+}
+
+func is_file(path: string): bool {
+    return fs__is_file(path);
+}
+
+func cwd(): string {
+    return fs__cwd();
+}
+
+func chdir(path: string): i32 {
+    return fs__chdir(path);
+}
+
+// Directory iteration (handle-based)
+
+func open_dir(path: string): voidptr {
+    return fs__open_dir(path);
+}
+
+func read_dir(handle: voidptr): string {
+    return fs__read_dir(handle);
+}
+
+func close_dir(handle: voidptr): i32 {
+    return fs__close_dir(handle);
+}
+
+// Path utilities
+
+func join_path(a: string, b: string): string {
+    return fs__join_path(a, b);
+}
+
+func dirname(path: string): string {
+    return fs__dirname(path);
+}
+
+func basename(path: string): string {
+    return fs__basename(path);
+}
+
+func extension(path: string): string {
+    return fs__extension(path);
+}
+
+func abs_path(path: string): string {
+    return fs__abs_path(path);
+}
+
+// Metadata & temp
+
+func modified_time(path: string): i64 {
+    return fs__modified_time(path);
+}
+
+func temp_dir(): string {
+    return fs__temp_dir();
 }

--- a/lib/include/fs.h
+++ b/lib/include/fs.h
@@ -22,6 +22,9 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <dirent.h>
+#include <limits.h>
+#include <errno.h>
 
 /* ---------- Convenience API (no handles) ---------- */
 
@@ -171,6 +174,168 @@ static inline bool fs__eof(void* handle) {
     FILE* fp = (FILE*)handle;
     if (!fp) return true;
     return feof(fp) != 0;
+}
+
+/* ---------- Directory operations ---------- */
+
+static inline int32_t fs__mkdir(const char* path) {
+    return (mkdir(path, 0755) == 0) ? 0 : -1;
+}
+
+static inline int32_t fs__mkdir_all(const char* path) {
+    char tmp[PATH_MAX];
+    size_t len = strlen(path);
+    if (len == 0 || len >= PATH_MAX) return -1;
+
+    memcpy(tmp, path, len + 1);
+
+    for (size_t i = 1; i < len; i++) {
+        if (tmp[i] == '/') {
+            tmp[i] = '\0';
+            if (mkdir(tmp, 0755) != 0 && errno != EEXIST) return -1;
+            tmp[i] = '/';
+        }
+    }
+    if (mkdir(tmp, 0755) != 0 && errno != EEXIST) return -1;
+    return 0;
+}
+
+static inline int32_t fs__rmdir(const char* path) {
+    return (rmdir(path) == 0) ? 0 : -1;
+}
+
+static inline bool fs__is_dir(const char* path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return false;
+    return S_ISDIR(st.st_mode);
+}
+
+static inline bool fs__is_file(const char* path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return false;
+    return S_ISREG(st.st_mode);
+}
+
+static inline const char* fs__cwd(void) {
+    char* result = getcwd(NULL, 0);
+    if (!result) return strdup("");
+    return result;
+}
+
+static inline int32_t fs__chdir(const char* path) {
+    return (chdir(path) == 0) ? 0 : -1;
+}
+
+/* ---------- Directory iteration (handle-based) ---------- */
+
+static inline void* fs__open_dir(const char* path) {
+    DIR* d = opendir(path);
+    return (void*)d;
+}
+
+static inline const char* fs__read_dir(void* handle) {
+    DIR* d = (DIR*)handle;
+    if (!d) return strdup("");
+    struct dirent* entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
+        return strdup(entry->d_name);
+    }
+    return strdup("");
+}
+
+static inline int32_t fs__close_dir(void* handle) {
+    DIR* d = (DIR*)handle;
+    if (!d) return -1;
+    return (closedir(d) == 0) ? 0 : -1;
+}
+
+/* ---------- Path utilities ---------- */
+
+static inline const char* fs__join_path(const char* a, const char* b) {
+    size_t alen = strlen(a);
+    size_t blen = strlen(b);
+    /* Strip trailing slash from a */
+    while (alen > 0 && a[alen - 1] == '/') alen--;
+    /* Strip leading slash from b */
+    while (blen > 0 && *b == '/') { b++; blen--; }
+
+    char* result = (char*)malloc(alen + 1 + blen + 1);
+    if (!result) return NULL;
+    memcpy(result, a, alen);
+    result[alen] = '/';
+    memcpy(result + alen + 1, b, blen);
+    result[alen + 1 + blen] = '\0';
+    return result;
+}
+
+static inline const char* fs__dirname(const char* path) {
+    size_t len = strlen(path);
+    /* Strip trailing slashes */
+    while (len > 1 && path[len - 1] == '/') len--;
+    /* Find last slash */
+    size_t i = len;
+    while (i > 0 && path[i - 1] != '/') i--;
+    if (i == 0) return strdup(".");
+    /* Strip trailing slashes from parent */
+    while (i > 1 && path[i - 1] == '/') i--;
+    char* result = (char*)malloc(i + 1);
+    if (!result) return NULL;
+    memcpy(result, path, i);
+    result[i] = '\0';
+    return result;
+}
+
+static inline const char* fs__basename(const char* path) {
+    size_t len = strlen(path);
+    /* Strip trailing slashes */
+    while (len > 1 && path[len - 1] == '/') len--;
+    /* Find last slash */
+    size_t i = len;
+    while (i > 0 && path[i - 1] != '/') i--;
+    size_t name_len = len - i;
+    char* result = (char*)malloc(name_len + 1);
+    if (!result) return NULL;
+    memcpy(result, path + i, name_len);
+    result[name_len] = '\0';
+    return result;
+}
+
+static inline const char* fs__extension(const char* path) {
+    size_t len = strlen(path);
+    /* Find last slash to avoid dots in directory names */
+    size_t last_slash = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (path[i] == '/') last_slash = i;
+    }
+    /* Find last dot after last slash */
+    const char* dot = NULL;
+    for (size_t i = last_slash; i < len; i++) {
+        if (path[i] == '.') dot = path + i;
+    }
+    if (!dot || dot == path + len - 1) return strdup("");
+    return strdup(dot);
+}
+
+static inline const char* fs__abs_path(const char* path) {
+    char* resolved = realpath(path, NULL);
+    if (!resolved) return strdup("");
+    return resolved;
+}
+
+/* ---------- Metadata & temp ---------- */
+
+static inline int64_t fs__modified_time(const char* path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return -1;
+    return (int64_t)st.st_mtime;
+}
+
+static inline const char* fs__temp_dir(void) {
+    const char* tmp = getenv("TMPDIR");
+    if (tmp && tmp[0] != '\0') return strdup(tmp);
+    return strdup("/tmp");
 }
 
 #endif /* WHIST_FS_H */

--- a/w0/CLAUDE.md
+++ b/w0/CLAUDE.md
@@ -110,7 +110,11 @@ bin/w0 --lib-path ../lib program.w | cc -x c -Ilib/include -o program - lib/whis
 **`fs.w`** — File I/O (imported as `import fs;`):
 - Convenience: `fs.read_file`, `fs.write_file`, `fs.append_file`, `fs.file_exists`, `fs.remove_file`, `fs.rename_file`, `fs.file_size`
 - Handle-based: `fs.open`, `fs.close`, `fs.read_line`, `fs.write_string`, `fs.flush`, `fs.seek`, `fs.tell`, `fs.eof`
-- Handles are `voidptr` (opaque FILE* pointers); `null` means invalid
+- Directory ops: `fs.mkdir`, `fs.mkdir_all`, `fs.rmdir`, `fs.is_dir`, `fs.is_file`, `fs.cwd`, `fs.chdir`
+- Directory iteration: `fs.open_dir`, `fs.read_dir`, `fs.close_dir` (handle-based, like file handles)
+- Path utilities: `fs.join_path`, `fs.dirname`, `fs.basename`, `fs.extension`, `fs.abs_path`
+- Metadata & temp: `fs.modified_time`, `fs.temp_dir`
+- Handles are `voidptr` (opaque FILE*/DIR* pointers); `null` means invalid
 - Requires `-Ilib/include` when compiling the generated C (for `fs.h` runtime)
 
 **`lib/include/`** — C header implementations backing extern modules (e.g., `fs.h`).

--- a/w0/test/run/stdlib/fs_dir_operations.w
+++ b/w0/test/run/stdlib/fs_dir_operations.w
@@ -1,0 +1,234 @@
+// Expected: PASS: fs_dir_operations
+// Test fs module: directory operations, path utilities, metadata
+
+import fs;
+import std;
+
+const BASE_DIR = "/tmp/whist_fs_dir_test";
+
+func cleanup(): void {
+    // Remove any files/dirs from previous runs
+    fs.remove_file(fs.join_path(BASE_DIR, "sub/nested/file.txt"));
+    fs.rmdir(fs.join_path(BASE_DIR, "sub/nested"));
+    fs.rmdir(fs.join_path(BASE_DIR, "sub"));
+    fs.remove_file(fs.join_path(BASE_DIR, "hello.txt"));
+    fs.remove_file(fs.join_path(BASE_DIR, "a.txt"));
+    fs.remove_file(fs.join_path(BASE_DIR, "b.txt"));
+    fs.remove_file(fs.join_path(BASE_DIR, "c.txt"));
+    fs.rmdir(BASE_DIR);
+}
+
+func test_mkdir_rmdir(): void {
+    var rc = fs.mkdir(BASE_DIR);
+    assert(rc == 0);
+    assert(fs.is_dir(BASE_DIR) == true);
+
+    // mkdir on existing dir should fail
+    rc = fs.mkdir(BASE_DIR);
+    assert(rc == -1);
+
+    // rmdir on empty dir
+    rc = fs.rmdir(BASE_DIR);
+    assert(rc == 0);
+    assert(fs.is_dir(BASE_DIR) == false);
+
+    // rmdir on non-existent should fail
+    rc = fs.rmdir(BASE_DIR);
+    assert(rc == -1);
+}
+
+func test_mkdir_all(): void {
+    var nested = fs.join_path(BASE_DIR, "sub/nested");
+    var rc = fs.mkdir_all(nested);
+    assert(rc == 0);
+    assert(fs.is_dir(BASE_DIR) == true);
+    assert(fs.is_dir(fs.join_path(BASE_DIR, "sub")) == true);
+    assert(fs.is_dir(nested) == true);
+
+    // mkdir_all on existing path should succeed (EEXIST is OK)
+    rc = fs.mkdir_all(nested);
+    assert(rc == 0);
+
+    // Write a file in the nested dir
+    fs.write_file(fs.join_path(nested, "file.txt"), "nested");
+    assert(fs.is_file(fs.join_path(nested, "file.txt")) == true);
+
+    // Cleanup
+    fs.remove_file(fs.join_path(nested, "file.txt"));
+    fs.rmdir(nested);
+    fs.rmdir(fs.join_path(BASE_DIR, "sub"));
+}
+
+func test_is_dir_is_file(): void {
+    assert(fs.is_dir(BASE_DIR) == true);
+    assert(fs.is_file(BASE_DIR) == false);
+
+    var file_path = fs.join_path(BASE_DIR, "hello.txt");
+    fs.write_file(file_path, "hi");
+
+    assert(fs.is_file(file_path) == true);
+    assert(fs.is_dir(file_path) == false);
+
+    // Non-existent path
+    assert(fs.is_dir("/tmp/whist_fs_dir_test_nonexistent") == false);
+    assert(fs.is_file("/tmp/whist_fs_dir_test_nonexistent") == false);
+
+    fs.remove_file(file_path);
+}
+
+func test_cwd_chdir(): void {
+    var original = fs.cwd();
+    assert(original != "");
+
+    var rc = fs.chdir(BASE_DIR);
+    assert(rc == 0);
+
+    var now = fs.cwd();
+    // abs_path to normalize (e.g. /private/tmp on macOS)
+    var abs_base = fs.abs_path(BASE_DIR);
+    assert(now == abs_base);
+
+    // Restore original directory
+    fs.chdir(original);
+}
+
+func test_open_read_close_dir(): void {
+    // Create some files to iterate
+    fs.write_file(fs.join_path(BASE_DIR, "a.txt"), "a");
+    fs.write_file(fs.join_path(BASE_DIR, "b.txt"), "b");
+    fs.write_file(fs.join_path(BASE_DIR, "c.txt"), "c");
+
+    var dh = fs.open_dir(BASE_DIR);
+    assert(dh != null);
+
+    var count: i64 = 0;
+    var entry = fs.read_dir(dh);
+    while (entry != "") {
+        count = count + 1;
+        entry = fs.read_dir(dh);
+    }
+    // Should have at least our 3 files (and no . or ..)
+    assert(count >= 3);
+
+    var rc = fs.close_dir(dh);
+    assert(rc == 0);
+
+    // open_dir on non-existent should return null
+    var bad = fs.open_dir("/tmp/whist_fs_dir_nonexistent_xyz");
+    assert(bad == null);
+
+    // Cleanup
+    fs.remove_file(fs.join_path(BASE_DIR, "a.txt"));
+    fs.remove_file(fs.join_path(BASE_DIR, "b.txt"));
+    fs.remove_file(fs.join_path(BASE_DIR, "c.txt"));
+}
+
+func test_join_path(): void {
+    var p1 = fs.join_path("/tmp", "file.txt");
+    assert(p1 == "/tmp/file.txt");
+
+    // Trailing slash on first arg should be stripped
+    var p2 = fs.join_path("/tmp/", "file.txt");
+    assert(p2 == "/tmp/file.txt");
+
+    // Leading slash on second arg should be stripped
+    var p3 = fs.join_path("/tmp", "/file.txt");
+    assert(p3 == "/tmp/file.txt");
+
+    // Both
+    var p4 = fs.join_path("/tmp/", "/file.txt");
+    assert(p4 == "/tmp/file.txt");
+}
+
+func test_dirname(): void {
+    var d1 = fs.dirname("/tmp/foo/bar.txt");
+    assert(d1 == "/tmp/foo");
+
+    var d2 = fs.dirname("/tmp/foo/");
+    assert(d2 == "/tmp");
+
+    var d3 = fs.dirname("file.txt");
+    assert(d3 == ".");
+
+    var d4 = fs.dirname("/");
+    assert(d4 == "/");
+}
+
+func test_basename(): void {
+    var b1 = fs.basename("/tmp/foo/bar.txt");
+    assert(b1 == "bar.txt");
+
+    var b2 = fs.basename("/tmp/foo/");
+    assert(b2 == "foo");
+
+    var b3 = fs.basename("file.txt");
+    assert(b3 == "file.txt");
+}
+
+func test_extension(): void {
+    var e1 = fs.extension("/tmp/foo/bar.txt");
+    assert(e1 == ".txt");
+
+    var e2 = fs.extension("/tmp/foo/bar.tar.gz");
+    assert(e2 == ".gz");
+
+    var e3 = fs.extension("/tmp/foo/bar");
+    assert(e3 == "");
+
+    // Dot in directory name shouldn't count
+    var e4 = fs.extension("/tmp/foo.d/bar");
+    assert(e4 == "");
+}
+
+func test_abs_path(): void {
+    // abs_path of an existing dir should return non-empty
+    var p = fs.abs_path(BASE_DIR);
+    assert(p != "");
+
+    // abs_path of non-existent should return empty
+    var bad = fs.abs_path("/tmp/whist_fs_dir_nonexistent_xyz");
+    assert(bad == "");
+}
+
+func test_modified_time(): void {
+    var file_path = fs.join_path(BASE_DIR, "hello.txt");
+    fs.write_file(file_path, "timestamp test");
+
+    var mtime = fs.modified_time(file_path);
+    assert(mtime > 0);
+
+    // Non-existent file
+    var bad = fs.modified_time("/tmp/whist_fs_dir_nonexistent_xyz.txt");
+    assert(bad == -1);
+
+    fs.remove_file(file_path);
+}
+
+func test_temp_dir(): void {
+    var tmp = fs.temp_dir();
+    assert(tmp != "");
+    // Should be a directory
+    assert(fs.is_dir(tmp) == true);
+}
+
+test "fs_dir_operations" {
+    cleanup();
+
+    test_mkdir_rmdir();
+    // Re-create BASE_DIR for remaining tests
+    fs.mkdir(BASE_DIR);
+
+    test_mkdir_all();
+    test_is_dir_is_file();
+    test_cwd_chdir();
+    test_open_read_close_dir();
+    test_join_path();
+    test_dirname();
+    test_basename();
+    test_extension();
+    test_abs_path();
+    test_modified_time();
+    test_temp_dir();
+
+    cleanup();
+}


### PR DESCRIPTION
## Summary
- Add 18 new functions to the `fs` module: directory operations (`mkdir`, `mkdir_all`, `rmdir`, `is_dir`, `is_file`, `cwd`, `chdir`), directory iteration (`open_dir`, `read_dir`, `close_dir`), path utilities (`join_path`, `dirname`, `basename`, `extension`, `abs_path`), and metadata/temp (`modified_time`, `temp_dir`)
- C implementations in `lib/include/fs.h`, Whist declarations and wrappers in `lib/fs.w`
- All string-returning functions return `""` on error (since Whist doesn't support `string == null`)

## Test plan
- [x] `make` builds successfully
- [x] `make test` — all 268 tests pass (170 run + 98 error)
- [x] New test `w0/test/run/stdlib/fs_dir_operations.w` covers: mkdir/rmdir, recursive mkdir_all, is_dir/is_file, cwd/chdir, directory iteration, path join/dirname/basename/extension, abs_path, modified_time, temp_dir