### PR TITLE
feat: write test runner in Whist (#195)

### DIFF
--- a/w0/Makefile
+++ b/w0/Makefile
@@ -8,7 +8,7 @@ DEPS = $(SRC:.c=.d)
 BIN = bin
 TARGET = $(BIN)/w0
 
-.PHONY: all clean test test-verbose test-valid test-run test-errors format metrics complexity
+.PHONY: all clean test test-verbose test-valid test-run test-errors test-whist format metrics complexity
 
 all: $(TARGET)
 
@@ -39,6 +39,10 @@ test-valid: $(TARGET)
 
 test-errors: $(TARGET)
 	@./scripts/run_tests.sh --errors
+
+test-whist: $(TARGET)
+	@$(TARGET) --lib-path ../lib tools/test_runner.w | cc -x c -I../lib/include -o $(BIN)/test_runner - ../lib/whist_runtime.c
+	@cd . && $(BIN)/test_runner
 
 format:
 	clang-format -i *.c *.h

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -1,0 +1,433 @@
+// Whist Test Runner
+// Replaces scripts/run_tests.sh — dogfooding the compiler.
+
+import std;
+import fs;
+
+// --- Helpers ---
+
+func collect_files(dir: string, files: Vec<string>): void {
+    var dh = fs.open_dir(dir);
+    if (dh == null) {
+        return;
+    }
+
+    var dirs = new Vec<string>{};
+    var entry = fs.read_dir(dh);
+    while (entry != "") {
+        var path = fs.join_path(dir, entry);
+        if (fs.is_dir(path)) {
+            dirs.push(path);
+        } else if (entry.ends_with(".w")) {
+            files.push(path);
+        }
+        entry = fs.read_dir(dh);
+    }
+    fs.close_dir(dh);
+
+    // Recurse into subdirectories
+    var i: i64 = 0;
+    while (i < dirs.count) {
+        collect_files(dirs[i], files);
+        i = i + 1;
+    }
+}
+
+func str_less_than(a: string, b: string): bool {
+    var len_a = a.length();
+    var len_b = b.length();
+    var min_len = len_a;
+    if (len_b < min_len) {
+        min_len = len_b;
+    }
+    // Compare character by character using char -> i32 cast
+    var ia: i64 = 0;
+    var ib: i64 = 0;
+    foreach (const ca in a) {
+        if (ia >= min_len) {
+            break;
+        }
+        var jb: i64 = 0;
+        foreach (const cb in b) {
+            if (jb == ia) {
+                var va = ca as i32;
+                var vb = cb as i32;
+                if (va < vb) {
+                    return true;
+                }
+                if (va > vb) {
+                    return false;
+                }
+                break;
+            }
+            jb = jb + 1;
+        }
+        ia = ia + 1;
+    }
+    return len_a < len_b;
+}
+
+func sort_strings(v: Vec<string>): void {
+    // Simple insertion sort using string comparison
+    var i: i64 = 1;
+    while (i < v.count) {
+        var key = v[i];
+        var j = i - 1;
+        while (j >= 0 && str_less_than(key, v[j])) {
+            v[j + 1] = v[j];
+            j = j - 1;
+        }
+        v[j + 1] = key;
+        i = i + 1;
+    }
+}
+
+func read_expected_lines(path: string, prefix: string): Vec<string> {
+    var lines = new Vec<string>{};
+    var content = fs.read_file(path);
+    var marker = "// " + prefix + ": ";
+    var marker_len = marker.length();
+
+    // Scan line by line through the content
+    var start: i64 = 0;
+    var i: i64 = 0;
+    while (i < content.length()) {
+        // Find end of line
+        var ch = content[i:i + 1];
+        if (ch == "\n" || i == content.length() - 1) {
+            var end = i;
+            if (ch == "\n") {
+                end = i;
+            } else {
+                end = i + 1;
+            }
+            var line = content[start:end];
+            if (line.starts_with(marker)) {
+                var text = line[marker_len:line.length()];
+                lines.push(text);
+            }
+            start = i + 1;
+        }
+        i = i + 1;
+    }
+    return lines;
+}
+
+func file_contains(path: string, pattern: string): bool {
+    var content = fs.read_file(path);
+    return content.contains(pattern);
+}
+
+func display_path(file: string): string {
+    // Strip "test/" prefix for display
+    if (file.starts_with("test/")) {
+        return file[5:file.length()];
+    }
+    return file;
+}
+
+func check_output_contains(output: string, expected: Vec<string>): bool {
+    var i: i64 = 0;
+    while (i < expected.count) {
+        if (!output.contains(expected[i])) {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+// --- Test runners ---
+
+func run_test_block_file(file: string, w0: string, lib_path: string, verbose: bool): bool {
+    var cmd = w0 + " --lib-path " + lib_path + " test " + file;
+    var result = std.exec(cmd);
+
+    var combined = result.output + result.error_output;
+    var expected = read_expected_lines(file, "Expected");
+
+    if (expected.count > 0) {
+        if (!check_output_contains(combined, expected)) {
+            if (verbose) {
+                std.println("  command: " + cmd);
+                std.println("  output:  " + combined);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    // No expected lines — just check exit code
+    if (result.exit_code != 0) {
+        if (verbose) {
+            std.println("  command: " + cmd);
+            std.println("  output:  " + combined);
+        }
+        return false;
+    }
+    return true;
+}
+
+func run_program_test(file: string, w0: string, lib_path: string, verbose: bool): bool {
+    // Compile
+    var compile_cmd = w0 + " --lib-path " + lib_path + " " + file + " | cc -x c -I" + lib_path + "/include -o /tmp/whist_test_bin - " + lib_path + "/whist_runtime.c";
+    var compile_result = std.exec(compile_cmd);
+    if (compile_result.exit_code != 0) {
+        if (verbose) {
+            std.println("  compile failed:");
+            std.println("  " + compile_result.error_output);
+        }
+        return false;
+    }
+
+    // Run
+    var run_result = std.exec("/tmp/whist_test_bin");
+
+    // Check expected exit code
+    var expected_exit_lines = read_expected_lines(file, "Expected exit");
+    var expected_exit: i64 = 0;
+    if (expected_exit_lines.count > 0) {
+        expected_exit = std.parse_i64(expected_exit_lines[0]);
+    }
+
+    var actual_exit: i64 = run_result.exit_code as i64;
+    if (actual_exit != expected_exit) {
+        if (verbose) {
+            std.println($"  exit code: {actual_exit} (expected {expected_exit})");
+            std.println("  stdout: " + run_result.output);
+            std.println("  stderr: " + run_result.error_output);
+        }
+        return false;
+    }
+
+    // Check expected stdout
+    var expected_stdout = read_expected_lines(file, "Expected");
+    if (expected_stdout.count > 0) {
+        if (!check_output_contains(run_result.output, expected_stdout)) {
+            if (verbose) {
+                std.println("  stdout mismatch:");
+                std.println("  actual: " + run_result.output);
+                var k: i64 = 0;
+                while (k < expected_stdout.count) {
+                    std.println("  expected line: " + expected_stdout[k]);
+                    k = k + 1;
+                }
+            }
+            return false;
+        }
+    }
+
+    // Check expected stderr
+    var expected_stderr = read_expected_lines(file, "Expected stderr");
+    if (expected_stderr.count > 0) {
+        if (!check_output_contains(run_result.error_output, expected_stderr)) {
+            if (verbose) {
+                std.println("  stderr mismatch:");
+                std.println("  actual: " + run_result.error_output);
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+func run_error_test(file: string, w0: string, lib_path: string, verbose: bool): bool {
+    var cmd = w0 + " --lib-path " + lib_path + " --check " + file;
+    var result = std.exec(cmd);
+
+    // Should fail (non-zero exit)
+    if (result.exit_code == 0) {
+        if (verbose) {
+            std.println("  should have failed but succeeded");
+        }
+        return false;
+    }
+
+    var output = result.output + result.error_output;
+
+    // Must contain "Error:"
+    if (!output.contains("Error:")) {
+        if (verbose) {
+            std.println("  no error message in output:");
+            std.println("  " + output);
+        }
+        return false;
+    }
+
+    // Check expected error text
+    var expected = read_expected_lines(file, "Expected error");
+    if (expected.count > 0) {
+        if (!check_output_contains(output, expected)) {
+            if (verbose) {
+                std.println("  wrong error message:");
+                std.println("  output: " + output);
+                var k: i64 = 0;
+                while (k < expected.count) {
+                    std.println("  expected: " + expected[k]);
+                    k = k + 1;
+                }
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// --- Main ---
+
+func main(): i32 {
+    var args = std.args();
+
+    var run_valid = false;
+    var run_errors = false;
+    var verbose = false;
+
+    var i: i64 = 1;
+    while (i < args.count) {
+        if (args[i] == "--run" || args[i] == "--valid") {
+            run_valid = true;
+        } else if (args[i] == "--errors") {
+            run_errors = true;
+        } else if (args[i] == "--verbose") {
+            verbose = true;
+        } else if (args[i] == "--help") {
+            std.println("Usage: test_runner [OPTIONS]");
+            std.println("");
+            std.println("Options:");
+            std.println("  --run       Run only executable program tests (test/run/**)");
+            std.println("  --errors    Run only error case tests (test/errors/**)");
+            std.println("  --verbose   Show detailed output on failure");
+            std.println("  --help      Show this help");
+            std.println("");
+            std.println("With no options, runs all tests.");
+            return 0;
+        }
+        i = i + 1;
+    }
+
+    // Default: run all
+    if (!run_valid && !run_errors) {
+        run_valid = true;
+        run_errors = true;
+    }
+
+    var w0 = "bin/w0";
+    var lib_path = "../lib";
+
+    var run_passed: i64 = 0;
+    var run_failed: i64 = 0;
+    var run_skipped: i64 = 0;
+    var error_passed: i64 = 0;
+    var error_failed: i64 = 0;
+
+    std.println("=== Running W0 Test Suite ===");
+    std.println("");
+
+    if (run_valid) {
+        std.println("=== Run Tests (test/run/**) ===");
+
+        var files = new Vec<string>{};
+        collect_files("test/run", files);
+        sort_strings(files);
+
+        var j: i64 = 0;
+        while (j < files.count) {
+            var file = files[j];
+            var disp = display_path(file);
+
+            var has_test_blocks = file_contains(file, "test \"");
+            var has_main = file_contains(file, "func main(");
+
+            if (has_test_blocks) {
+                std.print($"{disp}: ");
+                var ok = run_test_block_file(file, w0, lib_path, verbose);
+                if (ok) {
+                    std.println("PASS");
+                    run_passed = run_passed + 1;
+                } else {
+                    std.println("FAIL");
+                    run_failed = run_failed + 1;
+                }
+            } else if (has_main) {
+                std.print($"{disp}: ");
+                var ok = run_program_test(file, w0, lib_path, verbose);
+                if (ok) {
+                    std.println("PASS");
+                    run_passed = run_passed + 1;
+                } else {
+                    std.println("FAIL");
+                    run_failed = run_failed + 1;
+                }
+            } else {
+                if (verbose) {
+                    std.println($"{disp}: SKIP (helper module)");
+                }
+                run_skipped = run_skipped + 1;
+            }
+
+            j = j + 1;
+        }
+        std.println("");
+    }
+
+    if (run_errors) {
+        std.println("=== Error Cases (test/errors/**) ===");
+
+        var files = new Vec<string>{};
+        collect_files("test/errors", files);
+        sort_strings(files);
+
+        var j: i64 = 0;
+        while (j < files.count) {
+            var file = files[j];
+            var disp = display_path(file);
+
+            std.print($"{disp}: ");
+            var ok = run_error_test(file, w0, lib_path, verbose);
+            if (ok) {
+                std.println("PASS (correct error)");
+                error_passed = error_passed + 1;
+            } else {
+                std.println("FAIL");
+                error_failed = error_failed + 1;
+            }
+
+            j = j + 1;
+        }
+        std.println("");
+    }
+
+    // Summary
+    std.println("=== Test Summary ===");
+
+    if (run_valid) {
+        var run_total = run_passed + run_failed;
+        std.println($"Run Tests:      {run_passed}/{run_total} passed");
+        if (run_skipped > 0) {
+            std.println($"Run Skipped:    {run_skipped} helper module(s)");
+        }
+    }
+
+    if (run_errors) {
+        var error_total = error_passed + error_failed;
+        std.println($"Error Cases:    {error_passed}/{error_total} passed");
+    }
+
+    var total_passed = run_passed + error_passed;
+    var total_failed = run_failed + error_failed;
+    var total = total_passed + total_failed;
+
+    if (run_valid && run_errors) {
+        std.println($"Total:          {total_passed}/{total} tests passed");
+    }
+
+    if (total_failed == 0) {
+        std.println("All tests passed!");
+        return 0;
+    } else {
+        std.println($"{total_failed} test(s) failed");
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

- Rewrite the test suite runner as a Whist program (`tools/test_runner.w`), dogfooding `std.exec`, `fs` module, `Vec`, and string operations
- Add `make test-whist` Makefile target to compile and run the Whist test runner
- Produces identical results to the bash script: 172/172 run tests, 99/99 error tests, 5 skipped helper modules

Closes #195

## Test plan

- [x] `make test-whist` — compiles and runs the Whist test runner, all 271 tests pass
- [x] Results match `make test` (bash runner) exactly
- [x] `--run`, `--errors`, `--verbose`, `--help` flags all work