### PR TITLE
feat: owned temporaries system for RC leak prevention

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -430,6 +430,10 @@ static NodeList nodelist_clone(NodeList* list) {
 // corresponding reset here. This is the ONLY place checker flags are cleared for clones.
 // All fields listed here correspond to "Set by checker" comments in ast.h.
 static void node_reset_checker_flags(Node* node) {
+    // Top-level flags (apply to all expression node types)
+    node->is_owned_temp   = 0;
+    node->owned_temp_type = NULL;
+
     switch (node->type) {
     case NODE_BINARY:
         node->as.binary.is_string_op = 0;

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -178,6 +178,8 @@ struct Node {
     NodeType type;
     int      line;
     int      column;
+    int      is_owned_temp;   // Set by checker: expression produces an owned RC value
+    Type*    owned_temp_type; // Set by checker: the RC type of the owned temporary
 
     union {
         // Literals

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -257,6 +257,8 @@ static Type* check_arithmetic_op(Checker* checker, Node* node, Type* left, Type*
     // String concatenation: string + string
     if (op == TOK_PLUS && left->kind == TYPE_STRING && right->kind == TYPE_STRING) {
         node->as.binary.is_string_op = 1;
+        node->is_owned_temp          = 1;
+        node->owned_temp_type        = type_string;
         return type_string;
     }
     if ((type_is_integer(left) || left->kind == TYPE_F32 || left->kind == TYPE_F64) &&
@@ -455,6 +457,8 @@ static Type* check_slice_expr(Checker* checker, Node* node) {
                             "Slice end index must be an integer, got '%s'", type_name(t));
             }
         }
+        node->is_owned_temp   = 1;
+        node->owned_temp_type = type_string;
         return type_string;
     } else {
         check_error(checker, node->line, node->column, "Cannot slice type '%s'", type_name(object));
@@ -1404,7 +1408,12 @@ static Type* try_check_generic_free_function_call(Checker* checker, Node* node) 
     }
 
     node->as.call.resolved_name = xstrdup(inst->mangled_name);
-    return inst->func_type->as.func.return_type;
+    Type* ret                   = inst->func_type->as.func.return_type;
+    if (type_is_rc_managed(ret)) {
+        node->is_owned_temp   = 1;
+        node->owned_temp_type = ret;
+    }
+    return ret;
 }
 
 static int check_call_arg_count(Checker* checker, Node* node, Type* func_type) {
@@ -1471,7 +1480,12 @@ static Type* check_call_expr(Checker* checker, Node* node) {
 
     check_call_named_args(checker, node, func_type);
     check_call_variadic_tail_args(checker, node, func_type);
-    return func_type->as.func.return_type;
+    Type* ret = func_type->as.func.return_type;
+    if (type_is_rc_managed(ret)) {
+        node->is_owned_temp   = 1;
+        node->owned_temp_type = ret;
+    }
+    return ret;
 }
 
 // Type-check a `new` expression: resolve type, validate struct init, Vec elements, or init call
@@ -1527,6 +1541,8 @@ static Type* check_new_expr(Checker* checker, Node* node) {
             }
         }
         node->as.new_expr.resolved_type = resolved;
+        node->is_owned_temp             = 1;
+        node->owned_temp_type           = resolved;
         return resolved;
     }
 
@@ -1547,6 +1563,8 @@ static Type* check_new_expr(Checker* checker, Node* node) {
             }
         }
         node->as.new_expr.resolved_type = resolved;
+        node->is_owned_temp             = 1;
+        node->owned_temp_type           = resolved;
         return resolved;
     }
     if (resolved->kind == TYPE_STRINGBUILDER) {
@@ -1558,6 +1576,8 @@ static Type* check_new_expr(Checker* checker, Node* node) {
             return type_error;
         }
         node->as.new_expr.resolved_type = resolved;
+        node->is_owned_temp             = 1;
+        node->owned_temp_type           = resolved;
         return resolved;
     }
     if (resolved->kind != TYPE_STRUCT) {
@@ -1576,6 +1596,8 @@ static Type* check_new_expr(Checker* checker, Node* node) {
     if (init_type == type_error)
         return type_error;
     node->as.new_expr.resolved_type = resolved;
+    node->is_owned_temp             = 1;
+    node->owned_temp_type           = resolved;
     return resolved;
 }
 
@@ -1689,6 +1711,18 @@ static Type* check_string_interp_expr(Checker* checker, Node* node) {
             }
             node->as.string_interp.part_types[i] = t;
         }
+    }
+    // String interp with expressions produces an owned string (via __std_format)
+    int has_expr = 0;
+    for (int i = 0; i < count; i++) {
+        if (node->as.string_interp.parts.nodes[i]->type != NODE_STRING_LIT) {
+            has_expr = 1;
+            break;
+        }
+    }
+    if (has_expr) {
+        node->is_owned_temp   = 1;
+        node->owned_temp_type = type_string;
     }
     return type_string;
 }

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -644,13 +644,6 @@ static Type* resolve_new_expr_type(CodeGen* gen, Node* node) {
 
 // Emit a `new` expression as a GCC statement expression: __rc_alloc + field init
 static void emit_new_expr(CodeGen* gen, Node* node) {
-    // Check if this node was hoisted — if so, emit just the temp name
-    for (int i = 0; i < gen->hoist.count; i++) {
-        if (gen->hoist.nodes[i] == node) {
-            emit(gen, "%s", gen->hoist.names[i]);
-            return;
-        }
-    }
     Type* rtype = resolve_new_expr_type(gen, node);
     if (!rtype) {
         fprintf(stderr,
@@ -846,6 +839,21 @@ void emit_hoisted_new_expr(CodeGen* gen, Node* node, const char* temp_name) {
             free((char*)inc_fn);
         }
     }
+}
+
+// Emit an owned temporary as standalone statements with a given temp name.
+// For NODE_NEW_EXPR, delegates to emit_hoisted_new_expr.
+// For other expressions (calls, string ops), emits: Type temp = expr;
+void emit_hoisted_owned_temp(CodeGen* gen, Node* node, const char* temp_name) {
+    if (node->type == NODE_NEW_EXPR) {
+        emit_hoisted_new_expr(gen, node, temp_name);
+        return;
+    }
+    emit_indent(gen);
+    emit_resolved_type(gen, node->owned_temp_type);
+    emit(gen, " %s = ", temp_name);
+    emit_expr(gen, node);
+    emit(gen, ";\n");
 }
 
 static int string_interp_has_expr(Node* node) {
@@ -1261,6 +1269,14 @@ static void emit_compound_literal_from_list(CodeGen* gen, NodeList* elements) {
 void emit_expr(CodeGen* gen, Node* node) {
     if (!node)
         return;
+
+    // Check if this node was hoisted — if so, emit just the temp name
+    for (int i = 0; i < gen->hoist.count; i++) {
+        if (gen->hoist.nodes[i] == node) {
+            emit(gen, "%s", gen->hoist.names[i]);
+            return;
+        }
+    }
 
     switch (node->type) {
     case NODE_INT_LIT:

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -28,6 +28,7 @@ int         rc_is_tracked(CodeGen* gen, const char* name);
 void  emit_expr(CodeGen* gen, Node* node);
 void  emit_struct_init(CodeGen* gen, Node* node);
 void  emit_hoisted_new_expr(CodeGen* gen, Node* node, const char* temp_name);
+void  emit_hoisted_owned_temp(CodeGen* gen, Node* node, const char* temp_name);
 void  emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* temp_prefix,
                             int is_const);
 Node* lookup_generic_template_field_type(CodeGen* gen, const char* field_name);

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -62,6 +62,119 @@ static void hoist_push_new_arg(CodeGen* gen, Node* arg, const char* temp_name) {
     gen->hoist.count++;
 }
 
+// Recursively collect all is_owned_temp nodes in an expression tree (depth-first).
+// Children are collected before parents so inner temps are evaluated first.
+static void collect_owned_temps(Node* node, Node*** temps, int* count, int* cap) {
+    if (!node)
+        return;
+
+    // Walk children first (evaluation order: inner before outer)
+    switch (node->type) {
+    case NODE_CALL:
+        collect_owned_temps(node->as.call.func, temps, count, cap);
+        for (int i = 0; i < node->as.call.args.count; i++) {
+            collect_owned_temps(node->as.call.args.nodes[i], temps, count, cap);
+        }
+        break;
+    case NODE_BINARY:
+        collect_owned_temps(node->as.binary.left, temps, count, cap);
+        collect_owned_temps(node->as.binary.right, temps, count, cap);
+        break;
+    case NODE_UNARY:
+        collect_owned_temps(node->as.unary.operand, temps, count, cap);
+        break;
+    case NODE_MEMBER:
+        collect_owned_temps(node->as.member.object, temps, count, cap);
+        break;
+    case NODE_INDEX:
+        collect_owned_temps(node->as.index.object, temps, count, cap);
+        collect_owned_temps(node->as.index.index, temps, count, cap);
+        break;
+    case NODE_SLICE:
+        collect_owned_temps(node->as.slice.object, temps, count, cap);
+        collect_owned_temps(node->as.slice.start, temps, count, cap);
+        collect_owned_temps(node->as.slice.end, temps, count, cap);
+        break;
+    case NODE_NEW_EXPR:
+        // Walk new expr args and field init values
+        if (node->as.new_expr.init) {
+            for (int i = 0; i < node->as.new_expr.init->as.struct_init.fields.count; i++) {
+                Node* field = node->as.new_expr.init->as.struct_init.fields.nodes[i];
+                if (field && field->type == NODE_FIELD_INIT) {
+                    collect_owned_temps(field->as.field_init.value, temps, count, cap);
+                }
+            }
+        }
+        for (int i = 0; i < node->as.new_expr.args.count; i++) {
+            collect_owned_temps(node->as.new_expr.args.nodes[i], temps, count, cap);
+        }
+        break;
+    case NODE_CAST:
+        collect_owned_temps(node->as.cast_expr.expr, temps, count, cap);
+        break;
+    case NODE_STRING_INTERP:
+        for (int i = 0; i < node->as.string_interp.part_count; i++) {
+            collect_owned_temps(node->as.string_interp.parts.nodes[i], temps, count, cap);
+        }
+        break;
+    case NODE_ASSIGN:
+        collect_owned_temps(node->as.assign.target, temps, count, cap);
+        collect_owned_temps(node->as.assign.value, temps, count, cap);
+        break;
+    default:
+        break;
+    }
+
+    // Then collect this node if it's an owned temp
+    if (node->is_owned_temp) {
+        VEC_GROW(*temps, *count, *cap);
+        (*temps)[(*count)++] = node;
+    }
+}
+
+// Emit __rc_dec for a hoisted owned temp, using the appropriate dec function for its type.
+static void emit_owned_temp_dec(CodeGen* gen, Node* node, const char* name) {
+    Type* t = node->owned_temp_type;
+    if (t && t->kind == TYPE_ENUM && t->as.enm.has_rc_fields) {
+        emit_indent(gen);
+        emit(gen, "__rc_dec_%s(%s);\n", t->as.enm.name, name);
+    } else if (t && t->kind == TYPE_STRING) {
+        emit_indent(gen);
+        emit(gen, "__rc_dec((void*)%s);\n", name);
+    } else {
+        emit_indent(gen);
+        emit(gen, "__rc_dec(%s);\n", name);
+    }
+}
+
+// Hoist all owned temps in an expression tree. Returns the saved hoist count.
+static int hoist_owned_temps(CodeGen* gen, Node* expr) {
+    Node** temps = NULL;
+    int    count = 0;
+    int    cap   = 0;
+    collect_owned_temps(expr, &temps, &count, &cap);
+
+    int saved = gen->hoist.count;
+    for (int i = 0; i < count; i++) {
+        int  id = gen->out.temp_count++;
+        char name[32];
+        snprintf(name, sizeof(name), "__rc_tmp%d", id);
+        emit_hoisted_owned_temp(gen, temps[i], name);
+        hoist_push_new_arg(gen, temps[i], name);
+    }
+    free(temps);
+    return saved;
+}
+
+// Emit __rc_dec for all owned temps hoisted since saved_count, then restore hoist state.
+static void cleanup_owned_temps(CodeGen* gen, int saved_count) {
+    for (int i = saved_count; i < gen->hoist.count; i++) {
+        emit_owned_temp_dec(gen, gen->hoist.nodes[i], gen->hoist.names[i]);
+        free(gen->hoist.names[i]);
+    }
+    gen->hoist.count = saved_count;
+}
+
 static int emit_rc_ident_assign_stmt(CodeGen* gen, Node* expr) {
     if (expr->type != NODE_ASSIGN || expr->as.assign.op != TOK_EQ ||
         expr->as.assign.target->type != NODE_IDENT ||
@@ -250,53 +363,80 @@ static int emit_vec_index_assign_stmt(CodeGen* gen, Node* expr) {
     return 1;
 }
 
-static int emit_call_with_hoisted_new_args_stmt(CodeGen* gen, Node* expr) {
-    if (expr->type != NODE_CALL) {
+// Check if an expression tree contains any owned temps.
+static int has_owned_temps(Node* node) {
+    if (!node)
+        return 0;
+    if (node->is_owned_temp)
+        return 1;
+
+    switch (node->type) {
+    case NODE_CALL:
+        if (has_owned_temps(node->as.call.func))
+            return 1;
+        for (int i = 0; i < node->as.call.args.count; i++) {
+            if (has_owned_temps(node->as.call.args.nodes[i]))
+                return 1;
+        }
+        return 0;
+    case NODE_BINARY:
+        return has_owned_temps(node->as.binary.left) || has_owned_temps(node->as.binary.right);
+    case NODE_UNARY:
+        return has_owned_temps(node->as.unary.operand);
+    case NODE_MEMBER:
+        return has_owned_temps(node->as.member.object);
+    case NODE_INDEX:
+        return has_owned_temps(node->as.index.object) || has_owned_temps(node->as.index.index);
+    case NODE_SLICE:
+        return has_owned_temps(node->as.slice.object) || has_owned_temps(node->as.slice.start) ||
+               has_owned_temps(node->as.slice.end);
+    case NODE_NEW_EXPR:
+        if (node->as.new_expr.init) {
+            for (int i = 0; i < node->as.new_expr.init->as.struct_init.fields.count; i++) {
+                Node* field = node->as.new_expr.init->as.struct_init.fields.nodes[i];
+                if (field && field->type == NODE_FIELD_INIT &&
+                    has_owned_temps(field->as.field_init.value))
+                    return 1;
+            }
+        }
+        for (int i = 0; i < node->as.new_expr.args.count; i++) {
+            if (has_owned_temps(node->as.new_expr.args.nodes[i]))
+                return 1;
+        }
+        return 0;
+    case NODE_CAST:
+        return has_owned_temps(node->as.cast_expr.expr);
+    case NODE_STRING_INTERP:
+        for (int i = 0; i < node->as.string_interp.part_count; i++) {
+            if (has_owned_temps(node->as.string_interp.parts.nodes[i]))
+                return 1;
+        }
+        return 0;
+    case NODE_ASSIGN:
+        return has_owned_temps(node->as.assign.target) || has_owned_temps(node->as.assign.value);
+    default:
         return 0;
     }
-
-    int has_new_args = 0;
-    for (int i = 0; i < expr->as.call.args.count; i++) {
-        if (expr->as.call.args.nodes[i]->type == NODE_NEW_EXPR) {
-            has_new_args = 1;
-            break;
-        }
-    }
-    if (!has_new_args) {
-        return 0;
-    }
-
-    int saved_count = gen->hoist.count;
-    for (int i = 0; i < expr->as.call.args.count; i++) {
-        Node* arg = expr->as.call.args.nodes[i];
-        if (arg->type == NODE_NEW_EXPR) {
-            int  id = gen->out.temp_count++;
-            char name[32];
-            snprintf(name, sizeof(name), "__rc_tmp%d", id);
-            emit_hoisted_new_expr(gen, arg, name);
-            hoist_push_new_arg(gen, arg, name);
-        }
-    }
-    emit_indent(gen);
-    emit_expr(gen, expr);
-    emit(gen, ";\n");
-    for (int i = saved_count; i < gen->hoist.count; i++) {
-        emit_indent(gen);
-        emit(gen, "__rc_dec(%s);\n", gen->hoist.names[i]);
-        free(gen->hoist.names[i]);
-    }
-    gen->hoist.count = saved_count;
-    return 1;
 }
 
 // Emit an expression statement (NODE_EXPR_STMT).
 // Handles RC var reassignment, RC member assignment, Vec index assignment,
-// and simple expression statements.
+// and owned temporaries that need cleanup.
 static void emit_expr_stmt(CodeGen* gen, Node* node) {
     Node* expr = node->as.expr_stmt.expr;
 
     if (emit_rc_ident_assign_stmt(gen, expr) || emit_rc_member_assign_stmt(gen, expr) ||
-        emit_vec_index_assign_stmt(gen, expr) || emit_call_with_hoisted_new_args_stmt(gen, expr)) {
+        emit_vec_index_assign_stmt(gen, expr)) {
+        return;
+    }
+
+    // Check for owned temps in the expression tree
+    if (has_owned_temps(expr)) {
+        int saved = hoist_owned_temps(gen, expr);
+        emit_indent(gen);
+        emit_expr(gen, expr);
+        emit(gen, ";\n");
+        cleanup_owned_temps(gen, saved);
         return;
     }
 
@@ -611,6 +751,8 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
 
     // Handle RC-managed variable declarations
     if (node->as.var_decl.is_rc && node->as.var_decl.init) {
+        // Direct RC assignment: ownership transfers to the variable, don't hoist the init itself
+        node->as.var_decl.init->is_owned_temp = 0;
         if (node->as.var_decl.init->type == NODE_NEW_EXPR) {
             Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
             if (rtype && rtype->kind == TYPE_VEC) {
@@ -626,6 +768,13 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
             emit_var_decl_rc_copy(gen, node);
         }
         return;
+    }
+
+    // Hoist owned temps in init expression (e.g., var count = std.args().length)
+    int saved     = 0;
+    int has_temps = node->as.var_decl.init && has_owned_temps(node->as.var_decl.init);
+    if (has_temps) {
+        saved = hoist_owned_temps(gen, node->as.var_decl.init);
     }
 
     emit_indent(gen);
@@ -650,6 +799,11 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
         }
     }
     emit(gen, ";\n");
+
+    // Cleanup owned temps after the var decl
+    if (has_temps) {
+        cleanup_owned_temps(gen, saved);
+    }
 }
 
 // Emit a return statement (NODE_RETURN).
@@ -937,6 +1091,12 @@ static void emit_for_stmt(CodeGen* gen, Node* node) {
 }
 
 static void emit_foreach_collection_stmt(CodeGen* gen, Node* node) {
+    // Hoist owned temps in collection expression (evaluated once before the loop)
+    int saved = 0;
+    if (has_owned_temps(node->as.foreach_stmt.collection)) {
+        saved = hoist_owned_temps(gen, node->as.foreach_stmt.collection);
+    }
+
     int idx_id = gen->out.temp_count++;
     if (node->as.foreach_stmt.is_string) {
         emit_indent(gen);
@@ -968,6 +1128,11 @@ static void emit_foreach_collection_stmt(CodeGen* gen, Node* node) {
     gen->out.indent--;
     emit_indent(gen);
     emit(gen, "}\n");
+
+    // Cleanup owned temps after the loop
+    if (saved != gen->hoist.count) {
+        cleanup_owned_temps(gen, saved);
+    }
 }
 
 static void emit_foreach_range_stmt(CodeGen* gen, Node* node) {

--- a/w0/test/run/memory/rc_foreach_leak.w
+++ b/w0/test/run/memory/rc_foreach_leak.w
@@ -1,0 +1,17 @@
+import std;
+
+// Tests that foreach over an owned temp (std.args()) doesn't leak.
+// The Vec returned by std.args() is hoisted to a temp, used in the loop,
+// then __rc_dec'd after the loop.
+
+func main(): i32 {
+    var count = 0;
+    foreach (const item in std.args()) {
+        count = count + 1;
+    }
+    // std.args() always includes the program name, so count >= 1
+    if (count >= 1) {
+        return 0;
+    }
+    return 1;
+}


### PR DESCRIPTION
## Summary

- Generalize the existing hoist pattern (which only handled `NODE_NEW_EXPR` in call args) to handle **all owned RC temporaries** in all statement contexts
- Expressions producing owned RC values (calls returning structs/Vec/string, string concat, `new`, string interpolation, string slice) are now marked by the checker with `is_owned_temp` and automatically hoisted/cleaned up by codegen
- Fixes leaks in: `foreach` over owned collections (`std.args()`), method chains on owned temps, `var` decls with owned temp sub-expressions

## Approach

**Checker** (`checker_expr.c`): Sets `is_owned_temp` + `owned_temp_type` on expression nodes that produce owned RC values — calls returning RC types, `new` expressions, string concat, string slice, and string interpolation with expressions.

**AST** (`ast.h/c`): Two new top-level fields on `Node`: `is_owned_temp` (flag) and `owned_temp_type` (Type pointer). Reset in `node_reset_checker_flags` for generic re-checking.

**Codegen** (`codegen_stmt.c`): Replaces the old `emit_call_with_hoisted_new_args_stmt` with a general system:
- `collect_owned_temps` / `has_owned_temps` — recursively find owned temps in expression trees
- `hoist_owned_temps` — hoist all owned temps to named temporaries before the expression
- `cleanup_owned_temps` — emit `__rc_dec` for each temp after the statement
- Applied in `emit_expr_stmt`, `emit_var_decl_stmt`, and `emit_foreach_collection_stmt`

**Codegen** (`codegen_expr.c`): Hoist check moved from `emit_new_expr` to top of `emit_expr` so it applies to all hoisted expression types. New `emit_hoisted_owned_temp` handles both `new` exprs and general owned expressions.

## Test plan

- [x] New test `test/run/memory/rc_foreach_leak.w` — foreach over `std.args()` (owned Vec)
- [ ] Run full test suite (`make test`)
- [ ] Verify with `--rc-debug` that owned temps are properly allocated and freed