### PR TITLE
fix: track Vec/StringBuilder from function calls as RC-managed

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -762,8 +762,8 @@ static void check_var_decl_stmt(Checker* checker, Node* node) {
         } else if (node->as.var_decl.init->type == NODE_CALL && var_type) {
             // Store resolved type for codegen type inference
             node->as.var_decl.resolved_type = var_type;
-            if (var_type->kind == TYPE_STRUCT || var_type->kind == TYPE_STRING) {
-                // Function call returning a struct/string transfers RC ownership
+            if (type_is_rc_managed(var_type)) {
+                // Function call returning an RC-managed type transfers ownership
                 node->as.var_decl.is_rc = 1;
                 sym->is_rc              = 1;
             }

--- a/w0/test/run/memory/rc_strings2.w
+++ b/w0/test/run/memory/rc_strings2.w
@@ -1,0 +1,21 @@
+// Expected: PASS: rc_strings
+// Test RC string memory management
+
+import std;
+
+// impl Drop for Vec<string> {
+//     func drop() {
+//         // Clear should free strings
+//         self.clear();
+//     }
+// }
+
+test "rc_strings2" {
+    // Vec<string> with dynamic strings
+    var parts = "one,two,three".split(",");
+    assert(parts.count == 3);
+    assert(parts[0] == "one");
+    assert(parts[1] == "two");
+    assert(parts[2] == "three");
+    // parts.clear(); // Clear should free strings
+}


### PR DESCRIPTION
## Summary
- The RC propagation logic for `var x = func_call()` only set `is_rc` when the return type was `TYPE_STRUCT` or `TYPE_STRING`, missing `TYPE_VEC`, `TYPE_STRINGBUILDER`, and RC-carrying enums
- This caused `Vec<T>` values returned from functions (e.g. `string.split()`) to never be cleaned up at scope exit, leaking both the Vec and all its elements
- Replaced the manual kind checks with the existing `type_is_rc_managed()` helper which correctly covers all RC-managed types

## Test plan
- [x] Added `test/run/memory/rc_strings2.w` exercising `Vec<string>` from `split()` — verified with `--rc-debug` that all allocations are freed
- [x] Full test suite passes (280/280)