### PR TITLE
feat: match on general expression types

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -310,9 +310,14 @@ The second form iterates over a collection. Currently supported: `Vec<T>`, `Span
 <match-pattern> ::= '_'
                   | <identifier> [ '(' <identifier> { ',' <identifier> } ')' ]
                   | <identifier> '::' <identifier> [ '(' <identifier> { ',' <identifier> } ')' ]
+                  | <literal-pattern>
+
+<literal-pattern> ::= <integer-literal> | <float-literal> | <string-literal>
+                    | <char-literal> | 'true' | 'false'
+                    | '-' <integer-literal> | '-' <float-literal>
 ```
 
-Match statements destructure enum values by variant. The expression must be an enum type. Each arm matches a variant pattern and binds payload fields to local variables. Variant names can be unqualified (`Some(v)`) or qualified (`Option::Some(v)`). The wildcard pattern `_` matches any variant. Commas between arms are optional.
+Match statements destructure enum values by variant, or match on scalar/string values using literal patterns. When matching on an enum type, each arm matches a variant pattern and binds payload fields to local variables. Variant names can be unqualified (`Some(v)`) or qualified (`Option::Some(v)`). When matching on integers, floats, strings, chars, or bools, each arm uses a literal pattern. The wildcard pattern `_` matches any value. Match expressions (used as values) require a `_` arm. Commas between arms are optional.
 
 ```bnf
 <expr-stmt> ::= <expression> ';'

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -293,6 +293,7 @@ void node_free(Node* node) {
         }
         free(node->as.match_arm.bindings);
         node_free(node->as.match_arm.body);
+        node_free(node->as.match_arm.pattern_expr);
         break;
     case NODE_FUNC_DECL:
         free(node->as.func_decl.receiver_type);
@@ -498,6 +499,7 @@ static void node_reset_checker_flags(Node* node) {
     case NODE_MATCH:
         node->as.match_stmt.resolved_type       = NULL;
         node->as.match_stmt.resolved_value_type = NULL;
+        node->as.match_stmt.is_value_match      = 0;
         break;
     default:
         break; // Node types without checker flags need no reset
@@ -689,6 +691,7 @@ Node* node_clone(Node* node) {
         c->as.match_arm.binding_count       = node->as.match_arm.binding_count;
         c->as.match_arm.is_wildcard         = node->as.match_arm.is_wildcard;
         c->as.match_arm.body                = node_clone(node->as.match_arm.body);
+        c->as.match_arm.pattern_expr        = node_clone(node->as.match_arm.pattern_expr);
         if (node->as.match_arm.binding_count > 0) {
             c->as.match_arm.bindings = xmalloc(node->as.match_arm.binding_count * sizeof(char*));
             for (int i = 0; i < node->as.match_arm.binding_count; i++) {

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -423,6 +423,7 @@ struct Node {
             NodeList arms;                // List of NODE_MATCH_ARM nodes
             Type*    resolved_type;       // Set by checker: enum type of expr
             Type*    resolved_value_type; // Set by checker for match-expr result type
+            int      is_value_match;      // Set by checker: 1 if matching on non-enum type
         } match_stmt;
 
         // Match arm
@@ -433,8 +434,9 @@ struct Node {
             int    variant_name_length;
             char** bindings; // Binding names [f0_name, f1_name, ...]
             int    binding_count;
-            int    is_wildcard; // 1 if this is a `_` arm
-            Node*  body;        // Statement/block (match stmt) or expression (match expr)
+            int    is_wildcard;  // 1 if this is a `_` arm
+            Node*  body;         // Statement/block (match stmt) or expression (match expr)
+            Node*  pattern_expr; // Literal pattern for value match (NULL for enum match)
         } match_arm;
 
         // Function declaration

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -914,21 +914,74 @@ static void check_return_stmt(Checker* checker, Node* node) {
 // Match statement checking
 // =============================================================================
 
-static Type* check_match(Checker* checker, Node* node, int is_expr_context) {
-    Type* expr_type = check_expression(checker, node->as.match_stmt.expr);
-
-    if (expr_type->kind != TYPE_ENUM && expr_type->kind != TYPE_ERROR) {
-        check_error(checker, node->line, node->column,
-                    "Match expression must be an enum type, got '%s'", type_name(expr_type));
-        return type_error;
+static int type_is_matchable(Type* t) {
+    switch (t->kind) {
+    case TYPE_INT8:
+    case TYPE_INT16:
+    case TYPE_INT32:
+    case TYPE_INT64:
+    case TYPE_UINT8:
+    case TYPE_UINT16:
+    case TYPE_UINT32:
+    case TYPE_UINT64:
+    case TYPE_F32:
+    case TYPE_F64:
+    case TYPE_CHAR:
+    case TYPE_BOOL:
+    case TYPE_STRING:
+        return 1;
+    default:
+        return 0;
     }
+}
 
-    if (expr_type->kind == TYPE_ERROR)
-        return type_error;
+// Return 1 if node is a literal pattern suitable for value match
+static int is_literal_pattern(Node* node) {
+    if (!node)
+        return 0;
+    switch (node->type) {
+    case NODE_INT_LIT:
+    case NODE_FLOAT_LIT:
+    case NODE_STRING_LIT:
+    case NODE_CHAR_LIT:
+    case NODE_BOOL_LIT:
+        return 1;
+    case NODE_UNARY:
+        // Allow -<numeric_lit>
+        if (node->as.unary.op == TOK_MINUS) {
+            NodeType inner = node->as.unary.operand->type;
+            return inner == NODE_INT_LIT || inner == NODE_FLOAT_LIT;
+        }
+        return 0;
+    default:
+        return 0;
+    }
+}
 
-    node->as.match_stmt.resolved_type       = expr_type;
-    node->as.match_stmt.resolved_value_type = NULL;
+// Check a match arm body in expression or statement context, unifying arm result types
+static int check_match_arm_body(Checker* checker, Node* arm, int is_expr_context,
+                                Type** match_value_type, int* had_expr_error) {
+    if (is_expr_context) {
+        Type* arm_type = check_expression(checker, arm->as.match_arm.body);
+        if (arm_type->kind == TYPE_ERROR) {
+            *had_expr_error = 1;
+            return 0;
+        }
+        if (!*match_value_type) {
+            *match_value_type = arm_type;
+        } else if (!type_assignable(*match_value_type, arm_type) ||
+                   !type_assignable(arm_type, *match_value_type)) {
+            check_error_type(checker, arm->line, arm->column, "Match arm type mismatch",
+                             *match_value_type, arm_type);
+            *had_expr_error = 1;
+        }
+    } else {
+        check_statement(checker, arm->as.match_arm.body);
+    }
+    return 1;
+}
 
+static Type* check_match_enum(Checker* checker, Node* node, Type* expr_type, int is_expr_context) {
     Type* match_value_type = NULL;
     int   had_expr_error   = 0;
 
@@ -936,24 +989,15 @@ static Type* check_match(Checker* checker, Node* node, int is_expr_context) {
         Node* arm = node->as.match_stmt.arms.nodes[a];
 
         if (arm->as.match_arm.is_wildcard) {
-            if (is_expr_context) {
-                Type* arm_type = check_expression(checker, arm->as.match_arm.body);
-                if (arm_type->kind == TYPE_ERROR) {
-                    had_expr_error = 1;
-                    continue;
-                }
-                if (!match_value_type) {
-                    match_value_type = arm_type;
-                } else if (!type_assignable(match_value_type, arm_type) ||
-                           !type_assignable(arm_type, match_value_type)) {
-                    check_error_type(checker, arm->line, arm->column, "Match arm type mismatch",
-                                     match_value_type, arm_type);
-                    had_expr_error = 1;
-                }
-            } else {
-                // Wildcard: just check body
-                check_statement(checker, arm->as.match_arm.body);
-            }
+            check_match_arm_body(checker, arm, is_expr_context, &match_value_type, &had_expr_error);
+            continue;
+        }
+
+        // Reject value patterns in enum match
+        if (arm->as.match_arm.pattern_expr) {
+            check_error(checker, arm->line, arm->column,
+                        "Literal pattern cannot be used in match on enum type '%s'",
+                        type_name(expr_type));
             continue;
         }
 
@@ -1000,21 +1044,7 @@ static Type* check_match(Checker* checker, Node* node, int is_expr_context) {
             checker_define(checker, arm->as.match_arm.bindings[j], SYM_VAR, binding_type, 0, 0,
                            NULL);
         }
-        if (is_expr_context) {
-            Type* arm_type = check_expression(checker, arm->as.match_arm.body);
-            if (arm_type->kind == TYPE_ERROR) {
-                had_expr_error = 1;
-            } else if (!match_value_type) {
-                match_value_type = arm_type;
-            } else if (!type_assignable(match_value_type, arm_type) ||
-                       !type_assignable(arm_type, match_value_type)) {
-                check_error_type(checker, arm->line, arm->column, "Match arm type mismatch",
-                                 match_value_type, arm_type);
-                had_expr_error = 1;
-            }
-        } else {
-            check_statement(checker, arm->as.match_arm.body);
-        }
+        check_match_arm_body(checker, arm, is_expr_context, &match_value_type, &had_expr_error);
         checker_pop_scope(checker);
     }
 
@@ -1056,6 +1086,133 @@ static Type* check_match(Checker* checker, Node* node, int is_expr_context) {
     }
 
     return type_void;
+}
+
+// Compare two literal pattern nodes for duplicate detection
+static int literal_patterns_equal(Node* a, Node* b) {
+    if (a->type != b->type)
+        return 0;
+    switch (a->type) {
+    case NODE_INT_LIT:
+        return a->as.int_lit.value == b->as.int_lit.value;
+    case NODE_FLOAT_LIT:
+        return a->as.float_lit.value == b->as.float_lit.value;
+    case NODE_STRING_LIT:
+        return a->as.string_lit.length == b->as.string_lit.length &&
+               memcmp(a->as.string_lit.value, b->as.string_lit.value, a->as.string_lit.length) == 0;
+    case NODE_CHAR_LIT:
+        return a->as.char_lit.value == b->as.char_lit.value;
+    case NODE_BOOL_LIT:
+        return a->as.bool_lit.value == b->as.bool_lit.value;
+    case NODE_UNARY:
+        // Both must be negated numeric literals
+        if (a->as.unary.op != b->as.unary.op)
+            return 0;
+        return literal_patterns_equal(a->as.unary.operand, b->as.unary.operand);
+    default:
+        return 0;
+    }
+}
+
+static Type* check_match_value(Checker* checker, Node* node, Type* expr_type, int is_expr_context) {
+    Type* match_value_type = NULL;
+    int   had_expr_error   = 0;
+    int   has_wildcard     = 0;
+
+    for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+        Node* arm = node->as.match_stmt.arms.nodes[a];
+
+        if (arm->as.match_arm.is_wildcard) {
+            has_wildcard = 1;
+            check_match_arm_body(checker, arm, is_expr_context, &match_value_type, &had_expr_error);
+            continue;
+        }
+
+        // Reject enum variant patterns in value match
+        if (arm->as.match_arm.variant_name) {
+            check_error(checker, arm->line, arm->column,
+                        "Enum variant pattern cannot be used in match on '%s'",
+                        type_name(expr_type));
+            continue;
+        }
+
+        Node* pat = arm->as.match_arm.pattern_expr;
+        if (!pat) {
+            check_error(checker, arm->line, arm->column, "Expected literal pattern in value match");
+            continue;
+        }
+
+        if (!is_literal_pattern(pat)) {
+            check_error(checker, arm->line, arm->column, "Match pattern must be a literal value");
+            continue;
+        }
+
+        // Type-check the pattern expression and verify compatibility
+        Type* pat_type = check_expression(checker, pat);
+        if (pat_type->kind == TYPE_ERROR)
+            continue;
+
+        if (!type_assignable(expr_type, pat_type)) {
+            check_error(checker, arm->line, arm->column,
+                        "Pattern type '%s' is not compatible with match expression type '%s'",
+                        type_name(pat_type), type_name(expr_type));
+            continue;
+        }
+
+        // Check for duplicate literal patterns
+        for (int b = 0; b < a; b++) {
+            Node* prev = node->as.match_stmt.arms.nodes[b];
+            if (prev->as.match_arm.pattern_expr &&
+                literal_patterns_equal(pat, prev->as.match_arm.pattern_expr)) {
+                check_error(checker, arm->line, arm->column, "Duplicate match pattern");
+                break;
+            }
+        }
+
+        check_match_arm_body(checker, arm, is_expr_context, &match_value_type, &had_expr_error);
+    }
+
+    // Match expressions require a wildcard to guarantee a value is produced
+    if (is_expr_context && !has_wildcard) {
+        check_error(checker, node->line, node->column,
+                    "Match expression requires a wildcard '_' arm");
+        return type_error;
+    }
+
+    if (is_expr_context) {
+        if (!match_value_type || had_expr_error) {
+            node->as.match_stmt.resolved_value_type = type_error;
+            return type_error;
+        }
+        node->as.match_stmt.resolved_value_type = match_value_type;
+        return match_value_type;
+    }
+
+    return type_void;
+}
+
+static Type* check_match(Checker* checker, Node* node, int is_expr_context) {
+    Type* expr_type = check_expression(checker, node->as.match_stmt.expr);
+    if (expr_type->kind == TYPE_ERROR)
+        return type_error;
+
+    node->as.match_stmt.resolved_type       = expr_type;
+    node->as.match_stmt.resolved_value_type = NULL;
+
+    if (expr_type->kind == TYPE_ENUM) {
+        return check_match_enum(checker, node, expr_type, is_expr_context);
+    }
+
+    if (type_is_matchable(expr_type)) {
+        node->as.match_stmt.is_value_match = 1;
+        return check_match_value(checker, node, expr_type, is_expr_context);
+    }
+
+    check_error(checker, node->line, node->column,
+                "Match expression must be an enum, integer, float, string, char, or bool type, "
+                "got '%s'",
+                type_name(expr_type));
+    return type_error;
 }
 
 Type* check_match_expr(Checker* checker, Node* node) {

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -742,6 +742,7 @@ static int collect_string_literals_stmt_node(CodeGen* gen, Node* node) {
         collect_string_literals_nodelist(gen, &node->as.match_stmt.arms);
         return 1;
     case NODE_MATCH_ARM:
+        collect_string_literals_node(gen, node->as.match_arm.pattern_expr);
         collect_string_literals_node(gen, node->as.match_arm.body);
         return 1;
     case NODE_DEFER:

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -1075,9 +1075,74 @@ static void emit_try_expr(CodeGen* gen, Node* node) {
     }
 }
 
+// Emit a comparison for a value match arm pattern (inline, for expression context)
+static void emit_value_match_cond_expr(CodeGen* gen, int match_id, Node* pattern, Type* expr_type) {
+    if (expr_type->kind == TYPE_STRING) {
+        emit(gen, "strcmp(__match%d, ", match_id);
+        emit_expr(gen, pattern);
+        emit(gen, ") == 0");
+    } else {
+        emit(gen, "__match%d == ", match_id);
+        emit_expr(gen, pattern);
+    }
+}
+
+// Emit value match as expression via GCC statement expression
+static void emit_value_match_expr(CodeGen* gen, Node* node) {
+    Type* expr_type  = node->as.match_stmt.resolved_type;
+    Type* value_type = node->as.match_stmt.resolved_value_type;
+    if (!expr_type || !value_type || value_type->kind == TYPE_ERROR) {
+        emit(gen, "/* invalid value match expr */");
+        return;
+    }
+
+    int match_id = gen->out.temp_count++;
+
+    emit(gen, "({ ");
+    emit_resolved_type(gen, expr_type);
+    emit(gen, " __match%d = ", match_id);
+    emit_expr(gen, node->as.match_stmt.expr);
+    emit(gen, "; ");
+    emit_resolved_type(gen, value_type);
+    emit(gen, " __matchv%d; ", match_id);
+
+    int first = 1;
+    for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+        Node* arm = node->as.match_stmt.arms.nodes[a];
+
+        if (arm->as.match_arm.is_wildcard) {
+            if (first) {
+                emit(gen, "{ ");
+            } else {
+                emit(gen, "else { ");
+            }
+        } else {
+            if (first) {
+                emit(gen, "if (");
+            } else {
+                emit(gen, "else if (");
+            }
+            emit_value_match_cond_expr(gen, match_id, arm->as.match_arm.pattern_expr, expr_type);
+            emit(gen, ") { ");
+        }
+        first = 0;
+
+        emit(gen, "__matchv%d = ", match_id);
+        emit_expr(gen, arm->as.match_arm.body);
+        emit(gen, "; } ");
+    }
+
+    emit(gen, "__matchv%d; })", match_id);
+}
+
 // Emit match-as-expression via GCC statement expression:
 // ({ Enum __matchN = <expr>; Result __matchvN; if (...) { __matchvN = ...; } ... __matchvN; })
 static void emit_match_expr(CodeGen* gen, Node* node) {
+    if (node->as.match_stmt.is_value_match) {
+        emit_value_match_expr(gen, node);
+        return;
+    }
+
     Type* enum_type  = node->as.match_stmt.resolved_type;
     Type* value_type = node->as.match_stmt.resolved_value_type;
     if (!enum_type || enum_type->kind != TYPE_ENUM || !value_type ||

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -871,8 +871,74 @@ static void emit_return_stmt(CodeGen* gen, Node* node) {
     }
 }
 
+// Emit a comparison for a value match arm pattern
+static void emit_value_match_cond(CodeGen* gen, int match_id, Node* pattern, Type* expr_type) {
+    if (expr_type->kind == TYPE_STRING) {
+        emit(gen, "strcmp(__match%d, ", match_id);
+        emit_expr(gen, pattern);
+        emit(gen, ") == 0");
+    } else {
+        emit(gen, "__match%d == ", match_id);
+        emit_expr(gen, pattern);
+    }
+}
+
+// Emit a value match statement (non-enum) as an if/else-if chain
+static void emit_value_match_stmt(CodeGen* gen, Node* node) {
+    Type* expr_type = node->as.match_stmt.resolved_type;
+    if (!expr_type)
+        return;
+
+    int match_id = gen->out.temp_count++;
+    emit_indent(gen);
+    emit_resolved_type(gen, expr_type);
+    emit(gen, " __match%d = ", match_id);
+    emit_expr(gen, node->as.match_stmt.expr);
+    emit(gen, ";\n");
+
+    int first = 1;
+    for (int a = 0; a < node->as.match_stmt.arms.count; a++) {
+        Node* arm = node->as.match_stmt.arms.nodes[a];
+
+        emit_indent(gen);
+        if (arm->as.match_arm.is_wildcard) {
+            if (first) {
+                emit(gen, "{\n");
+            } else {
+                emit(gen, "else {\n");
+            }
+        } else {
+            if (first) {
+                emit(gen, "if (");
+            } else {
+                emit(gen, "else if (");
+            }
+            emit_value_match_cond(gen, match_id, arm->as.match_arm.pattern_expr, expr_type);
+            emit(gen, ") {\n");
+        }
+        first = 0;
+
+        gen->out.indent++;
+        if (arm->as.match_arm.body) {
+            if (arm->as.match_arm.body->type == NODE_BLOCK) {
+                emit_block_contents(gen, arm->as.match_arm.body);
+            } else {
+                emit_stmt(gen, arm->as.match_arm.body);
+            }
+        }
+        gen->out.indent--;
+        emit_indent(gen);
+        emit(gen, "}\n");
+    }
+}
+
 // Emit a match statement as an if/else-if chain over the enum tag
 static void emit_match_stmt(CodeGen* gen, Node* node) {
+    if (node->as.match_stmt.is_value_match) {
+        emit_value_match_stmt(gen, node);
+        return;
+    }
+
     Type* enum_type = node->as.match_stmt.resolved_type;
     if (!enum_type)
         return;

--- a/w0/parser_stmt.c
+++ b/w0/parser_stmt.c
@@ -210,6 +210,7 @@ Node* parse_match(Parser* parser, int is_expr) {
         arm->as.match_arm.binding_count       = 0;
         arm->as.match_arm.is_wildcard         = 0;
         arm->as.match_arm.body                = NULL;
+        arm->as.match_arm.pattern_expr        = NULL;
 
         // Parse pattern
         if (parser->current.type == TOK_IDENT && parser->current.length == 1 &&
@@ -257,6 +258,17 @@ Node* parse_match(Parser* parser, int is_expr) {
                 consume_token(parser, TOK_RPAREN, "Expected ')' after bindings");
                 arm->as.match_arm.bindings      = bindings;
                 arm->as.match_arm.binding_count = count;
+            }
+        } else if (check_token(parser, TOK_INT) || check_token(parser, TOK_FLOAT) ||
+                   check_token(parser, TOK_STRING) || check_token(parser, TOK_CHAR) ||
+                   check_token(parser, TOK_TRUE) || check_token(parser, TOK_FALSE) ||
+                   check_token(parser, TOK_MINUS)) {
+            // Value pattern: literal expression (checker validates)
+            arm->as.match_arm.pattern_expr = parse_expression(parser);
+            if (!arm->as.match_arm.pattern_expr) {
+                node_free(arm);
+                node_free(node);
+                return NULL;
             }
         } else {
             parse_error(parser, "Expected match pattern");

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -257,6 +257,9 @@ static void print_match_stmt(Node* node, int depth) {
 static void print_match_arm(Node* node, int depth) {
     if (node->as.match_arm.is_wildcard) {
         printf("MatchArm: _\n");
+    } else if (node->as.match_arm.pattern_expr) {
+        printf("MatchArm: <value>\n");
+        print_labeled_child("Pattern", node->as.match_arm.pattern_expr, depth + 1);
     } else {
         printf("MatchArm: ");
         if (node->as.match_arm.enum_name) {

--- a/w0/test/errors/error_match_nonenum.w
+++ b/w0/test/errors/error_match_nonenum.w
@@ -1,8 +1,10 @@
-// Expected error: Match expression must be an enum type
+// Expected error: Match expression must be an enum, integer, float, string, char, or bool type
+
+struct Point { x: i64, y: i64 }
 
 func main(): i32 {
-    var x: i64 = 42;
-    match (x) {
+    var p = new Point { x: 1, y: 2 };
+    match (p) {
         _ => { return 0; },
     }
     return 0;

--- a/w0/test/errors/error_match_value_duplicate.w
+++ b/w0/test/errors/error_match_value_duplicate.w
@@ -1,0 +1,11 @@
+// Expected error: Duplicate match pattern
+
+func main(): i32 {
+    var x: i64 = 42;
+    match (x) {
+        1 => { return 1; },
+        1 => { return 2; },
+        _ => { return 0; },
+    }
+    return 0;
+}

--- a/w0/test/errors/error_match_value_no_wildcard_expr.w
+++ b/w0/test/errors/error_match_value_no_wildcard_expr.w
@@ -1,0 +1,10 @@
+// Expected error: Match expression requires a wildcard '_' arm
+
+func main(): i32 {
+    var x: i64 = 42;
+    var result = match(x) {
+        1 => 10,
+        2 => 20,
+    };
+    return 0;
+}

--- a/w0/test/errors/error_match_value_type_mismatch.w
+++ b/w0/test/errors/error_match_value_type_mismatch.w
@@ -1,0 +1,10 @@
+// Expected error: Pattern type 'string' is not compatible with match expression type 'i64'
+
+func main(): i32 {
+    var x: i64 = 42;
+    match (x) {
+        "hello" => { return 1; },
+        _ => { return 0; },
+    }
+    return 0;
+}

--- a/w0/test/run/basics/match_value.w
+++ b/w0/test/run/basics/match_value.w
@@ -1,0 +1,112 @@
+// Expected: PASS: match string
+// Expected: PASS: match int
+// Expected: PASS: match char
+// Expected: PASS: match bool
+// Expected: PASS: match float
+// Expected: PASS: match expr
+// Expected: PASS: match negative
+
+import std;
+
+func match_string(s: string): i64 {
+    match (s) {
+        "hello" => { return 1; },
+        "world" => { return 2; },
+        _ => { return 0; },
+    }
+    return -1;
+}
+
+func match_int(x: i64): i64 {
+    match (x) {
+        1 => { return 10; },
+        2 => { return 20; },
+        _ => { return 0; },
+    }
+    return -1;
+}
+
+func match_char(c: char): i64 {
+    match (c) {
+        'a' => { return 1; },
+        'b' => { return 2; },
+        _ => { return 0; },
+    }
+    return -1;
+}
+
+func match_bool(b: bool): i64 {
+    match (b) {
+        true => { return 1; },
+        false => { return 0; },
+    }
+    return -1;
+}
+
+func match_float(f: f64): i64 {
+    match (f) {
+        1.0 => { return 1; },
+        2.5 => { return 2; },
+        _ => { return 0; },
+    }
+    return -1;
+}
+
+func match_expr(s: string): i64 {
+    var result = match(s) {
+        "hello" => 1,
+        "world" => 2,
+        _ => 0,
+    };
+    return result;
+}
+
+func match_negative(x: i64): i64 {
+    match (x) {
+        -1 => { return 100; },
+        -2 => { return 200; },
+        _ => { return 0; },
+    }
+    return -1;
+}
+
+test "match string" {
+    assert(match_string("hello") == 1);
+    assert(match_string("world") == 2);
+    assert(match_string("other") == 0);
+}
+
+test "match int" {
+    assert(match_int(1) == 10);
+    assert(match_int(2) == 20);
+    assert(match_int(3) == 0);
+}
+
+test "match char" {
+    assert(match_char('a') == 1);
+    assert(match_char('b') == 2);
+    assert(match_char('z') == 0);
+}
+
+test "match bool" {
+    assert(match_bool(true) == 1);
+    assert(match_bool(false) == 0);
+}
+
+test "match float" {
+    assert(match_float(1.0) == 1);
+    assert(match_float(2.5) == 2);
+    assert(match_float(9.9) == 0);
+}
+
+test "match expr" {
+    assert(match_expr("hello") == 1);
+    assert(match_expr("world") == 2);
+    assert(match_expr("nope") == 0);
+}
+
+test "match negative" {
+    assert(match_negative(-1) == 100);
+    assert(match_negative(-2) == 200);
+    assert(match_negative(0) == 0);
+}

--- a/w0/test/valid/match_value.w
+++ b/w0/test/valid/match_value.w
@@ -1,0 +1,72 @@
+// Match on string
+func match_string(s: string): i64 {
+    match (s) {
+        "hello" => { return 1; },
+        "world" => { return 2; },
+        _ => { return 0; },
+    }
+    return 0;
+}
+
+// Match on i64
+func match_int(x: i64): i64 {
+    match (x) {
+        1 => { return 10; },
+        2 => { return 20; },
+        -1 => { return -10; },
+        _ => { return 0; },
+    }
+    return 0;
+}
+
+// Match on char
+func match_char(c: char): i64 {
+    match (c) {
+        'a' => { return 1; },
+        'b' => { return 2; },
+        _ => { return 0; },
+    }
+    return 0;
+}
+
+// Match on bool
+func match_bool(b: bool): i64 {
+    match (b) {
+        true => { return 1; },
+        false => { return 0; },
+    }
+    return 0;
+}
+
+// Match on f64
+func match_float(f: f64): i64 {
+    match (f) {
+        1.0 => { return 1; },
+        -2.5 => { return 2; },
+        _ => { return 0; },
+    }
+    return 0;
+}
+
+// Match expression (returns value)
+func match_expr(s: string): i64 {
+    var result = match(s) {
+        "hello" => 1,
+        "world" => 2,
+        _ => 0,
+    };
+    return result;
+}
+
+// Match statement without wildcard (allowed for statements)
+func match_no_wildcard(x: i64): i64 {
+    match (x) {
+        1 => { return 10; },
+        2 => { return 20; },
+    }
+    return 0;
+}
+
+func main(): i32 {
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Extends `match` to work on any scalar/string type (integers, floats, string, char, bool) using literal patterns, not just enums
- Match expressions (used as values) require a wildcard `_` arm; match statements allow omitting it
- Checker validates pattern types match the expression, detects duplicate patterns, and rejects mixing enum/value patterns
- Codegen emits if/else-if chains with `strcmp` for strings, `==` for everything else

Example:
```whist
var result = match(s) {
    "hello" => 1,
    "world" => 2,
    _ => 0,
};
```

Closes #243

## Test plan

- [x] `make` builds with no warnings
- [x] All 207 tests pass (`make test`)
- [x] New valid test: `test/valid/match_value.w` — type-check-only for all supported types
- [x] New error tests: type mismatch, missing wildcard in expression, duplicate patterns
- [x] New runtime test: `test/run/basics/match_value.w` — compile & run for string/int/char/bool/float/negative/expression matching
- [x] Updated `test/errors/error_match_nonenum.w` — now uses struct (truly non-matchable type)