### PR TITLE
fix: rc handling for enum/Vec/StringBuilder types

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1814,10 +1814,19 @@ static void apply_trait_impl_flags(Checker* checker, Node* node, const char* tra
                                    const char* type_name_str, Symbol* type_sym, int is_generic,
                                    int is_primitive) {
     if (strcmp(trait_name, "Drop") == 0 && !is_generic && !is_primitive) {
-        type_sym->type->as.struc.has_drop = 1;
+        if (type_sym->type->kind == TYPE_STRUCT) {
+            type_sym->type->as.struc.has_drop = 1;
+        } else if (type_sym->type->kind == TYPE_ENUM) {
+            // Drop on enums is not yet supported — but don't access .as.struc
+            check_error(checker, node->line, node->column,
+                        "Drop trait is not supported for enum types");
+        }
     }
 
     if (strcmp(trait_name, "Eq") == 0 && !is_generic && !is_primitive) {
+        if (type_sym->type->kind != TYPE_STRUCT) {
+            return;
+        }
         type_sym->type->as.struc.has_eq = 1;
         // All struct-typed fields must also implement Eq.
         Type* stype = type_sym->type;

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -327,7 +327,8 @@ void emit_vec_methods(CodeGen* gen) {
         Type*        elem_type   = inst->elem_type;
         const char*  elem_tname  = type_mangle_name(elem_type);
         int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC ||
-                           elem_type->kind == TYPE_STRING);
+                           elem_type->kind == TYPE_STRING || elem_type->kind == TYPE_STRINGBUILDER);
+        int elem_is_rc_enum = (elem_type->kind == TYPE_ENUM && elem_type->as.enm.has_rc_fields);
 
         // Push (Vec<string> push is provided by whist_runtime.h)
         if (elem_type->kind != TYPE_STRING) {
@@ -343,6 +344,8 @@ void emit_vec_methods(CodeGen* gen) {
             emit(gen, "    }\n");
             if (elem_is_ptr) {
                 emit(gen, "    __rc_inc(value);\n");
+            } else if (elem_is_rc_enum) {
+                emit(gen, "    __rc_inc_%s(value);\n", elem_type->as.enm.name);
             }
             emit(gen, "    self->data[self->count] = value;\n");
             emit(gen, "    self->count++;\n");
@@ -378,6 +381,8 @@ void emit_vec_methods(CodeGen* gen) {
             } else {
                 emit(gen, "    __rc_inc(value);\n");
             }
+        } else if (elem_is_rc_enum) {
+            emit(gen, "    __rc_inc_%s(value);\n", elem_type->as.enm.name);
         }
         emit(gen, "    self->data[index] = value;\n");
         emit(gen, "    self->count++;\n");
@@ -521,6 +526,10 @@ void emit_vec_methods(CodeGen* gen) {
                 emit(gen, "        __rc_dec(self->data[i]);\n");
             }
             emit(gen, "    }\n");
+        } else if (elem_is_rc_enum) {
+            emit(gen, "    for (int64_t i = 0; i < self->count; i++) {\n");
+            emit(gen, "        __rc_dec_%s(self->data[i]);\n", elem_type->as.enm.name);
+            emit(gen, "    }\n");
         }
         emit(gen, "    self->count = 0;\n");
         emit(gen, "}\n\n");
@@ -567,6 +576,8 @@ void emit_vec_methods(CodeGen* gen) {
                 } else {
                     emit(gen, "    __rc_inc(self->data[0]);\n");
                 }
+            } else if (elem_is_rc_enum) {
+                emit(gen, "    __rc_inc_%s(self->data[0]);\n", elem_type->as.enm.name);
             }
             emit(gen,
                  "    return (Option_%s){.tag = Option_%s_Some, .Some = {.f0 = "
@@ -587,6 +598,9 @@ void emit_vec_methods(CodeGen* gen) {
                 } else {
                     emit(gen, "    __rc_inc(self->data[self->count - 1]);\n");
                 }
+            } else if (elem_is_rc_enum) {
+                emit(gen, "    __rc_inc_%s(self->data[self->count - 1]);\n",
+                     elem_type->as.enm.name);
             }
             emit(gen,
                  "    return (Option_%s){.tag = Option_%s_Some, "
@@ -730,7 +744,9 @@ void emit_vec_cleanup(CodeGen* gen) {
         VecInstance* inst        = &gen->checker.vecs[i];
         Type*        elem_type   = inst->elem_type;
         const char*  elem_tname  = type_mangle_name(elem_type);
-        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC);
+        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC ||
+                           elem_type->kind == TYPE_STRINGBUILDER);
+        int elem_is_rc_enum = (elem_type->kind == TYPE_ENUM && elem_type->as.enm.has_rc_fields);
 
         // Vec<string> cleanup is provided by whist_runtime.h
         if (elem_type->kind == TYPE_STRING)
@@ -741,6 +757,10 @@ void emit_vec_cleanup(CodeGen* gen) {
         if (elem_is_ptr) {
             emit(gen, "    for (int64_t i = 0; i < ptr->count; i++) {\n");
             emit(gen, "        __rc_dec(ptr->data[i]);\n");
+            emit(gen, "    }\n");
+        } else if (elem_is_rc_enum) {
+            emit(gen, "    for (int64_t i = 0; i < ptr->count; i++) {\n");
+            emit(gen, "        __rc_dec_%s(ptr->data[i]);\n", elem_type->as.enm.name);
             emit(gen, "    }\n");
         }
         emit(gen, "    free(ptr->data);\n");
@@ -818,10 +838,14 @@ void emit_struct_cleanup(CodeGen* gen, Node* ast) {
         }
         for (int f = 0; f < t->as.struc.field_count; f++) {
             Type* ft = t->as.struc.field_types[f];
-            if (ft && (ft->kind == TYPE_STRUCT || ft->kind == TYPE_VEC)) {
+            if (ft && (ft->kind == TYPE_STRUCT || ft->kind == TYPE_VEC ||
+                       ft->kind == TYPE_STRINGBUILDER)) {
                 emit(gen, "    __rc_dec(ptr->%s);\n", t->as.struc.field_names[f]);
             } else if (ft && ft->kind == TYPE_STRING) {
                 emit(gen, "    __rc_dec((void*)ptr->%s);\n", t->as.struc.field_names[f]);
+            } else if (ft && ft->kind == TYPE_ENUM && ft->as.enm.has_rc_fields) {
+                emit(gen, "    __rc_dec_%s(ptr->%s);\n", ft->as.enm.name,
+                     t->as.struc.field_names[f]);
             }
         }
         emit(gen, "}\n\n");

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -161,7 +161,8 @@ static int emit_rc_member_assign_stmt(CodeGen* gen, Node* expr) {
             value_is_rc = 1;
         }
         if (value_is_rc && field_ty &&
-            (field_ty->kind == TYPE_STRUCT || field_ty->kind == TYPE_STRING)) {
+            (field_ty->kind == TYPE_STRUCT || field_ty->kind == TYPE_STRING ||
+             field_ty->kind == TYPE_VEC || field_ty->kind == TYPE_STRINGBUILDER)) {
             int tmp = gen->out.temp_count++;
             emit_indent(gen);
             emit(gen, "void* __rc_tmp%d = (void*)", tmp);


### PR DESCRIPTION
## Summary
- **Vec methods and cleanup now handle enum elements with RC fields** — `push`, `insert`, `clear`, `first`, `last`, and `__Vec_T_cleanup` were only handling pointer-based RC types (struct, Vec, string). Enums with RC-managed variant fields (value types needing `__rc_inc_EnumName`/`__rc_dec_EnumName`) were silently skipped, leaking memory.
- **Member assignment RC handling extended to Vec and StringBuilder fields** — `emit_rc_member_assign_stmt` only checked `TYPE_STRUCT || TYPE_STRING`, so reassigning a Vec or StringBuilder struct field skipped the `__rc_inc(new)` / `__rc_dec(old)` dance, causing leaks or use-after-free.
- **`apply_trait_impl_flags` guards against union aliasing UB** — the function accessed `.as.struc` unconditionally, which is undefined behavior when the type is an enum. Now checks `type->kind` before accessing union members, and emits a proper error for unsupported `impl Drop for EnumType`.

## Test plan
- [x] Full test suite passes (202/202)
- [x] No new warnings from `make`