### PR TITLE
feat: string.index_of() method

### DIFF
--- a/lib/include/whist_runtime.h
+++ b/lib/include/whist_runtime.h
@@ -155,6 +155,11 @@ static inline bool __String_starts_with(const char* s, const char* prefix) {
     return strncmp(s, prefix, strlen(prefix)) == 0;
 }
 
+static inline int64_t __String_index_of(const char* s, const char* pattern) {
+    const char* p = strstr(s, pattern);
+    return p ? (int64_t)(p - s) : -1;
+}
+
 static inline bool __String_ends_with(const char* s, const char* suffix) {
     size_t ls = strlen(s), lsuf = strlen(suffix);
     return ls >= lsuf && strcmp(s + ls - lsuf, suffix) == 0;

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -678,7 +678,7 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
     return type_error;
 }
 
-// Check string member access (length, contains, starts_with, ends_with, split)
+// Check string member access (length, contains, starts_with, ends_with, index_of, split)
 // Returns NULL if member_name is not a built-in string method (falls through to primitive methods)
 static Type* check_member_string(Checker* checker, Node* node) {
     const char* member_name = node->as.member.name;
@@ -693,6 +693,12 @@ static Type* check_member_string(Checker* checker, Node* node) {
         Type** params = xmalloc(1 * sizeof(Type*));
         params[0]     = type_string;
         return type_func(params, 1, type_bool, 0);
+    }
+    if (strcmp(member_name, "index_of") == 0) {
+        sem_info_set_member_struct_name(checker->sem, node, "__String");
+        Type** params = xmalloc(1 * sizeof(Type*));
+        params[0]     = type_string;
+        return type_func(params, 1, type_int64, 0);
     }
     if (strcmp(member_name, "split") == 0) {
         sem_info_set_member_struct_name(checker->sem, node, "__String");

--- a/w0/test/run/strings/string_index_of.w
+++ b/w0/test/run/strings/string_index_of.w
@@ -1,0 +1,8 @@
+// Expected: PASS: string_index_of
+test "string_index_of" {
+    assert("hello world".index_of("world") == 6);
+    assert("hello world".index_of("hello") == 0);
+    assert("hello world".index_of("xyz") == -1);
+    assert("abcabc".index_of("bc") == 1);
+    assert("hello".index_of("") == 0);
+}


### PR DESCRIPTION
## Summary
- Add `string.index_of(pattern)` method returning the byte offset of the first occurrence, or `-1` if not found
- Uses `strstr` under the hood via `__String_index_of` in the runtime header
- Follows the same checker/codegen pattern as `contains`, `starts_with`, `ends_with`

Closes #223

## Test plan
- [x] New test `test/run/strings/string_index_of.w` covers: found at start, found in middle, not found, first occurrence, empty pattern
- [x] Full test suite passes (273/273)