### PR TITLE
feat: struct destructuring `var {field1, field2} = expr;`

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -174,14 +174,19 @@ Aliases are fully interchangeable with the underlying type: `var id: UserId = 42
 ```bnf
 <var-decl> ::= ( 'var' | 'const' ) <identifier> [ ':' <type> ] [ '=' <expression> ] ';'
             | ( 'var' | 'const' ) <destruct-pattern> [ ':' <type> ] '=' <expression> ';'
+            | ( 'var' | 'const' ) <struct-destruct> '=' <expression> ';'
 
 <destruct-pattern> ::= '(' <destruct-element> ',' <destruct-element> { ',' <destruct-element> } ')'
 
 <destruct-element> ::= <identifier>
                     | <destruct-pattern>
+
+<struct-destruct> ::= '{' <identifier> { ',' <identifier> } '}'
 ```
 
 **Tuple destructuring:** `var (a, b) = expr;` and `const (a, b) = expr;` unpack a tuple into individual bindings. The number of elements must match the tuple's arity. Nested patterns are supported: `var (x, (y, z)) = (1, (2, 3));` unpacks nested tuples.
+
+**Struct destructuring:** `var {field1, field2} = expr;` extracts named fields from a struct into local variables with the same names. The expression must evaluate to a struct type, and each identifier must match a field name on that struct. Partial destructuring is allowed (not all fields need to be listed). The underlying struct is kept alive as an RC-tracked temporary for the enclosing scope.
 
 ### Test Declaration
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -36,6 +36,35 @@ void pattern_tuple_push(DestructPattern* pattern, DestructPattern* elem) {
     pattern->as.tuple.elements[pattern->as.tuple.count++] = elem;
 }
 
+DestructPattern* pattern_new_struct(int capacity) {
+    DestructPattern* pattern             = xcalloc(1, sizeof(DestructPattern));
+    pattern->kind                        = PATTERN_STRUCT;
+    pattern->as.struc.field_names        = xmalloc(capacity * sizeof(char*));
+    pattern->as.struc.field_name_lengths = xmalloc(capacity * sizeof(int));
+    pattern->as.struc.field_types        = xcalloc(capacity, sizeof(Type*));
+    pattern->as.struc.count              = 0;
+    pattern->as.struc.capacity           = capacity;
+    pattern->resolved_type               = NULL;
+    return pattern;
+}
+
+void pattern_struct_push(DestructPattern* pattern, const char* name, int length) {
+    if (pattern->as.struc.count >= pattern->as.struc.capacity) {
+        pattern->as.struc.capacity *= 2;
+        pattern->as.struc.field_names =
+            xrealloc(pattern->as.struc.field_names, pattern->as.struc.capacity * sizeof(char*));
+        pattern->as.struc.field_name_lengths = xrealloc(pattern->as.struc.field_name_lengths,
+                                                        pattern->as.struc.capacity * sizeof(int));
+        pattern->as.struc.field_types =
+            xrealloc(pattern->as.struc.field_types, pattern->as.struc.capacity * sizeof(Type*));
+    }
+    int i                            = pattern->as.struc.count++;
+    pattern->as.struc.field_names[i] = xmalloc(length + 1);
+    memcpy(pattern->as.struc.field_names[i], name, length);
+    pattern->as.struc.field_names[i][length] = '\0';
+    pattern->as.struc.field_name_lengths[i]  = length;
+}
+
 void pattern_free(DestructPattern* pattern) {
     if (!pattern)
         return;
@@ -49,6 +78,14 @@ void pattern_free(DestructPattern* pattern) {
             pattern_free(pattern->as.tuple.elements[i]);
         }
         free(pattern->as.tuple.elements);
+        break;
+    case PATTERN_STRUCT:
+        for (int i = 0; i < pattern->as.struc.count; i++) {
+            free(pattern->as.struc.field_names[i]);
+        }
+        free(pattern->as.struc.field_names);
+        free(pattern->as.struc.field_name_lengths);
+        free(pattern->as.struc.field_types);
         break;
     }
     free(pattern);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -10,7 +10,8 @@ typedef struct Type            Type;
 // Destructuring pattern kinds
 typedef enum {
     PATTERN_IDENT, // Single identifier: x
-    PATTERN_TUPLE  // Nested tuple: (a, b) or (a, (b, c))
+    PATTERN_TUPLE, // Nested tuple: (a, b) or (a, (b, c))
+    PATTERN_STRUCT // Struct fields: {x, y}
 } PatternKind;
 
 // Recursive destructuring pattern for tuple unpacking
@@ -25,6 +26,13 @@ struct DestructPattern {
             DestructPattern** elements;
             int               count;
         } tuple;
+        struct {
+            char** field_names;
+            int*   field_name_lengths;
+            int    count;
+            int    capacity;
+            Type** field_types; // Set by checker (parallel array)
+        } struc;
     } as;
     Type* resolved_type; // Set by checker
 };
@@ -33,6 +41,8 @@ struct DestructPattern {
 DestructPattern* pattern_new_ident(const char* name, int length);
 DestructPattern* pattern_new_tuple(int capacity);
 void             pattern_tuple_push(DestructPattern* pattern, DestructPattern* elem);
+DestructPattern* pattern_new_struct(int capacity);
+void             pattern_struct_push(DestructPattern* pattern, const char* name, int length);
 void             pattern_free(DestructPattern* pattern);
 
 typedef enum {

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -490,6 +490,31 @@ static int check_destruct_pattern_redefinitions_internal(Checker* checker, Destr
             }
         }
         return 0;
+
+    case PATTERN_STRUCT:
+        for (int i = 0; i < pattern->as.struc.count; i++) {
+            const char* name = pattern->as.struc.field_names[i];
+
+            if (checker_lookup_local(checker, name)) {
+                check_error(checker, line, col, "Redefinition of '%s'", name);
+                return 1;
+            }
+
+            for (int j = 0; j < *count; j++) {
+                if (strcmp((*names)[j], name) == 0) {
+                    check_error(checker, line, col, "Redefinition of '%s'", name);
+                    return 1;
+                }
+            }
+
+            if (*count >= *capacity) {
+                *capacity *= 2;
+                *names = xrealloc(*names, (*capacity) * sizeof(char*));
+            }
+            (*names)[*count] = xstrdup(name);
+            (*count)++;
+        }
+        return 0;
     }
     return 0;
 }
@@ -542,6 +567,34 @@ static int check_destruct_pattern_against_type(Checker* checker, DestructPattern
             }
         }
         return 0;
+
+    case PATTERN_STRUCT:
+        if (type->kind != TYPE_STRUCT && type->kind != TYPE_ERROR) {
+            check_error(checker, line, col, "Struct destructuring requires a struct type, got '%s'",
+                        type_name(type));
+            return 1;
+        }
+        if (type->kind == TYPE_ERROR) {
+            for (int i = 0; i < pattern->as.struc.count; i++)
+                pattern->as.struc.field_types[i] = type_error;
+            return 0;
+        }
+        for (int i = 0; i < pattern->as.struc.count; i++) {
+            int found = 0;
+            for (int j = 0; j < type->as.struc.field_count; j++) {
+                if (strcmp(pattern->as.struc.field_names[i], type->as.struc.field_names[j]) == 0) {
+                    pattern->as.struc.field_types[i] = type->as.struc.field_types[j];
+                    found                            = 1;
+                    break;
+                }
+            }
+            if (!found) {
+                check_error(checker, line, col, "Struct '%s' has no field '%s'",
+                            type->as.struc.name, pattern->as.struc.field_names[i]);
+                return 1;
+            }
+        }
+        return 0;
     }
     return 0;
 }
@@ -570,6 +623,14 @@ static void define_destruct_pattern_vars(Checker* checker, DestructPattern* patt
                 define_destruct_pattern_vars(checker, pattern->as.tuple.elements[i], type_error,
                                              is_const, is_public);
             }
+        }
+        break;
+
+    case PATTERN_STRUCT:
+        for (int i = 0; i < pattern->as.struc.count; i++) {
+            checker_define(checker, pattern->as.struc.field_names[i], SYM_VAR,
+                           pattern->as.struc.field_types[i], is_const, is_public,
+                           checker->modules.current_module);
         }
         break;
     }
@@ -601,6 +662,24 @@ static void check_var_decl_stmt(Checker* checker, Node* node) {
         // Define all variables in the pattern
         define_destruct_pattern_vars(checker, pattern, init_type, node->as.var_decl.is_const,
                                      node->as.var_decl.is_public);
+
+        // RC tracking for struct destructuring (the temp struct must stay alive)
+        if (pattern->kind == PATTERN_STRUCT && init_type->kind == TYPE_STRUCT) {
+            Node* init = node->as.var_decl.init;
+            if (init->type == NODE_NEW_EXPR) {
+                node->as.var_decl.is_rc         = 1;
+                node->as.var_decl.resolved_type = init->as.new_expr.resolved_type;
+            } else if (init->type == NODE_IDENT) {
+                Symbol* src = checker_lookup(checker, init->as.ident.name);
+                if (src && src->is_rc) {
+                    node->as.var_decl.is_rc         = 1;
+                    node->as.var_decl.resolved_type = src->type;
+                }
+            } else if (init->type == NODE_CALL) {
+                node->as.var_decl.is_rc         = 1;
+                node->as.var_decl.resolved_type = init_type;
+            }
+        }
         return;
     }
 

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -1289,5 +1289,18 @@ void emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* t
             }
         }
         break;
+
+    case PATTERN_STRUCT:
+        // Struct patterns: extract fields via pointer access (->)
+        for (int i = 0; i < pattern->as.struc.count; i++) {
+            emit_indent(gen);
+            if (is_const) {
+                emit(gen, "const ");
+            }
+            emit_resolved_type(gen, pattern->as.struc.field_types[i]);
+            emit(gen, " %s = %s->%s;\n", pattern->as.struc.field_names[i], temp_prefix,
+                 pattern->as.struc.field_names[i]);
+        }
+        break;
     }
 }

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -444,9 +444,34 @@ static void emit_var_decl_inferred_type(CodeGen* gen, Node* node) {
 // Emit a variable declaration statement (NODE_VAR_DECL).
 // Handles destructuring, RC-managed declarations, type inference, and struct init.
 static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
-    // Handle destructuring: var (a, b) = tuple; or var (a, (b, c)) = nested;
+    // Handle destructuring: var (a, b) = tuple; or var {x, y} = struct_expr;
     DestructPattern* pattern = node->as.var_decl.destruct_pattern;
     if (pattern) {
+        if (pattern->kind == PATTERN_STRUCT) {
+            // Struct destructuring: var {a, b} = expr;
+            Type* struct_type = pattern->resolved_type;
+            int   temp_id     = gen->out.temp_count++;
+
+            // Emit temp: StructName* __destruct0 = expr;
+            // emit_resolved_type already adds * for struct types
+            emit_indent(gen);
+            emit_resolved_type(gen, struct_type);
+            emit(gen, " __destruct%d = ", temp_id);
+            emit_expr(gen, node->as.var_decl.init);
+            emit(gen, ";\n");
+
+            // Emit field extractions
+            char temp_name[64];
+            snprintf(temp_name, sizeof(temp_name), "__destruct%d", temp_id);
+            emit_destruct_pattern(gen, pattern, temp_name, node->as.var_decl.is_const);
+
+            // RC-track the temp (struct stays alive for scope)
+            if (node->as.var_decl.is_rc) {
+                rc_push_var(gen, temp_name, struct_type);
+            }
+            return;
+        }
+        // Tuple destructuring
         Type* tuple_type = pattern->resolved_type;
         emit_indent(gen);
         emit_resolved_type(gen, tuple_type);

--- a/w0/parser.c
+++ b/w0/parser.c
@@ -1538,6 +1538,49 @@ static DestructPattern* parse_destruct_pattern(Parser* parser) {
 static Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
     Token start = parser->current;
 
+    // Check for struct destructuring: var {field1, field2} = expr;
+    if (check_token(parser, TOK_LBRACE)) {
+        advance_token(parser); // consume '{'
+
+        DestructPattern* pattern = pattern_new_struct(4);
+
+        // Parse first field name (required)
+        Token field = parser->current;
+        consume_token(parser, TOK_IDENT, "Expected field name");
+        pattern_struct_push(pattern, field.start, field.length);
+
+        // Parse remaining comma-separated field names
+        while (match_token(parser, TOK_COMMA)) {
+            field = parser->current;
+            consume_token(parser, TOK_IDENT, "Expected field name");
+            pattern_struct_push(pattern, field.start, field.length);
+        }
+
+        consume_token(parser, TOK_RBRACE, "Expected '}'");
+
+        Node*          node = node_new(NODE_VAR_DECL, start.line, start.column);
+        var_decl_node* vdn  = &node->as.var_decl;
+
+        vdn->name             = NULL;
+        vdn->name_length      = 0;
+        vdn->is_public        = is_public;
+        vdn->is_const         = is_const;
+        vdn->type             = NULL;
+        vdn->init             = NULL;
+        vdn->destruct_pattern = pattern;
+
+        // Initializer is required for struct destructuring
+        if (!match_token(parser, TOK_EQ)) {
+            parse_error(parser, "Struct destructuring requires an initializer");
+            node_free(node);
+            return NULL;
+        }
+        vdn->init = parse_expression(parser);
+
+        consume_token(parser, TOK_SEMICOLON, "Expected ';' after variable declaration");
+        return node;
+    }
+
     // Check for destructuring: var (a, b) = ... or var (a, (b, c)) = ...
     if (check_token(parser, TOK_LPAREN)) {
         DestructPattern* pattern = parse_destruct_pattern(parser);

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -38,6 +38,15 @@ static void print_destruct_pattern(DestructPattern* pattern) {
         }
         printf(")");
         break;
+    case PATTERN_STRUCT:
+        printf("{");
+        for (int i = 0; i < pattern->as.struc.count; i++) {
+            if (i > 0)
+                printf(", ");
+            printf("%s", pattern->as.struc.field_names[i]);
+        }
+        printf("}");
+        break;
     }
 }
 

--- a/w0/test/errors/error_struct_destruct_duplicate.w
+++ b/w0/test/errors/error_struct_destruct_duplicate.w
@@ -1,0 +1,12 @@
+// ERROR TEST: Duplicate field names in struct destructuring
+// Expected error: Redefinition of 'x'
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+func main(): i32 {
+    var {x, x} = new Point {x: 1, y: 2};
+    return 0;
+}

--- a/w0/test/errors/error_struct_destruct_no_field.w
+++ b/w0/test/errors/error_struct_destruct_no_field.w
@@ -1,0 +1,12 @@
+// ERROR TEST: Struct destructuring with non-existent field
+// Expected error: Struct 'Point' has no field 'z'
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+func main(): i32 {
+    var {x, z} = new Point {x: 1, y: 2};
+    return 0;
+}

--- a/w0/test/errors/error_struct_destruct_not_struct.w
+++ b/w0/test/errors/error_struct_destruct_not_struct.w
@@ -1,0 +1,7 @@
+// ERROR TEST: Struct destructuring on non-struct type
+// Expected error: Struct destructuring requires a struct type, got 'i64'
+
+func main(): i32 {
+    var {x, y} = 42;
+    return 0;
+}

--- a/w0/test/run/types/struct_destructure.w
+++ b/w0/test/run/types/struct_destructure.w
@@ -1,0 +1,40 @@
+// Expected: PASS: struct_destructure
+// Test struct destructuring: var {field1, field2} = expr;
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+func make_point(a: i64, b: i64): Point {
+    return new Point {x: a, y: b};
+}
+
+struct Info {
+    code: i64,
+    value: i64,
+    extra: i64,
+}
+
+test "struct_destructure" {
+    // Basic: destructure from new expression
+    var {x, y} = new Point {x: 10, y: 20};
+    assert(x == 10);
+    assert(y == 20);
+
+    // Partial: only extract some fields
+    var {code} = new Info {code: 42, value: 7, extra: 99};
+    assert(code == 42);
+
+    // Const destructuring
+    const {value, extra} = new Info {code: 1, value: 2, extra: 3};
+    assert(value == 2);
+    assert(extra == 3);
+
+    // Destructure from function return (RC-tracked temp)
+    if (true) {
+        var {x, y} = make_point(30, 40);
+        assert(x == 30);
+        assert(y == 40);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `var {field1, field2} = expr;` syntax to extract named struct fields into local variables
- The underlying struct is kept alive as an RC-tracked temporary for the enclosing scope (borrow semantics)
- Partial destructuring supported (not all fields need to be listed)
- Works with `var` and `const`, with `new` expressions, function returns, and variable copies

## Changes

- **AST**: `PATTERN_STRUCT` variant with `field_names`, `field_name_lengths`, `field_types` parallel arrays
- **Parser**: Detect `var {` / `const {` and parse comma-separated field names
- **Checker**: Validate field names exist on struct type, check for duplicates/redefinitions, RC tracking for struct temps
- **Codegen**: Emit `StructType* __destructN = expr;` + `type field = __destructN->field;` per field, with `rc_push_var` for scope cleanup
- **Grammar**: Added `<struct-destruct>` BNF rule and documentation

## Test plan

- [x] `make` — clean build, no warnings
- [x] `make test` — all 278 tests pass (177 run + 101 error)
- [x] New run test: `struct_destructure.w` (basic, partial, const, function return)
- [x] New error tests: non-struct type, non-existent field, duplicate field names

Closes #229