### PR TITLE
feat: add std.exec for capturing command output

### DIFF
--- a/lib/include/std_exec.h
+++ b/lib/include/std_exec.h
@@ -1,0 +1,112 @@
+/*
+ * std_exec.h — Command execution with output capture for the Whist standard library
+ *
+ * Provides an opaque-handle API so Whist extern functions can extract
+ * exit code, stdout, and stderr from a subprocess without needing to
+ * return a Whist struct directly from C.
+ *
+ * Functions use the std__ prefix (double underscore) to avoid
+ * colliding with the module-prefixed wrapper names (std_*) generated
+ * by the whist compiler.
+ *
+ * Usage: compile with -Ilib/include so #include <std_exec.h> resolves.
+ */
+
+#ifndef WHIST_STD_EXEC_H
+#define WHIST_STD_EXEC_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+typedef struct {
+    int32_t exit_code;
+    char* out;
+    char* err;
+} __ExecResult;
+
+static char* __exec_read_file(const char* path) {
+    FILE* f = fopen(path, "r");
+    if (!f) {
+        char* empty = (char*)malloc(1);
+        empty[0] = '\0';
+        return empty;
+    }
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char* buf = (char*)malloc(len + 1);
+    if (len > 0) {
+        size_t n = fread(buf, 1, len, f);
+        buf[n] = '\0';
+    } else {
+        buf[0] = '\0';
+    }
+    fclose(f);
+    return buf;
+}
+
+static inline void* std__exec(const char* cmd) {
+    char stdout_tmpl[] = "/tmp/whist_exec_out_XXXXXX";
+    char stderr_tmpl[] = "/tmp/whist_exec_err_XXXXXX";
+
+    int out_fd = mkstemp(stdout_tmpl);
+    int err_fd = mkstemp(stderr_tmpl);
+    if (out_fd < 0 || err_fd < 0) {
+        __ExecResult* r = (__ExecResult*)malloc(sizeof(__ExecResult));
+        r->exit_code = -1;
+        r->out = strdup("");
+        r->err = strdup("failed to create temp files");
+        return r;
+    }
+    close(out_fd);
+    close(err_fd);
+
+    /* Build: (cmd) > stdout_tmp 2> stderr_tmp
+     * The subshell ensures internal redirections (e.g. >&2)
+     * resolve before our outer capture redirections. */
+    size_t cmdlen = strlen(cmd) + strlen(stdout_tmpl) + strlen(stderr_tmpl) + 16;
+    char* full_cmd = (char*)malloc(cmdlen);
+    snprintf(full_cmd, cmdlen, "(%s) > %s 2> %s", cmd, stdout_tmpl, stderr_tmpl);
+
+    int status = system(full_cmd);
+    free(full_cmd);
+
+    __ExecResult* r = (__ExecResult*)malloc(sizeof(__ExecResult));
+    if (WIFEXITED(status)) {
+        r->exit_code = WEXITSTATUS(status);
+    } else {
+        r->exit_code = -1;
+    }
+    r->out = __exec_read_file(stdout_tmpl);
+    r->err = __exec_read_file(stderr_tmpl);
+
+    unlink(stdout_tmpl);
+    unlink(stderr_tmpl);
+
+    return r;
+}
+
+static inline int32_t std__exec_exit_code(void* handle) {
+    return ((__ExecResult*)handle)->exit_code;
+}
+
+static inline const char* std__exec_output(void* handle) {
+    return strdup(((__ExecResult*)handle)->out);
+}
+
+static inline const char* std__exec_error_output(void* handle) {
+    return strdup(((__ExecResult*)handle)->err);
+}
+
+static inline void std__exec_free(void* handle) {
+    __ExecResult* r = (__ExecResult*)handle;
+    free(r->out);
+    free(r->err);
+    free(r);
+}
+
+#endif

--- a/lib/std.w
+++ b/lib/std.w
@@ -97,6 +97,32 @@ func to_string(n: i64): string {
     return std__to_string(n);
 }
 
+// Command execution with output capture
+struct ExecResult {
+    exit_code: i32,
+    output: string,
+    error_output: string
+}
+
+private extern std_exec {
+    func std__exec(cmd: string): voidptr;
+    func std__exec_exit_code(handle: voidptr): i32;
+    func std__exec_output(handle: voidptr): string;
+    func std__exec_error_output(handle: voidptr): string;
+    func std__exec_free(handle: voidptr): void;
+}
+
+func exec(cmd: string): ExecResult {
+    var handle = std__exec(cmd);
+    var result = new ExecResult {
+        exit_code: std__exec_exit_code(handle),
+        output: std__exec_output(handle),
+        error_output: std__exec_error_output(handle)
+    };
+    std__exec_free(handle);
+    return result;
+}
+
 // Private internal function - should not be visible outside std
 private func _internal_std(): i64 {
     return 42;

--- a/w0/test/run/stdlib/std_exec.w
+++ b/w0/test/run/stdlib/std_exec.w
@@ -1,0 +1,25 @@
+// Expected: PASS: exec captures exit code
+// Expected: PASS: exec captures output
+// Expected: PASS: exec captures nonzero exit
+// Expected: PASS: exec captures stderr
+import std;
+
+test "exec captures exit code" {
+    var result = std.exec("echo hello");
+    assert(result.exit_code == 0);
+}
+
+test "exec captures output" {
+    var result = std.exec("echo hello");
+    assert(result.output == "hello\n");
+}
+
+test "exec captures nonzero exit" {
+    var result = std.exec("exit 42");
+    assert(result.exit_code == 42);
+}
+
+test "exec captures stderr" {
+    var result = std.exec("echo oops >&2");
+    assert(result.error_output == "oops\n");
+}


### PR DESCRIPTION
## Summary

- Adds `std.exec(cmd)` which runs a shell command and returns an `ExecResult` struct with `exit_code`, `output`, and `error_output` fields
- Uses an opaque handle pattern (like `fs.open_dir`/`fs.read_dir`) since extern functions can't directly return Whist structs
- Command is wrapped in a subshell `(cmd)` so internal redirections (e.g. `>&2`) work correctly with output capture

Closes #215

## Test plan

- [x] `make` — compiler builds
- [x] `make test` — all 271 tests pass (including 4 new `std_exec` tests)
- [x] New tests verify: exit code capture, stdout capture, nonzero exit code, stderr capture