### PR TITLE
feat: reference-counted strings with immortal literals

### DIFF
--- a/lib/include/fs.h
+++ b/lib/include/fs.h
@@ -25,6 +25,7 @@
 #include <dirent.h>
 #include <limits.h>
 #include <errno.h>
+#include <whist_runtime.h>
 
 /* ---------- Convenience API (no handles) ---------- */
 
@@ -41,7 +42,7 @@ static inline const char* fs__read_file(const char* path) {
         return NULL;
     }
 
-    char* buf = (char*)malloc((size_t)size + 1);
+    char* buf = __rc_strmalloc((size_t)size + 1);
     if (!buf) {
         fclose(fp);
         return NULL;
@@ -132,7 +133,9 @@ static inline const char* fs__read_line(void* handle) {
     }
 
     buf[len] = '\0';
-    return buf;
+    const char* result = __rc_strdup(buf);
+    free(buf);
+    return result;
 }
 
 static inline int32_t fs__write_string(void* handle, const char* content) {
@@ -217,8 +220,10 @@ static inline bool fs__is_file(const char* path) {
 }
 
 static inline const char* fs__cwd(void) {
-    char* result = getcwd(NULL, 0);
-    if (!result) return strdup("");
+    char* tmp = getcwd(NULL, 0);
+    if (!tmp) return __rc_strdup("");
+    const char* result = __rc_strdup(tmp);
+    free(tmp);
     return result;
 }
 
@@ -235,14 +240,14 @@ static inline void* fs__open_dir(const char* path) {
 
 static inline const char* fs__read_dir(void* handle) {
     DIR* d = (DIR*)handle;
-    if (!d) return strdup("");
+    if (!d) return __rc_strdup("");
     struct dirent* entry;
     while ((entry = readdir(d)) != NULL) {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
             continue;
-        return strdup(entry->d_name);
+        return __rc_strdup(entry->d_name);
     }
-    return strdup("");
+    return __rc_strdup("");
 }
 
 static inline int32_t fs__close_dir(void* handle) {
@@ -261,7 +266,7 @@ static inline const char* fs__join_path(const char* a, const char* b) {
     /* Strip leading slash from b */
     while (blen > 0 && *b == '/') { b++; blen--; }
 
-    char* result = (char*)malloc(alen + 1 + blen + 1);
+    char* result = __rc_strmalloc(alen + 1 + blen + 1);
     if (!result) return NULL;
     memcpy(result, a, alen);
     result[alen] = '/';
@@ -277,10 +282,10 @@ static inline const char* fs__dirname(const char* path) {
     /* Find last slash */
     size_t i = len;
     while (i > 0 && path[i - 1] != '/') i--;
-    if (i == 0) return strdup(".");
+    if (i == 0) return __rc_strdup(".");
     /* Strip trailing slashes from parent */
     while (i > 1 && path[i - 1] == '/') i--;
-    char* result = (char*)malloc(i + 1);
+    char* result = __rc_strmalloc(i + 1);
     if (!result) return NULL;
     memcpy(result, path, i);
     result[i] = '\0';
@@ -295,7 +300,7 @@ static inline const char* fs__basename(const char* path) {
     size_t i = len;
     while (i > 0 && path[i - 1] != '/') i--;
     size_t name_len = len - i;
-    char* result = (char*)malloc(name_len + 1);
+    char* result = __rc_strmalloc(name_len + 1);
     if (!result) return NULL;
     memcpy(result, path + i, name_len);
     result[name_len] = '\0';
@@ -314,14 +319,16 @@ static inline const char* fs__extension(const char* path) {
     for (size_t i = last_slash; i < len; i++) {
         if (path[i] == '.') dot = path + i;
     }
-    if (!dot || dot == path + len - 1) return strdup("");
-    return strdup(dot);
+    if (!dot || dot == path + len - 1) return __rc_strdup("");
+    return __rc_strdup(dot);
 }
 
 static inline const char* fs__abs_path(const char* path) {
     char* resolved = realpath(path, NULL);
-    if (!resolved) return strdup("");
-    return resolved;
+    if (!resolved) return __rc_strdup("");
+    const char* result = __rc_strdup(resolved);
+    free(resolved);
+    return result;
 }
 
 /* ---------- Metadata & temp ---------- */
@@ -334,8 +341,8 @@ static inline int64_t fs__modified_time(const char* path) {
 
 static inline const char* fs__temp_dir(void) {
     const char* tmp = getenv("TMPDIR");
-    if (tmp && tmp[0] != '\0') return strdup(tmp);
-    return strdup("/tmp");
+    if (tmp && tmp[0] != '\0') return __rc_strdup(tmp);
+    return __rc_strdup("/tmp");
 }
 
 #endif /* WHIST_FS_H */

--- a/lib/include/std_exec.h
+++ b/lib/include/std_exec.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <sys/wait.h>
+#include <whist_runtime.h>
 
 typedef struct {
     int32_t exit_code;
@@ -119,11 +120,11 @@ static inline int32_t std__exec_exit_code(void* handle) {
 }
 
 static inline const char* std__exec_output(void* handle) {
-    return strdup(((__ExecResult*)handle)->out);
+    return __rc_strdup(((__ExecResult*)handle)->out);
 }
 
 static inline const char* std__exec_error_output(void* handle) {
-    return strdup(((__ExecResult*)handle)->err);
+    return __rc_strdup(((__ExecResult*)handle)->err);
 }
 
 static inline void std__exec_free(void* handle) {

--- a/lib/include/std_str.h
+++ b/lib/include/std_str.h
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <whist_runtime.h>
 
 static inline int64_t std__parse_i64(const char* s) {
     return (int64_t)strtoll(s, NULL, 10);
@@ -23,7 +24,7 @@ static inline int64_t std__parse_i64(const char* s) {
 static inline const char* std__to_string(int64_t n) {
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "%lld", (long long)n);
-    char* r = (char*)malloc(len + 1);
+    char* r = __rc_strmalloc(len + 1);
     snprintf(r, len + 1, "%lld", (long long)n);
     return r;
 }

--- a/lib/include/whist_runtime.h
+++ b/lib/include/whist_runtime.h
@@ -51,6 +51,8 @@ static inline void __rc_inc(void* ptr) {
     if (!ptr)
         return;
     __RcHeader* h = ((__RcHeader*)ptr - 1);
+    if (h->refcount == SIZE_MAX)
+        return; /* immortal string literal */
     h->refcount++;
     fprintf(stderr, "RC_INC: %p (rc=%zu)\n", ptr, h->refcount);
 }
@@ -59,6 +61,8 @@ static inline void __rc_dec(void* ptr) {
     if (!ptr)
         return;
     __RcHeader* h = (__RcHeader*)ptr - 1;
+    if (h->refcount == SIZE_MAX)
+        return; /* immortal string literal */
     if (--h->refcount == 0) {
         if (h->cleanup)
             h->cleanup(ptr);
@@ -85,13 +89,18 @@ static inline void* __rc_alloc(size_t size, void (*cleanup)(void*)) {
 static inline void __rc_inc(void* ptr) {
     if (!ptr)
         return;
-    ((__RcHeader*)ptr - 1)->refcount++;
+    __RcHeader* h = (__RcHeader*)ptr - 1;
+    if (h->refcount == SIZE_MAX)
+        return; /* immortal string literal */
+    h->refcount++;
 }
 
 static inline void __rc_dec(void* ptr) {
     if (!ptr)
         return;
     __RcHeader* h = (__RcHeader*)ptr - 1;
+    if (h->refcount == SIZE_MAX)
+        return; /* immortal string literal */
     if (--h->refcount == 0) {
         if (h->cleanup)
             h->cleanup(ptr);
@@ -100,6 +109,20 @@ static inline void __rc_dec(void* ptr) {
 }
 
 #endif /* WHIST_RC_DEBUG */
+
+/* --- RC string helpers (for C runtime code returning strings to Whist) --- */
+static inline const char* __rc_strdup(const char* s) {
+    if (!s)
+        return NULL;
+    size_t len = strlen(s);
+    char*  r   = (char*)__rc_alloc(len + 1, NULL);
+    memcpy(r, s, len + 1);
+    return r;
+}
+
+static inline char* __rc_strmalloc(size_t size) {
+    return (char*)__rc_alloc(size, NULL);
+}
 
 /* --- Bounds checks --- */
 static inline void __w0_span_check(uint64_t count, int64_t idx, int line, int col) {
@@ -131,7 +154,7 @@ static inline int64_t __String_length(const char* s) {
 
 static inline const char* __String_concat(const char* a, const char* b) {
     size_t la = strlen(a), lb = strlen(b);
-    char*  r = (char*)malloc(la + lb + 1);
+    char*  r = (char*)__rc_alloc(la + lb + 1, NULL);
     memcpy(r, a, la);
     memcpy(r + la, b, lb + 1);
     return r;
@@ -141,7 +164,7 @@ static inline const char* __String_substr(const char* s, int64_t start, int64_t 
     int64_t len = end - start;
     if (len < 0)
         len = 0;
-    char* r = (char*)malloc(len + 1);
+    char* r = (char*)__rc_alloc(len + 1, NULL);
     memcpy(r, s + start, len);
     r[len] = '\0';
     return r;
@@ -174,6 +197,9 @@ typedef struct {
 
 static inline void __Vec_string_cleanup(void* raw) {
     __Vec_string* ptr = (__Vec_string*)raw;
+    for (int64_t i = 0; i < ptr->count; i++) {
+        __rc_dec((void*)ptr->data[i]);
+    }
     free(ptr->data);
 }
 
@@ -183,6 +209,7 @@ static inline void __Vec_string_push(__Vec_string* self, const char* value) {
         self->data      = (const char**)realloc(self->data, new_cap * sizeof(const char*));
         self->capacity  = new_cap;
     }
+    __rc_inc((void*)value);
     self->data[self->count++] = value;
 }
 
@@ -197,10 +224,14 @@ static inline __Vec_string* __String_split(const char* s, const char* delim) {
     for (;;) {
         const char* found = strstr(p, delim);
         if (!found) {
-            __Vec_string_push(vec, __String_substr(p, 0, (int64_t)strlen(p)));
+            const char* part = __String_substr(p, 0, (int64_t)strlen(p));
+            __Vec_string_push(vec, part); /* push incs; dec our local ref */
+            __rc_dec((void*)part);
             break;
         }
-        __Vec_string_push(vec, __String_substr(p, 0, (int64_t)(found - p)));
+        const char* part = __String_substr(p, 0, (int64_t)(found - p));
+        __Vec_string_push(vec, part); /* push incs; dec our local ref */
+        __rc_dec((void*)part);
         p = found + dlen;
     }
     return vec;
@@ -212,7 +243,7 @@ static inline const char* __std_format(const char* fmt, ...) {
     va_copy(args2, args1);
     int n = vsnprintf(NULL, 0, fmt, args1);
     va_end(args1);
-    char* buf = (char*)malloc(n + 1);
+    char* buf = (char*)__rc_alloc(n + 1, NULL);
     vsnprintf(buf, n + 1, fmt, args2);
     va_end(args2);
     return buf;
@@ -271,11 +302,11 @@ static inline void __StringBuilder_clear(__StringBuilder* self) {
 
 static inline const char* __StringBuilder_to_string(__StringBuilder* self) {
     if (!self->data || self->count == 0) {
-        char* e = (char*)malloc(1);
+        char* e = (char*)__rc_alloc(1, NULL);
         e[0]    = '\0';
         return e;
     }
-    char* r = (char*)malloc(self->count + 1);
+    char* r = (char*)__rc_alloc(self->count + 1, NULL);
     memcpy(r, self->data, self->count + 1);
     return r;
 }

--- a/lib/whist_runtime.c
+++ b/lib/whist_runtime.c
@@ -9,6 +9,6 @@ int64_t std__argc(void) {
 
 const char* std__argv(int64_t i) {
     if (i < 0 || i >= (int64_t)__w0_argc)
-        return "";
-    return (const char*)__w0_argv[i];
+        return __rc_strdup("");
+    return __rc_strdup((const char*)__w0_argv[i]);
 }

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -762,12 +762,19 @@ static void check_var_decl_stmt(Checker* checker, Node* node) {
         } else if (node->as.var_decl.init->type == NODE_CALL && var_type) {
             // Store resolved type for codegen type inference
             node->as.var_decl.resolved_type = var_type;
-            if (var_type->kind == TYPE_STRUCT) {
-                // Function call returning a struct transfers RC ownership
+            if (var_type->kind == TYPE_STRUCT || var_type->kind == TYPE_STRING) {
+                // Function call returning a struct/string transfers RC ownership
                 node->as.var_decl.is_rc = 1;
                 sym->is_rc              = 1;
             }
         }
+    }
+
+    // All string variables are RC-managed (immortal literals are no-ops for inc/dec)
+    if (sym && var_type && var_type->kind == TYPE_STRING && !node->as.var_decl.is_rc) {
+        node->as.var_decl.is_rc         = 1;
+        node->as.var_decl.resolved_type = type_string;
+        sym->is_rc                      = 1;
     }
 }
 

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -507,6 +507,11 @@ void codegen_init(CodeGen* gen, FILE* out, CodeGenChecker checker_data, int rc_d
     gen->aliases.use_count            = 0;
     gen->aliases.use_capacity         = 0;
 
+    gen->string_lits.values   = NULL;
+    gen->string_lits.lengths  = NULL;
+    gen->string_lits.count    = 0;
+    gen->string_lits.capacity = 0;
+
     gen->tuple_types         = NULL;
     gen->tuple_type_count    = 0;
     gen->tuple_type_capacity = 0;
@@ -523,6 +528,11 @@ void codegen_free(CodeGen* gen) {
         free(gen->rc.vars[i].name);
     }
     free(gen->rc.vars);
+    for (int i = 0; i < gen->string_lits.count; i++) {
+        free(gen->string_lits.values[i]);
+    }
+    free(gen->string_lits.values);
+    free(gen->string_lits.lengths);
     for (int i = 0; i < gen->enums.count; i++) {
         free(gen->enums.names[i]);
     }
@@ -563,6 +573,251 @@ static void collect_types_and_aliases(CodeGen* gen, Node* ast) {
             }
         }
     }
+}
+
+// Register a string literal in the table, deduplicating by value. Returns the index.
+static int register_string_lit(CodeGen* gen, const char* value, int length) {
+    for (int i = 0; i < gen->string_lits.count; i++) {
+        if (gen->string_lits.lengths[i] == length &&
+            memcmp(gen->string_lits.values[i], value, length) == 0)
+            return i;
+    }
+    VEC_GROW(gen->string_lits.values, gen->string_lits.count, gen->string_lits.capacity);
+    gen->string_lits.lengths =
+        xrealloc(gen->string_lits.lengths, gen->string_lits.capacity * sizeof(int));
+    char* copy = xmalloc(length + 1);
+    memcpy(copy, value, length);
+    copy[length]                                     = '\0';
+    gen->string_lits.values[gen->string_lits.count]  = copy;
+    gen->string_lits.lengths[gen->string_lits.count] = length;
+    return gen->string_lits.count++;
+}
+
+// Recursively walk AST to collect all string literals
+static void collect_string_literals_node(CodeGen* gen, Node* node) {
+    if (!node)
+        return;
+    switch (node->type) {
+    case NODE_STRING_LIT:
+        register_string_lit(gen, node->as.string_lit.value, node->as.string_lit.length);
+        break;
+    case NODE_STRING_INTERP: {
+        // Check if all parts are text — if so, register the concatenation
+        int all_text = 1;
+        for (int i = 0; i < node->as.string_interp.part_count; i++) {
+            if (node->as.string_interp.parts.nodes[i]->type != NODE_STRING_LIT) {
+                all_text = 0;
+                break;
+            }
+        }
+        if (all_text && node->as.string_interp.part_count > 0) {
+            // Calculate total length
+            int total = 0;
+            for (int i = 0; i < node->as.string_interp.part_count; i++) {
+                total += node->as.string_interp.parts.nodes[i]->as.string_lit.length;
+            }
+            char* concat = xmalloc(total + 1);
+            int   pos    = 0;
+            for (int i = 0; i < node->as.string_interp.part_count; i++) {
+                Node* p = node->as.string_interp.parts.nodes[i];
+                memcpy(concat + pos, p->as.string_lit.value, p->as.string_lit.length);
+                pos += p->as.string_lit.length;
+            }
+            concat[total] = '\0';
+            register_string_lit(gen, concat, total);
+            free(concat);
+        }
+        // Recurse into parts regardless
+        for (int i = 0; i < node->as.string_interp.part_count; i++) {
+            collect_string_literals_node(gen, node->as.string_interp.parts.nodes[i]);
+        }
+        break;
+    }
+    case NODE_PROGRAM:
+        for (int i = 0; i < node->as.program.modules.count; i++)
+            collect_string_literals_node(gen, node->as.program.modules.nodes[i]);
+        break;
+    case NODE_MODULE:
+        for (int i = 0; i < node->as.module.decls.count; i++)
+            collect_string_literals_node(gen, node->as.module.decls.nodes[i]);
+        break;
+    case NODE_FUNC_DECL:
+        if (node->as.func_decl.body)
+            collect_string_literals_node(gen, node->as.func_decl.body);
+        break;
+    case NODE_BLOCK:
+        for (int i = 0; i < node->as.block.stmts.count; i++)
+            collect_string_literals_node(gen, node->as.block.stmts.nodes[i]);
+        break;
+    case NODE_VAR_DECL:
+        collect_string_literals_node(gen, node->as.var_decl.init);
+        break;
+    case NODE_RETURN:
+        collect_string_literals_node(gen, node->as.return_stmt.value);
+        break;
+    case NODE_IF:
+        collect_string_literals_node(gen, node->as.if_stmt.cond);
+        collect_string_literals_node(gen, node->as.if_stmt.then_block);
+        collect_string_literals_node(gen, node->as.if_stmt.else_block);
+        break;
+    case NODE_FOR:
+        collect_string_literals_node(gen, node->as.for_stmt.init);
+        collect_string_literals_node(gen, node->as.for_stmt.cond);
+        collect_string_literals_node(gen, node->as.for_stmt.post);
+        collect_string_literals_node(gen, node->as.for_stmt.body);
+        break;
+    case NODE_FOREACH:
+        collect_string_literals_node(gen, node->as.foreach_stmt.collection);
+        collect_string_literals_node(gen, node->as.foreach_stmt.start);
+        collect_string_literals_node(gen, node->as.foreach_stmt.end);
+        collect_string_literals_node(gen, node->as.foreach_stmt.body);
+        break;
+    case NODE_WHILE:
+        collect_string_literals_node(gen, node->as.while_stmt.cond);
+        collect_string_literals_node(gen, node->as.while_stmt.body);
+        break;
+    case NODE_EXPR_STMT:
+        collect_string_literals_node(gen, node->as.expr_stmt.expr);
+        break;
+    case NODE_BINARY:
+        collect_string_literals_node(gen, node->as.binary.left);
+        collect_string_literals_node(gen, node->as.binary.right);
+        break;
+    case NODE_UNARY:
+        collect_string_literals_node(gen, node->as.unary.operand);
+        break;
+    case NODE_CALL:
+        collect_string_literals_node(gen, node->as.call.func);
+        for (int i = 0; i < node->as.call.args.count; i++)
+            collect_string_literals_node(gen, node->as.call.args.nodes[i]);
+        break;
+    case NODE_MEMBER:
+        collect_string_literals_node(gen, node->as.member.object);
+        break;
+    case NODE_INDEX:
+        collect_string_literals_node(gen, node->as.index.object);
+        collect_string_literals_node(gen, node->as.index.index);
+        break;
+    case NODE_SLICE:
+        collect_string_literals_node(gen, node->as.slice.object);
+        collect_string_literals_node(gen, node->as.slice.start);
+        collect_string_literals_node(gen, node->as.slice.end);
+        break;
+    case NODE_ASSIGN:
+        collect_string_literals_node(gen, node->as.assign.target);
+        collect_string_literals_node(gen, node->as.assign.value);
+        break;
+    case NODE_CAST:
+        collect_string_literals_node(gen, node->as.cast_expr.expr);
+        break;
+    case NODE_NEW_EXPR:
+        collect_string_literals_node(gen, node->as.new_expr.init);
+        for (int i = 0; i < node->as.new_expr.args.count; i++)
+            collect_string_literals_node(gen, node->as.new_expr.args.nodes[i]);
+        break;
+    case NODE_STRUCT_INIT:
+        for (int i = 0; i < node->as.struct_init.fields.count; i++)
+            collect_string_literals_node(gen, node->as.struct_init.fields.nodes[i]);
+        break;
+    case NODE_FIELD_INIT:
+        collect_string_literals_node(gen, node->as.field_init.value);
+        break;
+    case NODE_MATCH:
+        collect_string_literals_node(gen, node->as.match_stmt.expr);
+        for (int i = 0; i < node->as.match_stmt.arms.count; i++) {
+            collect_string_literals_node(gen, node->as.match_stmt.arms.nodes[i]);
+        }
+        break;
+    case NODE_MATCH_ARM:
+        collect_string_literals_node(gen, node->as.match_arm.body);
+        break;
+    case NODE_DEFER:
+        collect_string_literals_node(gen, node->as.defer_stmt.stmt);
+        break;
+    case NODE_ENUM_VALUE:
+        for (int i = 0; i < node->as.enum_value.args.count; i++)
+            collect_string_literals_node(gen, node->as.enum_value.args.nodes[i]);
+        break;
+    case NODE_TUPLE_LIT:
+        for (int i = 0; i < node->as.tuple_lit.elements.count; i++)
+            collect_string_literals_node(gen, node->as.tuple_lit.elements.nodes[i]);
+        break;
+    case NODE_IMPL_DECL:
+        for (int i = 0; i < node->as.impl_decl.methods.count; i++)
+            collect_string_literals_node(gen, node->as.impl_decl.methods.nodes[i]);
+        break;
+    case NODE_TEST_DECL:
+        collect_string_literals_node(gen, node->as.test_decl.body);
+        break;
+    case NODE_STRUCT_DECL:
+    case NODE_ENUM_DECL:
+    case NODE_TRAIT_DECL:
+    case NODE_TYPE_ALIAS:
+    case NODE_EXTERN_MODULE:
+    case NODE_USE_DECL:
+        break;
+    default:
+        break;
+    }
+}
+
+static void collect_string_literals(CodeGen* gen, Node* ast) {
+    collect_string_literals_node(gen, ast);
+}
+
+// Emit escaped string content (shared helper for string literal table)
+static void emit_escaped_string(CodeGen* gen, const char* value, int length) {
+    for (int i = 0; i < length; i++) {
+        char c = value[i];
+        switch (c) {
+        case '\n':
+            emit(gen, "\\n");
+            break;
+        case '\t':
+            emit(gen, "\\t");
+            break;
+        case '\r':
+            emit(gen, "\\r");
+            break;
+        case '\\':
+            emit(gen, "\\\\");
+            break;
+        case '"':
+            emit(gen, "\\\"");
+            break;
+        case '\0':
+            emit(gen, "\\0");
+            break;
+        default:
+            emit(gen, "%c", c);
+            break;
+        }
+    }
+}
+
+// Emit static RC string literal structs with immortal (SIZE_MAX) refcount
+static void emit_string_literals(CodeGen* gen) {
+    if (gen->string_lits.count == 0)
+        return;
+    for (int i = 0; i < gen->string_lits.count; i++) {
+        emit(gen,
+             "static struct { __RcHeader hdr; char data[%d]; } __rc_str_%d = "
+             "{ {SIZE_MAX, NULL}, \"",
+             gen->string_lits.lengths[i] + 1, i);
+        emit_escaped_string(gen, gen->string_lits.values[i], gen->string_lits.lengths[i]);
+        emit(gen, "\" };\n");
+    }
+    emit(gen, "\n");
+}
+
+// Look up a string literal's index in the table. Returns -1 if not found.
+int lookup_string_lit(CodeGen* gen, const char* value, int length) {
+    for (int i = 0; i < gen->string_lits.count; i++) {
+        if (gen->string_lits.lengths[i] == length &&
+            memcmp(gen->string_lits.values[i], value, length) == 0)
+            return i;
+    }
+    return -1;
 }
 
 // Emit the standard C header includes for the generated output
@@ -1249,10 +1504,12 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     int has_user_main = program_has_user_main(ast);
 
     collect_types_and_aliases(gen, ast);
+    collect_string_literals(gen, ast);
     emit_c_headers(gen);
     emit_rc_runtime(gen);
     emit_bounds_checks(gen);
     emit_string_helpers(gen);
+    emit_string_literals(gen);
     emit_tuple_typedefs(gen);
     register_enum_names(gen, ast);
     compute_enum_rc_flags(gen, ast);

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -112,6 +112,13 @@ typedef struct {
     Type** tuple_types;
     int    tuple_type_count;
     int    tuple_type_capacity;
+    // RC string literal table (immortal static structs)
+    struct {
+        char** values;  // String values (owned copies)
+        int*   lengths; // String lengths
+        int    count;
+        int    capacity;
+    } string_lits;
     // Current module name (NULL for "main")
     const char* current_module;
     // 1 if currently emitting an enum method body

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -106,32 +106,37 @@ static char* resolve_generic_method_target(CodeGen* gen, Node* member) {
 
 // Emit a string literal with C escape sequences
 static void emit_string_lit(CodeGen* gen, Node* node) {
-    emit(gen, "\"");
-    // Escape special characters
-    for (int i = 0; i < node->as.string_lit.length; i++) {
-        char c = node->as.string_lit.value[i];
-        switch (c) {
-        case '\n':
-            emit(gen, "\\n");
-            break;
-        case '\t':
-            emit(gen, "\\t");
-            break;
-        case '\r':
-            emit(gen, "\\r");
-            break;
-        case '\\':
-            emit(gen, "\\\\");
-            break;
-        case '"':
-            emit(gen, "\\\"");
-            break;
-        default:
-            emit(gen, "%c", c);
-            break;
+    int idx = lookup_string_lit(gen, node->as.string_lit.value, node->as.string_lit.length);
+    if (idx >= 0) {
+        emit(gen, "((const char*)__rc_str_%d.data)", idx);
+    } else {
+        // Fallback: inline C string literal (should not happen for well-collected AST)
+        emit(gen, "\"");
+        for (int i = 0; i < node->as.string_lit.length; i++) {
+            char c = node->as.string_lit.value[i];
+            switch (c) {
+            case '\n':
+                emit(gen, "\\n");
+                break;
+            case '\t':
+                emit(gen, "\\t");
+                break;
+            case '\r':
+                emit(gen, "\\r");
+                break;
+            case '\\':
+                emit(gen, "\\\\");
+                break;
+            case '"':
+                emit(gen, "\\\"");
+                break;
+            default:
+                emit(gen, "%c", c);
+                break;
+            }
         }
+        emit(gen, "\"");
     }
-    emit(gen, "\"");
 }
 
 // Emit a character literal with C escape sequences
@@ -745,40 +750,57 @@ static void emit_string_interp(CodeGen* gen, Node* node) {
     }
 
     if (!has_expr) {
-        // All parts are text — concatenate into a single string literal
-        emit(gen, "\"");
+        // All parts are text — concatenate and look up in string literal table
+        int total = 0;
+        for (int i = 0; i < count; i++)
+            total += node->as.string_interp.parts.nodes[i]->as.string_lit.length;
+        char* concat = (char*)malloc(total + 1);
+        int   pos    = 0;
         for (int i = 0; i < count; i++) {
-            Node* part = node->as.string_interp.parts.nodes[i];
-            // Emit with C escaping
-            const char* s = part->as.string_lit.value;
-            int         n = part->as.string_lit.length;
-            for (int j = 0; j < n; j++) {
-                switch (s[j]) {
-                case '\n':
-                    emit(gen, "\\n");
-                    break;
-                case '\t':
-                    emit(gen, "\\t");
-                    break;
-                case '\r':
-                    emit(gen, "\\r");
-                    break;
-                case '\\':
-                    emit(gen, "\\\\");
-                    break;
-                case '"':
-                    emit(gen, "\\\"");
-                    break;
-                case '\0':
-                    emit(gen, "\\0");
-                    break;
-                default:
-                    emit(gen, "%c", s[j]);
-                    break;
+            Node* p = node->as.string_interp.parts.nodes[i];
+            memcpy(concat + pos, p->as.string_lit.value, p->as.string_lit.length);
+            pos += p->as.string_lit.length;
+        }
+        concat[total] = '\0';
+        int idx       = lookup_string_lit(gen, concat, total);
+        free(concat);
+        if (idx >= 0) {
+            emit(gen, "((const char*)__rc_str_%d.data)", idx);
+        } else {
+            // Fallback: inline C string literal
+            emit(gen, "\"");
+            for (int i = 0; i < count; i++) {
+                Node*       part = node->as.string_interp.parts.nodes[i];
+                const char* s    = part->as.string_lit.value;
+                int         n    = part->as.string_lit.length;
+                for (int j = 0; j < n; j++) {
+                    switch (s[j]) {
+                    case '\n':
+                        emit(gen, "\\n");
+                        break;
+                    case '\t':
+                        emit(gen, "\\t");
+                        break;
+                    case '\r':
+                        emit(gen, "\\r");
+                        break;
+                    case '\\':
+                        emit(gen, "\\\\");
+                        break;
+                    case '"':
+                        emit(gen, "\\\"");
+                        break;
+                    case '\0':
+                        emit(gen, "\\0");
+                        break;
+                    default:
+                        emit(gen, "%c", s[j]);
+                        break;
+                    }
                 }
             }
+            emit(gen, "\"");
         }
-        emit(gen, "\"");
         return;
     }
 

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -7,6 +7,7 @@
 // --- From codegen.c: generic substitution ---
 Type* subst_lookup(CodeGen* gen, const char* name);
 char* stringify_expr(Node* node);
+int   lookup_string_lit(CodeGen* gen, const char* value, int length);
 
 // --- From codegen_emit.c: shared helpers ---
 void        defer_push(CodeGen* gen, Node* node);

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -74,6 +74,8 @@ static void emit_rc_dec_var(CodeGen* gen, RcVar* var) {
     Type* t = var->type;
     if (t && t->kind == TYPE_ENUM && t->as.enm.has_rc_fields) {
         emit(gen, "__rc_dec_%s(%s)", t->as.enm.name, var->name);
+    } else if (t && t->kind == TYPE_STRING) {
+        emit(gen, "__rc_dec((void*)%s)", var->name);
     } else {
         emit(gen, "__rc_dec(%s)", var->name);
     }
@@ -169,6 +171,9 @@ static void emit_enum_rc_func(CodeGen* gen, const char* ename, Node* enum_decl, 
             }
             if (enum_nm) {
                 emit(gen, "        __rc_%s_%s(v.%.*s.f%d);\n", op, enum_nm,
+                     var->as.enum_variant.name_length, var->as.enum_variant.name, t);
+            } else if (tnode->type == NODE_IDENT && strcmp(tnode->as.ident.name, "string") == 0) {
+                emit(gen, "        __rc_%s((void*)v.%.*s.f%d);\n", op,
                      var->as.enum_variant.name_length, var->as.enum_variant.name, t);
             } else {
                 emit(gen, "        __rc_%s(v.%.*s.f%d);\n", op, var->as.enum_variant.name_length,
@@ -321,7 +326,8 @@ void emit_vec_methods(CodeGen* gen) {
         VecInstance* inst        = &gen->checker.vecs[i];
         Type*        elem_type   = inst->elem_type;
         const char*  elem_tname  = type_mangle_name(elem_type);
-        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
+        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC ||
+                           elem_type->kind == TYPE_STRING);
 
         // Push (Vec<string> push is provided by whist_runtime.h)
         if (elem_type->kind != TYPE_STRING) {
@@ -363,6 +369,9 @@ void emit_vec_methods(CodeGen* gen) {
         emit_resolved_type(gen, elem_type);
         emit(gen, "));\n");
         emit(gen, "    }\n");
+        if (elem_type->kind == TYPE_STRING) {
+            emit(gen, "    __rc_inc((void*)value);\n");
+        }
         emit(gen, "    self->data[index] = value;\n");
         emit(gen, "    self->count++;\n");
         emit(gen, "}\n\n");
@@ -499,7 +508,11 @@ void emit_vec_methods(CodeGen* gen) {
         emit(gen, "static inline void __Vec_%s_clear(__Vec_%s* self) {\n", elem_tname, elem_tname);
         if (elem_is_ptr) {
             emit(gen, "    for (int64_t i = 0; i < self->count; i++) {\n");
-            emit(gen, "        __rc_dec(self->data[i]);\n");
+            if (elem_type->kind == TYPE_STRING) {
+                emit(gen, "        __rc_dec((void*)self->data[i]);\n");
+            } else {
+                emit(gen, "        __rc_dec(self->data[i]);\n");
+            }
             emit(gen, "    }\n");
         }
         emit(gen, "    self->count = 0;\n");
@@ -542,7 +555,11 @@ void emit_vec_methods(CodeGen* gen) {
                  option_tname);
             emit(gen, "    }\n");
             if (elem_is_ptr) {
-                emit(gen, "    __rc_inc(self->data[0]);\n");
+                if (elem_type->kind == TYPE_STRING) {
+                    emit(gen, "    __rc_inc((void*)self->data[0]);\n");
+                } else {
+                    emit(gen, "    __rc_inc(self->data[0]);\n");
+                }
             }
             emit(gen,
                  "    return (Option_%s){.tag = Option_%s_Some, .Some = {.f0 = "
@@ -558,7 +575,11 @@ void emit_vec_methods(CodeGen* gen) {
                  option_tname);
             emit(gen, "    }\n");
             if (elem_is_ptr) {
-                emit(gen, "    __rc_inc(self->data[self->count - 1]);\n");
+                if (elem_type->kind == TYPE_STRING) {
+                    emit(gen, "    __rc_inc((void*)self->data[self->count - 1]);\n");
+                } else {
+                    emit(gen, "    __rc_inc(self->data[self->count - 1]);\n");
+                }
             }
             emit(gen,
                  "    return (Option_%s){.tag = Option_%s_Some, "
@@ -663,6 +684,9 @@ void emit_struct_cleanup(CodeGen* gen, Node* ast) {
                 if (rc_fields[f].is_enum) {
                     emit(gen, "    __rc_dec_%s(ptr->%s);\n", rc_fields[f].type_name,
                          rc_fields[f].field_name);
+                } else if (rc_fields[f].type_name &&
+                           strcmp(rc_fields[f].type_name, "string") == 0) {
+                    emit(gen, "    __rc_dec((void*)ptr->%s);\n", rc_fields[f].field_name);
                 } else {
                     emit(gen, "    __rc_dec(ptr->%s);\n", rc_fields[f].field_name);
                 }
@@ -698,10 +722,10 @@ void emit_struct_cleanup(CodeGen* gen, Node* ast) {
         }
         for (int f = 0; f < t->as.struc.field_count; f++) {
             Type* ft = t->as.struc.field_types[f];
-            if (ft && ft->kind == TYPE_STRUCT) {
+            if (ft && (ft->kind == TYPE_STRUCT || ft->kind == TYPE_VEC)) {
                 emit(gen, "    __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
-            } else if (ft && ft->kind == TYPE_VEC) {
-                emit(gen, "    __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
+            } else if (ft && ft->kind == TYPE_STRING) {
+                emit(gen, "    __rc_dec((void*)ptr->%s);\n", t->as.struc.field_names[f]);
             }
         }
         emit(gen, "}\n\n");

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -82,7 +82,11 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
         emit_indent(gen);
         emit(gen, "__rc_inc(__rc_tmp%d);\n", temp_id);
         emit_indent(gen);
-        emit(gen, "__rc_dec(%s);\n", var_name);
+        if (var_type && var_type->kind == TYPE_STRING) {
+            emit(gen, "__rc_dec((void*)%s);\n", var_name);
+        } else {
+            emit(gen, "__rc_dec(%s);\n", var_name);
+        }
         emit_indent(gen);
         emit(gen, "%s = __rc_tmp%d;\n", var_name, temp_id);
         return;
@@ -132,7 +136,12 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
             int value_is_rc = (expr->as.assign.value->type == NODE_IDENT &&
                                rc_is_tracked(gen, expr->as.assign.value->as.ident.name)) ||
                               expr->as.assign.value->type == NODE_NEW_EXPR;
-            if (value_is_rc && field_ty && field_ty->kind == TYPE_STRUCT) {
+            // For string fields, any value assignment needs RC handling
+            if (field_ty && field_ty->kind == TYPE_STRING) {
+                value_is_rc = 1;
+            }
+            if (value_is_rc && field_ty &&
+                (field_ty->kind == TYPE_STRUCT || field_ty->kind == TYPE_STRING)) {
                 int tmp = gen->out.temp_count++;
                 emit_indent(gen);
                 emit(gen, "void* __rc_tmp%d = (void*)", tmp);
@@ -141,7 +150,11 @@ static void emit_expr_stmt(CodeGen* gen, Node* node) {
                 emit_indent(gen);
                 emit(gen, "__rc_inc(__rc_tmp%d);\n", tmp);
                 emit_indent(gen);
-                emit(gen, "__rc_dec(");
+                if (field_ty->kind == TYPE_STRING) {
+                    emit(gen, "__rc_dec((void*)");
+                } else {
+                    emit(gen, "__rc_dec(");
+                }
                 emit_expr(gen, member);
                 emit(gen, ");\n");
                 emit_indent(gen);
@@ -318,15 +331,22 @@ static void emit_var_decl_rc_copy(CodeGen* gen, Node* node) {
     emit(gen, " = ");
     emit_expr(gen, node->as.var_decl.init);
     emit(gen, ";\n");
-    // Function calls transfer ownership (rc already 1), no inc needed
-    Type* rc_type = node->as.var_decl.resolved_type;
-    int   skip_inc =
-        node->as.var_decl.init->type == NODE_CALL ||
-        (rc_type && rc_type->kind == TYPE_ENUM && node->as.var_decl.init->type == NODE_ENUM_VALUE);
+    // Function calls and string operations transfer ownership (rc already 1), no inc needed
+    Type* rc_type  = node->as.var_decl.resolved_type;
+    Node* init     = node->as.var_decl.init;
+    int   skip_inc = init->type == NODE_CALL || init->type == NODE_STRING_LIT ||
+                   init->type == NODE_STRING_INTERP ||
+                   (init->type == NODE_BINARY && init->as.binary.is_string_op) ||
+                   (init->type == NODE_SLICE && init->as.slice.is_string) ||
+                   (rc_type && rc_type->kind == TYPE_ENUM && init->type == NODE_ENUM_VALUE);
     if (!skip_inc && rc_type) {
         const char* inc_fn = get_inc_func_for_type(rc_type);
         emit_indent(gen);
-        emit(gen, "%s(%s);\n", inc_fn, node->as.var_decl.name);
+        if (rc_type->kind == TYPE_STRING) {
+            emit(gen, "%s((void*)%s);\n", inc_fn, node->as.var_decl.name);
+        } else {
+            emit(gen, "%s(%s);\n", inc_fn, node->as.var_decl.name);
+        }
         free((char*)inc_fn);
     }
     rc_push_var(gen, node->as.var_decl.name, rc_type);

--- a/w0/codegen_types.c
+++ b/w0/codegen_types.c
@@ -116,6 +116,8 @@ int type_node_has_rc(CodeGen* gen, Node* type_node) {
         return 0;     // Primitives, etc.
     }
 
+    if (strcmp(name, "string") == 0)
+        return 1;
     if (type_is_builtin_name(name))
         return 0;
     if (is_enum_type_name(gen, name))

--- a/w0/test/run/memory/rc_strings.w
+++ b/w0/test/run/memory/rc_strings.w
@@ -1,0 +1,59 @@
+// Expected: PASS: rc_strings
+// Test RC string memory management
+
+import std;
+
+func make_greeting(name: string): string {
+    return "Hello, " + name + "!";
+}
+
+struct Person {
+    name: string,
+    title: string,
+}
+
+test "rc_strings" {
+    // String literals are immortal (no alloc/free)
+    var lit = "hello";
+    assert(lit == "hello");
+
+    // String concat creates RC-managed string
+    var s = "foo" + "bar";
+    assert(s == "foobar");
+
+    // String substr creates RC-managed string
+    var sub = s[0:3];
+    assert(sub == "foo");
+
+    // String interpolation with expressions creates RC-managed string
+    var x = 42;
+    var interp = $"x is {x}";
+    assert(interp == "x is 42");
+
+    // Function returning string transfers ownership
+    var greeting = make_greeting("World");
+    assert(greeting == "Hello, World!");
+
+    // String copy between variables
+    var a = "dynamic" + "!";
+    var b = a;
+    assert(a == b);
+
+    // Struct with string fields (cleanup decrements strings)
+    var p = new Person { name: "Alice", title: "Dr." };
+    assert(p.name == "Alice");
+    assert(p.title == "Dr.");
+    // p = null;
+
+    // Vec<string> with dynamic strings
+    var parts = "one,two,three".split(",");
+    assert(parts.count == 3);
+    assert(parts[0] == "one");
+    assert(parts[1] == "two");
+    assert(parts[2] == "three");
+    // parts.clear(); // Clear should free strings
+
+    // std.format creates RC-managed string
+    var formatted = std.format("value=%d", 99);
+    assert(formatted == "value=99");
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -389,7 +389,8 @@ int type_supports_equality(Type* type) {
 int type_is_rc_managed(Type* type) {
     if (!type)
         return 0;
-    if (type->kind == TYPE_STRUCT || type->kind == TYPE_VEC || type->kind == TYPE_STRINGBUILDER)
+    if (type->kind == TYPE_STRUCT || type->kind == TYPE_VEC || type->kind == TYPE_STRINGBUILDER ||
+        type->kind == TYPE_STRING)
         return 1;
     if (type->kind == TYPE_ENUM && type->as.enm.has_rc_fields)
         return 1;


### PR DESCRIPTION
## Summary

- All strings are now RC-managed with automatic scope-based cleanup
- String literals use static RC headers with `SIZE_MAX` refcount (immortal — `__rc_inc`/`__rc_dec` are no-ops)
- Dynamic strings from concat, substr, format, interpolation, and C library functions use `__rc_alloc` and are freed at scope exit
- String literal table: codegen collects all string literals and emits static `__rc_str_N` structs with immortal headers
- `Vec<string>` push increments refcount; cleanup decrements all elements
- C library headers (`fs.h`, `std_str.h`, `std_exec.h`) updated to return RC-allocated strings via `__rc_strdup`/`__rc_strmalloc`

## Files changed

| Area | Files | Changes |
|------|-------|---------|
| Runtime | `whist_runtime.h`, `whist_runtime.c` | SIZE_MAX sentinel, `__rc_strdup`/`__rc_strmalloc`, Vec push incs, split decs |
| Library | `fs.h`, `std_str.h`, `std_exec.h` | Return RC-allocated strings |
| Type system | `types.c` | `type_is_rc_managed` returns 1 for `TYPE_STRING` |
| Checker | `checker.c` | Mark all string vars as RC-tracked |
| Codegen | `codegen.c/h`, `codegen_internal.h` | String literal table (collect, emit, lookup) |
| Codegen | `codegen_expr.c` | Emit `__rc_str_N` references for literals/pure-text interps |
| Codegen | `codegen_types.c` | `type_node_has_rc` returns 1 for `"string"` |
| Codegen | `codegen_stmt.c` | `skip_inc` for string ops, `(void*)` casts, field assignment RC |
| Codegen | `codegen_rc.c` | `(void*)` casts for string elements/fields, insert incs |
| Test | `rc_strings.w` | New test covering all RC string scenarios |

## Test plan

- [x] `make test` — all 279 tests pass (178 run + 101 error)
- [x] `make test-whist` — Whist-based test runner passes all 279 tests
- [x] ASAN clean — no heap-buffer-overflow, no use-after-free
- [x] New `rc_strings.w` test covers: literals, concat, substr, interpolation, function returns, struct fields, Vec<string>, std.format