### PR TITLE
feat: user-defined methods on Vec<T>

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -233,6 +233,14 @@ void checker_free(Checker* checker) {
     // Free vec instances
     for (int i = 0; i < checker->containers.vec_count; i++) {
         free(checker->containers.vecs[i].mangled_name);
+        for (int j = 0; j < checker->containers.vecs[i].method_count; j++) {
+            free(checker->containers.vecs[i].method_names[j]);
+        }
+        free(checker->containers.vecs[i].method_names);
+        free(checker->containers.vecs[i].method_types);
+        free(checker->containers.vecs[i].method_is_const);
+        // method_bodies are AST nodes — freed by node_free on cloned bodies
+        free(checker->containers.vecs[i].method_bodies);
     }
     free(checker->containers.vecs);
     // Free trait implementations
@@ -2236,6 +2244,15 @@ int checker_check(Checker* checker, Node* ast) {
     }
 
     checker_push_scope(checker); // Global scope
+
+    // Register builtin Vec<T> as a GenericDef so user methods can be attached
+    {
+        char** vec_params = xmalloc(sizeof(char*));
+        vec_params[0]     = xstrdup("T");
+        register_generic_def(checker, "Vec", vec_params, NULL, 1, NULL);
+        free(vec_params[0]);
+        free(vec_params);
+    }
 
     for (size_t i = 0; i < sizeof(k_checker_pass_specs) / sizeof(k_checker_pass_specs[0]); i++) {
         run_checker_pass(checker, ast, &k_checker_pass_specs[i]);

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -87,6 +87,15 @@ typedef struct {
     char* mangled_name; // "Vec_i64"
     Type* elem_type;    // The element type
     Type* type;         // The TYPE_VEC instance
+    // User-defined methods (instantiated per Vec<T>)
+    char** method_names;
+    Type** method_types;
+    int*   method_is_const;
+    int    method_count;
+    int    method_capacity;
+    // Cloned method bodies for codegen (parallel to GenericDef.methods ordering)
+    Node** method_bodies;
+    int    method_body_count;
 } VecInstance;
 
 // Generic free function definition (template)

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -680,6 +680,32 @@ static Type* check_member_vec(Checker* checker, Node* node, Type* object) {
         // clear
         return type_func(NULL, 0, type_void, 0);
     }
+    // Look up user-defined methods on VecInstance
+    {
+        char lookup_mangled[256];
+        snprintf(lookup_mangled, sizeof(lookup_mangled), "Vec_%s", type_mangle_name(elem_type));
+        VecInstance* inst = lookup_vec_instance_pub(checker, lookup_mangled);
+        if (inst) {
+            for (int i = 0; i < inst->method_count; i++) {
+                if (strcmp(inst->method_names[i], member_name) == 0) {
+                    if (!inst->method_is_const[i]) {
+                        const char* const_name =
+                            get_const_binding_name(checker, node->as.member.object);
+                        if (const_name) {
+                            check_error(checker, node->line, node->column,
+                                        "Cannot call mutating method '%s' on const '%s'",
+                                        member_name, const_name);
+                            return type_error;
+                        }
+                    }
+                    char mangled[256];
+                    snprintf(mangled, sizeof(mangled), "__Vec_%s", type_mangle_name(elem_type));
+                    sem_info_set_member_struct_name(checker->sem, node, mangled);
+                    return inst->method_types[i];
+                }
+            }
+        }
+    }
     check_error(checker, node->line, node->column, "Vec has no member '%s'", member_name);
     return type_error;
 }

--- a/w0/checker_internal.h
+++ b/w0/checker_internal.h
@@ -13,10 +13,11 @@ void check_error_cannot(Checker* checker, int line, int col, const char* action,
 void check_statement(Checker* checker, Node* node);
 
 // --- From checker_types.c: type resolution ---
-Type* resolve_type(Checker* checker, Node* type_node);
-Type* ensure_vec_type(Checker* checker, Type* elem_type);
-Type* instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
-                               Type** resolved_args, int arg_count);
+Type*        resolve_type(Checker* checker, Node* type_node);
+Type*        ensure_vec_type(Checker* checker, Type* elem_type);
+Type*        instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
+                                      Type** resolved_args, int arg_count);
+VecInstance* lookup_vec_instance_pub(Checker* checker, const char* mangled_name);
 
 // --- From checker_types.c: generic definition management ---
 void             register_generic_def(Checker* checker, const char* name, char** type_params,

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -275,15 +275,27 @@ static VecInstance* lookup_vec_instance(Checker* checker, const char* mangled_na
     return NULL;
 }
 
+// Public wrapper for lookup_vec_instance (for use by checker_expr.c)
+VecInstance* lookup_vec_instance_pub(Checker* checker, const char* mangled_name) {
+    return lookup_vec_instance(checker, mangled_name);
+}
+
 // Register an instantiated vec type
 static void register_vec_instance(Checker* checker, const char* mangled_name, Type* elem_type,
                                   Type* vec_type) {
     VEC_GROW(checker->containers.vecs, checker->containers.vec_count,
              checker->containers.vec_capacity);
-    VecInstance* inst  = &checker->containers.vecs[checker->containers.vec_count++];
-    inst->mangled_name = xstrdup(mangled_name);
-    inst->elem_type    = elem_type;
-    inst->type         = vec_type;
+    VecInstance* inst       = &checker->containers.vecs[checker->containers.vec_count++];
+    inst->mangled_name      = xstrdup(mangled_name);
+    inst->elem_type         = elem_type;
+    inst->type              = vec_type;
+    inst->method_names      = NULL;
+    inst->method_types      = NULL;
+    inst->method_is_const   = NULL;
+    inst->method_count      = 0;
+    inst->method_capacity   = 0;
+    inst->method_bodies     = NULL;
+    inst->method_body_count = 0;
 }
 
 // Register an instantiated generic type
@@ -680,6 +692,101 @@ Type* instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
     return enum_type;
 }
 
+// Instantiate user-defined methods on a Vec<T> instance from the Vec GenericDef
+static void instantiate_vec_user_methods(Checker* checker, const char* mangled, Type* elem_type,
+                                         Type* vec_type) {
+    GenericDef* vec_def = lookup_generic_def(checker, "Vec");
+    if (!vec_def || vec_def->method_count == 0) {
+        return;
+    }
+
+    VecInstance* inst = lookup_vec_instance(checker, mangled);
+    if (!inst) {
+        return;
+    }
+
+    // Allocate method body storage
+    inst->method_bodies     = xcalloc(vec_def->method_count, sizeof(Node*));
+    inst->method_body_count = vec_def->method_count;
+
+    for (int m = 0; m < vec_def->method_count; m++) {
+        Node*           method_decl = vec_def->methods[m];
+        func_decl_node* mfdn        = &method_decl->as.func_decl;
+
+        // Set up substitution context: T -> elem_type
+        char** old_params = checker->generics.current_type_params;
+        Type** old_args   = checker->generics.current_type_args;
+        int    old_count  = checker->generics.current_type_param_count;
+
+        char* tp                                   = "T";
+        checker->generics.current_type_params      = &tp;
+        checker->generics.current_type_args        = &elem_type;
+        checker->generics.current_type_param_count = 1;
+
+        // Resolve parameter types
+        int    param_count = mfdn->params.count;
+        Type** param_types = NULL;
+        if (param_count > 0) {
+            param_types = xmalloc(param_count * sizeof(Type*));
+            for (int p = 0; p < param_count; p++) {
+                Node* param    = mfdn->params.nodes[p];
+                param_types[p] = resolve_type(checker, param->as.param.type);
+            }
+        }
+
+        Type* return_type =
+            mfdn->return_type ? resolve_type(checker, mfdn->return_type) : type_void;
+
+        Type* method_type = type_func(param_types, param_count, return_type, 0);
+
+        // Clone and type-check the body
+        if (mfdn->body) {
+            Node* body_clone       = node_clone(mfdn->body);
+            inst->method_bodies[m] = body_clone;
+
+            checker_push_scope(checker);
+            Type* old_return             = checker->current_func_return;
+            checker->current_func_return = return_type;
+
+            // Inject 'self' as a Vec<T> variable
+            checker_define(checker, "self", SYM_VAR, vec_type, mfdn->receiver_is_const, 0, NULL);
+
+            // Define parameters
+            for (int p = 0; p < param_count; p++) {
+                Node* param = mfdn->params.nodes[p];
+                checker_define(checker, param->as.param.name, SYM_VAR, param_types[p],
+                               param->as.param.is_const, 0, NULL);
+            }
+
+            // Check body statements on the cloned body
+            for (int s = 0; s < body_clone->as.block.stmts.count; s++) {
+                check_statement(checker, body_clone->as.block.stmts.nodes[s]);
+            }
+
+            checker->current_func_return = old_return;
+            checker_pop_scope(checker);
+        }
+
+        // Restore substitution context
+        checker->generics.current_type_params      = old_params;
+        checker->generics.current_type_args        = old_args;
+        checker->generics.current_type_param_count = old_count;
+
+        // Register the method on the VecInstance
+        VEC_GROW(inst->method_names, inst->method_count, inst->method_capacity);
+        // Also grow parallel arrays manually
+        inst->method_types = xrealloc(inst->method_types, (inst->method_count + 1) * sizeof(Type*));
+        inst->method_is_const =
+            xrealloc(inst->method_is_const, (inst->method_count + 1) * sizeof(int));
+
+        int n                    = inst->method_count;
+        inst->method_names[n]    = xstrdup(mfdn->name);
+        inst->method_types[n]    = method_type;
+        inst->method_is_const[n] = mfdn->receiver_is_const;
+        inst->method_count       = n + 1;
+    }
+}
+
 // Resolve Vec<T> type: validate single arg, create vec type, and register span companion
 static Type* resolve_vec_type(Checker* checker, Node* type_node) {
     int arg_count = type_node->as.generic_type.type_args.count;
@@ -719,6 +826,9 @@ static Type* resolve_vec_type(Checker* checker, Node* type_node) {
         register_span_instance(checker, span_mangled, elem_type, span_type);
     }
 
+    // Instantiate user-defined methods on this Vec<T>
+    instantiate_vec_user_methods(checker, mangled, elem_type, vec_type);
+
     return vec_type;
 }
 
@@ -743,6 +853,9 @@ Type* ensure_vec_type(Checker* checker, Type* elem_type) {
         Type* span_type = type_span(elem_type);
         register_span_instance(checker, span_mangled, elem_type, span_type);
     }
+
+    // Instantiate user-defined methods on this Vec<T>
+    instantiate_vec_user_methods(checker, mangled, elem_type, vec_type);
 
     return vec_type;
 }

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1544,6 +1544,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit_enum_eq_helpers(gen, ast);
     emit_vec_cleanup(gen);
     emit_vec_methods(gen);
+    emit_vec_user_methods(gen, ast);
     emit_struct_cleanup(gen, ast);
     emit_declarations(gen, ast);
     emit_generic_method_impls(gen, ast);

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -1566,10 +1566,57 @@ static void emit_generic_func_forward_decls(CodeGen* gen, Node* ast) {
     }
 }
 
+static void emit_vec_user_method_forward_decls(CodeGen* gen, Node* ast) {
+    for (int i = 0; i < gen->checker.vec_count; i++) {
+        VecInstance* inst = &gen->checker.vecs[i];
+        if (inst->method_count == 0) {
+            continue;
+        }
+
+        const char* elem_tname = type_mangle_name(inst->elem_type);
+
+        // Find the Vec GenericDef's methods in the AST to get parameter type nodes
+        Node** methods      = NULL;
+        int    method_count = 0;
+        collect_generic_methods(ast, "Vec", &methods, &method_count);
+
+        for (int m = 0; m < inst->method_count && m < method_count; m++) {
+            func_decl_node* fdn = &methods[m]->as.func_decl;
+
+            // Set up substitution: T -> elem_type
+            TypeSubstContext  subst_ctx;
+            TypeSubstContext* old_subst = gen->generics.subst;
+            char*             tp        = "T";
+            subst_ctx.type_params       = &tp;
+            subst_ctx.type_args         = &inst->elem_type;
+            subst_ctx.count             = 1;
+            gen->generics.subst         = &subst_ctx;
+
+            emit_func_return_type(gen, fdn);
+            emit(gen, " __Vec_%s_%s(__Vec_%s* self", elem_tname, fdn->name, elem_tname);
+
+            for (int p = 0; p < fdn->params.count; p++) {
+                emit(gen, ", ");
+                Node* param = fdn->params.nodes[p];
+                if (param->as.param.is_const) {
+                    emit(gen, "const ");
+                }
+                emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+            }
+            emit(gen, ");\n");
+
+            gen->generics.subst = old_subst;
+        }
+
+        free(methods);
+    }
+}
+
 // Emit forward declarations for all functions, methods, and generic method instances
 void emit_function_forward_decls(CodeGen* gen, Node* ast) {
     emit_non_generic_function_forward_decls(gen, ast);
     emit_generic_method_forward_decls(gen, ast);
     emit_generic_func_forward_decls(gen, ast);
+    emit_vec_user_method_forward_decls(gen, ast);
     emit(gen, "\n");
 }

--- a/w0/codegen_emit.h
+++ b/w0/codegen_emit.h
@@ -42,6 +42,7 @@ void emit_rc_runtime(CodeGen* gen);
 void emit_enum_rc_helpers(CodeGen* gen, Node* ast);
 void emit_struct_cleanup(CodeGen* gen, Node* ast);
 void emit_vec_methods(CodeGen* gen);
+void emit_vec_user_methods(CodeGen* gen, Node* ast);
 void emit_vec_cleanup(CodeGen* gen);
 
 #endif

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -635,6 +635,95 @@ void emit_vec_methods(CodeGen* gen) {
     }
 }
 
+// Emit user-defined method implementations for each Vec type instance
+void emit_vec_user_methods(CodeGen* gen, Node* ast) {
+    for (int i = 0; i < gen->checker.vec_count; i++) {
+        VecInstance* inst = &gen->checker.vecs[i];
+        if (inst->method_count == 0) {
+            continue;
+        }
+
+        const char* elem_tname = type_mangle_name(inst->elem_type);
+
+        // Get the Vec GenericDef's methods from AST to get param type nodes
+        Node** methods      = NULL;
+        int    method_count = 0;
+        collect_generic_methods(ast, "Vec", &methods, &method_count);
+
+        for (int m = 0; m < inst->method_count && m < method_count; m++) {
+            func_decl_node* fdn = &methods[m]->as.func_decl;
+
+            // Set up substitution: T -> elem_type
+            TypeSubstContext subst_ctx;
+            char*            tp   = "T";
+            subst_ctx.type_params = &tp;
+            subst_ctx.type_args   = &inst->elem_type;
+            subst_ctx.count       = 1;
+            gen->generics.subst   = &subst_ctx;
+
+            // Emit return type
+            if (fdn->return_is_const && fdn->return_type) {
+                emit(gen, "const ");
+            }
+            emit_type(gen, fdn->return_type);
+
+            // Method name: __Vec_T_methodname(
+            emit(gen, " __Vec_%s_%s(__Vec_%s* self", elem_tname, fdn->name, elem_tname);
+
+            // Other parameters
+            for (int p = 0; p < fdn->params.count; p++) {
+                emit(gen, ", ");
+                Node* param = fdn->params.nodes[p];
+                if (param->as.param.is_const) {
+                    emit(gen, "const ");
+                }
+                emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+            }
+            emit(gen, ") {\n");
+
+            // Clear defer stack for this function
+            defer_clear(gen);
+            gen->defer.return_type = fdn->return_type;
+
+            // Use per-instantiation cloned body
+            Node* method_body = NULL;
+            if (inst->method_bodies && m < inst->method_body_count && inst->method_bodies[m]) {
+                method_body = inst->method_bodies[m];
+            } else {
+                method_body = fdn->body;
+            }
+
+            gen->out.indent++;
+
+            if (method_body) {
+                for (int s = 0; s < method_body->as.block.stmts.count; s++) {
+                    emit_stmt(gen, method_body->as.block.stmts.nodes[s]);
+                }
+            }
+
+            // RC cleanup for implicit void return
+            if (gen->rc.count > 0 && method_body) {
+                int   sc   = method_body->as.block.stmts.count;
+                Node* last = sc > 0 ? method_body->as.block.stmts.nodes[sc - 1] : NULL;
+                if (!last || last->type != NODE_RETURN) {
+                    rc_cleanup_all(gen, NULL);
+                }
+            }
+
+            gen->out.indent--;
+            emit(gen, "}\n\n");
+
+            // Clear defer stack and RC tracking
+            defer_clear(gen);
+            rc_clear_all(gen);
+            gen->defer.return_type = NULL;
+            gen->generics.subst    = NULL;
+        }
+
+        free(methods);
+    }
+}
+
 // Emit __Vec_T_cleanup functions that free Vec elements and data array
 void emit_vec_cleanup(CodeGen* gen) {
     for (int i = 0; i < gen->checker.vec_count; i++) {

--- a/w0/test/run/collections/vec.w
+++ b/w0/test/run/collections/vec.w
@@ -8,6 +8,16 @@
 // Expected: PASS: vec_nested
 // Expected: PASS: vec_contains_sort
 // Expected: PASS: vec_string_sort
+// Expected: PASS: vec_user_method
+
+func (Vec<T>) beep(value: T): bool {
+    for (var i: i64 = 0; i < self.count; i += 1) {
+        if (self[i] == value) {
+            return true;
+        }
+    }
+    return false;
+}
 
 // Shared definitions
 
@@ -32,6 +42,8 @@ test "vec_basic" {
     assert(nums[0] == 10);
     assert(nums[1] == 20);
     assert(nums[2] == 30);
+
+    nums.beep(20);
 }
 
 test "vec_clear" {
@@ -263,4 +275,20 @@ test "vec_string_sort" {
     var rev = new Vec<string>{"z", "m", "a"};
     rev.sort();
     assert(rev[0] == "a" && rev[1] == "m" && rev[2] == "z");
+}
+
+test "vec_user_method" {
+    var nums = new Vec<i64>{10, 20, 30};
+
+    assert(nums.beep(20));
+    assert(!nums.beep(99));
+
+    // Empty vec
+    var empty = new Vec<i64>{};
+    assert(!empty.beep(1));
+
+    // String vec with same user method
+    var words = new Vec<string>{"hello", "world"};
+    assert(words.beep("hello"));
+    assert(!words.beep("missing"));
 }


### PR DESCRIPTION
## Summary

- Register `Vec<T>` as a `GenericDef` before checker passes so user-written methods (e.g. `func (Vec<T>) beep(value: T): bool`) are attached via the existing generic method registration in Pass 2
- Instantiate user methods per concrete `Vec<T>` type (clone + type-check body with `T→elem_type` substitution), storing results on `VecInstance`
- Fall back to user method lookup in `check_member_vec` before emitting "no member" error
- Emit forward declarations and method implementations in codegen using the same `__Vec_T_methodname` dispatch pattern as builtin Vec methods

## Test plan
- [x] `make` builds cleanly with no warnings
- [x] `make test` — 201/202 pass (1 pre-existing failure in `rc_vec_remove_swap_remove`)
- [x] New `vec_user_method` test exercises `beep` on both `Vec<i64>` and `Vec<string>`