### PR TITLE
feat: Vec<string>.sort() support

### DIFF
--- a/w0/test/run/collections/vec_string_sort.w
+++ b/w0/test/run/collections/vec_string_sort.w
@@ -1,0 +1,30 @@
+// Expected: PASS: vec_string_sort
+// Test Vec<string> sort()
+
+test "vec_string_sort" {
+    var v = new Vec<string>{"cherry", "apple", "banana"};
+    v.sort();
+    assert(v[0] == "apple");
+    assert(v[1] == "banana");
+    assert(v[2] == "cherry");
+
+    // Empty vec
+    var empty = new Vec<string>{};
+    empty.sort();
+    assert(empty.count == 0);
+
+    // Single element
+    var single = new Vec<string>{"only"};
+    single.sort();
+    assert(single[0] == "only");
+
+    // Already sorted
+    var sorted = new Vec<string>{"a", "b", "c"};
+    sorted.sort();
+    assert(sorted[0] == "a" && sorted[1] == "b" && sorted[2] == "c");
+
+    // Reverse order
+    var rev = new Vec<string>{"z", "m", "a"};
+    rev.sort();
+    assert(rev[0] == "a" && rev[1] == "m" && rev[2] == "z");
+}

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -33,20 +33,6 @@ func collect_files(dir: string, files: Vec<string>): void {
     }
 }
 
-func sort_strings(v: Vec<string>): void {
-    // Simple insertion sort using string comparison
-    var i: i64 = 1;
-    while (i < v.count) {
-        var key = v[i];
-        var j = i - 1;
-        while (j >= 0 && key < v[j]) {
-            v[j + 1] = v[j];
-            j = j - 1;
-        }
-        v[j + 1] = key;
-        i = i + 1;
-    }
-}
 
 func read_expected_lines(path: string, prefix: string): Vec<string> {
     var lines = new Vec<string>{};
@@ -276,7 +262,7 @@ func main(): i32 {
 
         var files = new Vec<string>{};
         collect_files("test/run", files);
-        sort_strings(files);
+        files.sort();
 
         var j: i64 = 0;
         while (j < files.count) {
@@ -323,7 +309,7 @@ func main(): i32 {
 
         var files = new Vec<string>{};
         collect_files("test/errors", files);
-        sort_strings(files);
+        files.sort();
 
         var j: i64 = 0;
         while (j < files.count) {


### PR DESCRIPTION
## Summary
- Add runtime test for `Vec<string>.sort()` covering basic, empty, single-element, already-sorted, and reverse-order cases
- Simplify test runner by replacing the 14-line manual `sort_strings()` insertion sort with the built-in `files.sort()`

The Vec<string>.sort() implementation (checker + codegen with `strcmp`-based comparison) was already in place — this PR adds test coverage and uses it in the test runner.

## Test plan
- [x] New `test/run/collections/vec_string_sort.w` passes
- [x] Full test suite passes (274/274)

Closes #221