### PR TITLE
feat: lambda expressions (non-capturing)

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -421,6 +421,7 @@ Examples: `'A' as i32` (yields 65), `65 as char` (yields 'A'), `x as i64`
                 | <tuple-literal>
                 | <array-literal>
                 | <match-expr>
+                | <lambda-expr>
 
 <new-expr> ::= 'new' <type> '{' [ <init-list> ] '}'
             | 'new' <type> '(' [ <arg-list> ] ')'
@@ -443,9 +444,18 @@ Examples: `'A' as i32` (yields 65), `65 as char` (yields 'A'), `x as i64`
 <match-expr> ::= 'match' '(' <expression> ')' '{' { <match-expr-arm> } '}'
 
 <match-expr-arm> ::= <match-pattern> '=>' <expression> [ ',' ]
+
+<lambda-expr> ::= '|' [ <lambda-params> ] '|' [ '->' <type> ] ( <block> | <expression> )
+               | '||' [ '->' <type> ] ( <block> | <expression> )
+
+<lambda-params> ::= <lambda-param> { ',' <lambda-param> }
+
+<lambda-param> ::= <identifier> ':' <type>
 ```
 
 `match` can be used as a statement or expression. In expression form, each arm body must be an expression (block bodies are not allowed).
+
+**Lambda expressions:** `|x: i64| x * 2` creates an anonymous function (non-capturing). Lambdas compile to plain C function pointers and have type `func(T1, T2, ...): R`. Parameter type annotations are required. The return type is inferred from the body for expression lambdas, or defaults to `void` for block lambdas (use `-> T` to specify explicitly). Empty-parameter lambdas use `||`: `|| 42`. Lambdas can be assigned to `func(...)` typed variables, passed as function arguments, or called directly: `(|x: i64| x + 1)(42)`. Variable capture (closures) is not yet supported — referencing variables from an enclosing scope is a compile error.
 
 **Tuple literals:** `(1, "hello")` creates a tuple value. Tuples must have at least two elements. Access elements by index: `t[0]`, `t[1]`.
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -197,6 +197,11 @@ void node_free(Node* node) {
         free(node->as.try_expr.enum_name);
         free(node->as.try_expr.ret_enum_name);
         break;
+    case NODE_LAMBDA:
+        nodelist_free(&node->as.lambda.params);
+        node_free(node->as.lambda.return_type);
+        node_free(node->as.lambda.body);
+        break;
     case NODE_BINARY:
         node_free(node->as.binary.left);
         node_free(node->as.binary.right);
@@ -501,6 +506,10 @@ static void node_reset_checker_flags(Node* node) {
         node->as.match_stmt.resolved_value_type = NULL;
         node->as.match_stmt.is_value_match      = 0;
         break;
+    case NODE_LAMBDA:
+        node->as.lambda.lambda_id     = 0;
+        node->as.lambda.resolved_type = NULL;
+        break;
     default:
         break; // Node types without checker flags need no reset
     }
@@ -607,6 +616,12 @@ Node* node_clone(Node* node) {
         break;
     case NODE_TRY_EXPR:
         c->as.try_expr.expr = node_clone(node->as.try_expr.expr);
+        break;
+    case NODE_LAMBDA:
+        c->as.lambda.params       = nodelist_clone(&node->as.lambda.params);
+        c->as.lambda.return_type  = node_clone(node->as.lambda.return_type);
+        c->as.lambda.body         = node_clone(node->as.lambda.body);
+        c->as.lambda.is_expr_body = node->as.lambda.is_expr_body;
         break;
     case NODE_TUPLE_TYPE:
         c->as.tuple_type.elem_types = nodelist_clone(&node->as.tuple_type.elem_types);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -69,6 +69,7 @@ typedef enum {
     NODE_STRING_INTERP,
     NODE_CAST,
     NODE_TRY_EXPR,
+    NODE_LAMBDA,
 
     // Statements
     NODE_EXPR_STMT,
@@ -323,6 +324,17 @@ struct Node {
             char* enum_name;      // Set by checker: operand's mangled enum name
             char* ret_enum_name;  // Set by checker: function return's mangled enum name
         } try_expr;
+
+        // Lambda expression: |params| body
+        struct {
+            NodeList params;       // NODE_PARAM nodes
+            Node*    return_type;  // Explicit return type (NULL = inferred)
+            Node*    body;         // Block or expression node
+            int      is_expr_body; // 1 if body is expression (not block)
+            // Set by checker:
+            int   lambda_id;     // Unique ID for codegen (__lambda_N)
+            Type* resolved_type; // TYPE_FUNC
+        } lambda;
 
         // Tuple type: (T1, T2, ...)
         struct {

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -138,6 +138,8 @@ void checker_init(Checker* checker) {
     checker->alias_depth                    = 0;
     checker->enum_target_hint               = NULL;
     checker->self_type                      = NULL;
+    checker->lambda_next_id                 = 0;
+    checker->lambda_depth                   = 0;
     checker->sem                            = sem_info_new();
     types_init();
 }
@@ -150,11 +152,12 @@ void checker_set_direct_imports(Checker* checker, char** direct_imports, int cou
 
 // Push a new scope onto the scope chain for block-level symbol resolution
 void checker_push_scope(Checker* checker) {
-    Scope* scope   = xcalloc(1, sizeof(Scope));
-    scope->symbols = xcalloc(SCOPE_SIZE, sizeof(Symbol*));
-    scope->size    = SCOPE_SIZE;
-    scope->parent  = checker->scope;
-    checker->scope = scope;
+    Scope* scope              = xcalloc(1, sizeof(Scope));
+    scope->symbols            = xcalloc(SCOPE_SIZE, sizeof(Symbol*));
+    scope->size               = SCOPE_SIZE;
+    scope->parent             = checker->scope;
+    scope->is_lambda_boundary = 0;
+    checker->scope            = scope;
 }
 
 // Pop the current scope and free all its symbols

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -31,6 +31,7 @@ struct Scope {
     Symbol** symbols; // Hash table
     int      size;
     Scope*   parent;
+    int      is_lambda_boundary; // 1 = marks lambda scope boundary
 };
 
 // Trait implementation record
@@ -202,6 +203,10 @@ struct Checker {
     // Self type: set to TYPE_GENERIC_PARAM("Self") in trait decls,
     // concrete implementing type in impl blocks; NULL otherwise.
     Type* self_type;
+
+    // Lambda tracking
+    int lambda_next_id; // Next lambda ID (monotonically increasing)
+    int lambda_depth;   // >0 when inside a lambda body
 
     // Sidecar semantic metadata used by checker/codegen; owned by checker.
     SemInfo* sem;

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1862,6 +1862,128 @@ static Type* check_try_expr(Checker* checker, Node* node) {
 }
 
 // =============================================================================
+// Lambda expression checking
+// =============================================================================
+
+// Check if a variable name is captured across a lambda boundary
+static int is_captured_variable(Checker* checker, const char* name) {
+    int    crossed_boundary = 0;
+    Scope* scope            = checker->scope;
+    while (scope) {
+        // Check this scope for the variable
+        unsigned hash = 5381;
+        for (const char* p = name; *p; p++)
+            hash = ((hash << 5) + hash) + (unsigned char)*p;
+        int idx = hash % scope->size;
+        for (Symbol* sym = scope->symbols[idx]; sym; sym = sym->next) {
+            if (strcmp(sym->name, name) == 0 && sym->kind == SYM_VAR) {
+                return crossed_boundary;
+            }
+        }
+        if (scope->is_lambda_boundary)
+            crossed_boundary = 1;
+        scope = scope->parent;
+    }
+    return 0;
+}
+
+static Type* check_lambda_expr(Checker* checker, Node* node) {
+    // Assign unique ID
+    node->as.lambda.lambda_id = checker->lambda_next_id++;
+
+    NodeList* params      = &node->as.lambda.params;
+    int       param_count = params->count;
+
+    // Resolve parameter types
+    Type** param_types = NULL;
+    if (param_count > 0) {
+        param_types = xmalloc(param_count * sizeof(Type*));
+    }
+    for (int i = 0; i < param_count; i++) {
+        Node* p = params->nodes[i];
+        if (!p->as.param.type) {
+            check_error(checker, p->line, p->column,
+                        "Lambda parameter '%s' requires a type annotation", p->as.param.name);
+            free(param_types);
+            return type_error;
+        }
+        param_types[i] = resolve_type(checker, p->as.param.type);
+        if (param_types[i]->kind == TYPE_ERROR) {
+            free(param_types);
+            return type_error;
+        }
+    }
+
+    // Resolve explicit return type
+    Type* return_type = NULL;
+    if (node->as.lambda.return_type) {
+        return_type = resolve_type(checker, node->as.lambda.return_type);
+        if (return_type->kind == TYPE_ERROR) {
+            free(param_types);
+            return type_error;
+        }
+    }
+
+    // Push lambda scope
+    checker_push_scope(checker);
+    checker->scope->is_lambda_boundary = 1;
+
+    // Save and set function return context
+    Type* old_return = checker->current_func_return;
+    checker->lambda_depth++;
+
+    // Define params in lambda scope
+    for (int i = 0; i < param_count; i++) {
+        Node* p = params->nodes[i];
+        checker_define(checker, p->as.param.name, SYM_VAR, param_types[i], p->as.param.is_const, 0,
+                       NULL);
+    }
+
+    if (node->as.lambda.is_expr_body) {
+        // Expression body: infer return type
+        if (!return_type) {
+            // Set return type temporarily to NULL to allow checking
+            checker->current_func_return = type_void;
+        } else {
+            checker->current_func_return = return_type;
+        }
+        Type* body_type = check_expression(checker, node->as.lambda.body);
+        if (!return_type) {
+            return_type = body_type;
+        } else if (!type_assignable(return_type, body_type)) {
+            check_error(checker, node->as.lambda.body->line, node->as.lambda.body->column,
+                        "Lambda body type '%s' doesn't match return type '%s'",
+                        type_name(body_type), type_name(return_type));
+        }
+    } else {
+        // Block body
+        if (!return_type) {
+            return_type = type_void;
+        }
+        checker->current_func_return = return_type;
+        // Check block statements (like check_function_body)
+        Node* body = node->as.lambda.body;
+        if (body && body->type == NODE_BLOCK) {
+            for (int i = 0; i < body->as.block.stmts.count; i++) {
+                check_statement(checker, body->as.block.stmts.nodes[i]);
+            }
+        }
+    }
+
+    // Restore state
+    checker->lambda_depth--;
+    checker->current_func_return = old_return;
+    checker_pop_scope(checker);
+
+    // Build TYPE_FUNC
+    Type* func_type               = type_func(param_types, param_count, return_type, 0);
+    node->as.lambda.resolved_type = func_type;
+    // param_types ownership transferred to type_func
+
+    return func_type;
+}
+
+// =============================================================================
 // Expression checking
 // =============================================================================
 
@@ -1890,6 +2012,12 @@ Type* check_expression(Checker* checker, Node* node) {
         return type_null; // null reference
 
     case NODE_IDENT: {
+        if (checker->lambda_depth > 0 && is_captured_variable(checker, node->as.ident.name)) {
+            check_error(checker, node->line, node->column,
+                        "Cannot capture variable '%s' — closures not yet supported",
+                        node->as.ident.name);
+            return type_error;
+        }
         Symbol* sym = checker_lookup(checker, node->as.ident.name);
         if (!sym) {
             check_error(checker, node->line, node->column, "Undefined identifier '%s'",
@@ -1948,6 +2076,9 @@ Type* check_expression(Checker* checker, Node* node) {
 
     case NODE_STRING_INTERP:
         return check_string_interp_expr(checker, node);
+
+    case NODE_LAMBDA:
+        return check_lambda_expr(checker, node);
 
     default:
         check_error(checker, node->line, node->column, "Unknown expression type %d", node->type);

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -518,6 +518,10 @@ void codegen_init(CodeGen* gen, FILE* out, CodeGenChecker checker_data, int rc_d
     gen->hoist.count    = 0;
     gen->hoist.capacity = 0;
 
+    gen->lambdas.nodes    = NULL;
+    gen->lambdas.count    = 0;
+    gen->lambdas.capacity = 0;
+
     gen->tuple_types         = NULL;
     gen->tuple_type_count    = 0;
     gen->tuple_type_capacity = 0;
@@ -560,6 +564,7 @@ void codegen_free(CodeGen* gen) {
     }
     free(gen->hoist.nodes);
     free(gen->hoist.names);
+    free(gen->lambdas.nodes);
 }
 
 // Collect tuple types from all declarations and register non-generic type aliases
@@ -697,6 +702,10 @@ static int collect_string_literals_expr_node(CodeGen* gen, Node* node) {
     case NODE_TUPLE_LIT:
         collect_string_literals_nodelist(gen, &node->as.tuple_lit.elements);
         return 1;
+    case NODE_LAMBDA:
+        collect_string_literals_nodelist(gen, &node->as.lambda.params);
+        collect_string_literals_node(gen, node->as.lambda.body);
+        return 1;
     default:
         return 0;
     }
@@ -798,6 +807,225 @@ static void collect_string_literals_node(CodeGen* gen, Node* node) {
 
 static void collect_string_literals(CodeGen* gen, Node* ast) {
     collect_string_literals_node(gen, ast);
+}
+
+// ============================================================================
+// Lambda collection and emission
+// ============================================================================
+
+static void collect_lambdas_node(CodeGen* gen, Node* node);
+
+static void collect_lambdas_nodelist(CodeGen* gen, NodeList* list) {
+    for (int i = 0; i < list->count; i++) {
+        collect_lambdas_node(gen, list->nodes[i]);
+    }
+}
+
+static void collect_lambdas_node(CodeGen* gen, Node* node) {
+    if (!node)
+        return;
+
+    if (node->type == NODE_LAMBDA) {
+        VEC_GROW(gen->lambdas.nodes, gen->lambdas.count, gen->lambdas.capacity);
+        gen->lambdas.nodes[gen->lambdas.count++] = node;
+        // Recurse into lambda body for nested lambdas
+        collect_lambdas_node(gen, node->as.lambda.body);
+        return;
+    }
+
+    switch (node->type) {
+    // Expressions
+    case NODE_BINARY:
+        collect_lambdas_node(gen, node->as.binary.left);
+        collect_lambdas_node(gen, node->as.binary.right);
+        break;
+    case NODE_UNARY:
+        collect_lambdas_node(gen, node->as.unary.operand);
+        break;
+    case NODE_CALL:
+        collect_lambdas_node(gen, node->as.call.func);
+        collect_lambdas_nodelist(gen, &node->as.call.args);
+        break;
+    case NODE_MEMBER:
+        collect_lambdas_node(gen, node->as.member.object);
+        break;
+    case NODE_INDEX:
+        collect_lambdas_node(gen, node->as.index.object);
+        collect_lambdas_node(gen, node->as.index.index);
+        break;
+    case NODE_SLICE:
+        collect_lambdas_node(gen, node->as.slice.object);
+        collect_lambdas_node(gen, node->as.slice.start);
+        collect_lambdas_node(gen, node->as.slice.end);
+        break;
+    case NODE_ASSIGN:
+        collect_lambdas_node(gen, node->as.assign.target);
+        collect_lambdas_node(gen, node->as.assign.value);
+        break;
+    case NODE_CAST:
+        collect_lambdas_node(gen, node->as.cast_expr.expr);
+        break;
+    case NODE_TRY_EXPR:
+        collect_lambdas_node(gen, node->as.try_expr.expr);
+        break;
+    case NODE_NEW_EXPR:
+        collect_lambdas_node(gen, node->as.new_expr.init);
+        collect_lambdas_nodelist(gen, &node->as.new_expr.args);
+        break;
+    case NODE_STRUCT_INIT:
+        collect_lambdas_nodelist(gen, &node->as.struct_init.fields);
+        break;
+    case NODE_FIELD_INIT:
+        collect_lambdas_node(gen, node->as.field_init.value);
+        break;
+    case NODE_ENUM_VALUE:
+        collect_lambdas_nodelist(gen, &node->as.enum_value.args);
+        break;
+    case NODE_TUPLE_LIT:
+        collect_lambdas_nodelist(gen, &node->as.tuple_lit.elements);
+        break;
+    case NODE_ARRAY_LIT:
+        collect_lambdas_nodelist(gen, &node->as.array_lit.elements);
+        break;
+    case NODE_STRING_INTERP:
+        collect_lambdas_nodelist(gen, &node->as.string_interp.parts);
+        break;
+
+    // Statements
+    case NODE_BLOCK:
+        collect_lambdas_nodelist(gen, &node->as.block.stmts);
+        break;
+    case NODE_VAR_DECL:
+        collect_lambdas_node(gen, node->as.var_decl.init);
+        break;
+    case NODE_RETURN:
+        collect_lambdas_node(gen, node->as.return_stmt.value);
+        break;
+    case NODE_IF:
+        collect_lambdas_node(gen, node->as.if_stmt.cond);
+        collect_lambdas_node(gen, node->as.if_stmt.then_block);
+        collect_lambdas_node(gen, node->as.if_stmt.else_block);
+        break;
+    case NODE_FOR:
+        collect_lambdas_node(gen, node->as.for_stmt.init);
+        collect_lambdas_node(gen, node->as.for_stmt.cond);
+        collect_lambdas_node(gen, node->as.for_stmt.post);
+        collect_lambdas_node(gen, node->as.for_stmt.body);
+        break;
+    case NODE_FOREACH:
+        collect_lambdas_node(gen, node->as.foreach_stmt.collection);
+        collect_lambdas_node(gen, node->as.foreach_stmt.start);
+        collect_lambdas_node(gen, node->as.foreach_stmt.end);
+        collect_lambdas_node(gen, node->as.foreach_stmt.body);
+        break;
+    case NODE_WHILE:
+        collect_lambdas_node(gen, node->as.while_stmt.cond);
+        collect_lambdas_node(gen, node->as.while_stmt.body);
+        break;
+    case NODE_EXPR_STMT:
+        collect_lambdas_node(gen, node->as.expr_stmt.expr);
+        break;
+    case NODE_MATCH:
+        collect_lambdas_node(gen, node->as.match_stmt.expr);
+        collect_lambdas_nodelist(gen, &node->as.match_stmt.arms);
+        break;
+    case NODE_MATCH_ARM:
+        collect_lambdas_node(gen, node->as.match_arm.pattern_expr);
+        collect_lambdas_node(gen, node->as.match_arm.body);
+        break;
+    case NODE_DEFER:
+        collect_lambdas_node(gen, node->as.defer_stmt.stmt);
+        break;
+
+    // Declarations
+    case NODE_PROGRAM:
+        collect_lambdas_nodelist(gen, &node->as.program.modules);
+        break;
+    case NODE_MODULE:
+        collect_lambdas_nodelist(gen, &node->as.module.decls);
+        break;
+    case NODE_FUNC_DECL:
+        collect_lambdas_node(gen, node->as.func_decl.body);
+        break;
+    case NODE_IMPL_DECL:
+        collect_lambdas_nodelist(gen, &node->as.impl_decl.methods);
+        break;
+    case NODE_TEST_DECL:
+        collect_lambdas_node(gen, node->as.test_decl.body);
+        break;
+
+    default:
+        break;
+    }
+}
+
+static void collect_lambdas(CodeGen* gen, Node* ast) {
+    collect_lambdas_node(gen, ast);
+}
+
+static void emit_lambda_forward_decls(CodeGen* gen) {
+    for (int i = 0; i < gen->lambdas.count; i++) {
+        Node* lam       = gen->lambdas.nodes[i];
+        Type* func_type = lam->as.lambda.resolved_type;
+        if (!func_type)
+            continue;
+
+        emit(gen, "static ");
+        emit_resolved_type(gen, func_type->as.func.return_type);
+        emit(gen, " __lambda_%d(", lam->as.lambda.lambda_id);
+        for (int p = 0; p < func_type->as.func.param_count; p++) {
+            if (p > 0)
+                emit(gen, ", ");
+            emit_resolved_type(gen, func_type->as.func.param_types[p]);
+            emit(gen, " %s", lam->as.lambda.params.nodes[p]->as.param.name);
+        }
+        if (func_type->as.func.param_count == 0)
+            emit(gen, "void");
+        emit(gen, ");\n");
+    }
+    if (gen->lambdas.count > 0)
+        emit(gen, "\n");
+}
+
+static void emit_lambda_definitions(CodeGen* gen) {
+    for (int i = 0; i < gen->lambdas.count; i++) {
+        Node* lam       = gen->lambdas.nodes[i];
+        Type* func_type = lam->as.lambda.resolved_type;
+        if (!func_type)
+            continue;
+
+        emit(gen, "static ");
+        emit_resolved_type(gen, func_type->as.func.return_type);
+        emit(gen, " __lambda_%d(", lam->as.lambda.lambda_id);
+        for (int p = 0; p < func_type->as.func.param_count; p++) {
+            if (p > 0)
+                emit(gen, ", ");
+            emit_resolved_type(gen, func_type->as.func.param_types[p]);
+            emit(gen, " %s", lam->as.lambda.params.nodes[p]->as.param.name);
+        }
+        if (func_type->as.func.param_count == 0)
+            emit(gen, "void");
+        emit(gen, ") {\n");
+
+        gen->out.indent++;
+        if (lam->as.lambda.is_expr_body) {
+            // Expression body: return expr;
+            emit_indent(gen);
+            emit(gen, "return ");
+            emit_expr(gen, lam->as.lambda.body);
+            emit(gen, ";\n");
+        } else {
+            // Block body
+            emit_block_contents(gen, lam->as.lambda.body);
+            // Implicit void return cleanup
+            if (func_type->as.func.return_type == type_void) {
+                rc_cleanup_all(gen, NULL);
+            }
+        }
+        gen->out.indent--;
+        emit(gen, "}\n\n");
+        rc_clear_all(gen);
+    }
 }
 
 // Emit escaped string content (shared helper for string literal table)
@@ -1612,12 +1840,15 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     emit_enum_rc_helpers(gen, ast);
     emit_struct_body_typedefs(gen, ast);
     emit_function_forward_decls(gen, ast);
+    collect_lambdas(gen, ast);
+    emit_lambda_forward_decls(gen);
     emit_enum_eq_helpers(gen, ast);
     emit_vec_cleanup(gen);
     emit_vec_methods(gen);
     emit_vec_user_methods(gen, ast);
     emit_struct_cleanup(gen, ast);
     emit_declarations(gen, ast);
+    emit_lambda_definitions(gen);
     emit_generic_method_impls(gen, ast);
     emit_generic_func_impls(gen, ast);
     if (gen->test_mode) {

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -126,6 +126,12 @@ typedef struct {
         int    count;
         int    capacity;
     } hoist;
+    // Lambda functions collected for top-level emission
+    struct {
+        Node** nodes; // NODE_LAMBDA AST nodes (not owned)
+        int    count;
+        int    capacity;
+    } lambdas;
     // Current module name (NULL for "main")
     const char* current_module;
     // 1 if currently emitting an enum method body

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -1444,6 +1444,10 @@ void emit_expr(CodeGen* gen, Node* node) {
         emit_match_expr(gen, node);
         break;
 
+    case NODE_LAMBDA:
+        emit(gen, "__lambda_%d", node->as.lambda.lambda_id);
+        break;
+
     default:
         emit(gen, "/* unknown expr %d */", node->type);
         break;

--- a/w0/parser_expr.c
+++ b/w0/parser_expr.c
@@ -532,6 +532,54 @@ static Node* parse_new_expr(Parser* parser, Token new_token) {
     return node;
 }
 
+static Node* parse_lambda_expr(Parser* parser, Token start) {
+    Node* node = node_new(NODE_LAMBDA, start.line, start.column);
+    nodelist_init(&node->as.lambda.params);
+    node->as.lambda.return_type   = NULL;
+    node->as.lambda.body          = NULL;
+    node->as.lambda.is_expr_body  = 0;
+    node->as.lambda.lambda_id     = 0;
+    node->as.lambda.resolved_type = NULL;
+
+    // Parse params: |x: T, y: U| or ||
+    if (!check_token(parser, TOK_PIPE)) {
+        for (;;) {
+            Token param_name = parser->current;
+            consume_token(parser, TOK_IDENT, "Expected parameter name in lambda");
+
+            Node* param                 = node_new(NODE_PARAM, param_name.line, param_name.column);
+            param->as.param.name        = copy_token_string(&param_name);
+            param->as.param.name_length = param_name.length;
+            param->as.param.is_const    = 0;
+
+            consume_token(parser, TOK_COLON, "Expected ':' after lambda parameter name");
+            param->as.param.type = parse_type(parser);
+
+            nodelist_push(&node->as.lambda.params, param);
+
+            if (!match_token(parser, TOK_COMMA))
+                break;
+        }
+    }
+    consume_token(parser, TOK_PIPE, "Expected '|' after lambda parameters");
+
+    // Optional return type: -> Type
+    if (match_token(parser, TOK_ARROW)) {
+        node->as.lambda.return_type = parse_type(parser);
+    }
+
+    // Body: block or expression
+    if (match_token(parser, TOK_LBRACE)) {
+        node->as.lambda.body         = parse_block(parser);
+        node->as.lambda.is_expr_body = 0;
+    } else {
+        node->as.lambda.body         = parse_expression(parser);
+        node->as.lambda.is_expr_body = 1;
+    }
+
+    return node;
+}
+
 static Node* parse_array_lit(Parser* parser, Token token) {
     Node* node = node_new(NODE_ARRAY_LIT, token.line, token.column);
     nodelist_init(&node->as.array_lit.elements);
@@ -606,6 +654,29 @@ static Node* parse_primary_expression(Parser* parser) {
     case TOK_LBRACKET:
         advance_token(parser);
         return parse_array_lit(parser, token);
+    case TOK_PIPE:
+        advance_token(parser);
+        return parse_lambda_expr(parser, token);
+    case TOK_PIPE_PIPE: {
+        // || is lexed as a single token; treat as empty-param lambda
+        advance_token(parser);
+        Node* lam = node_new(NODE_LAMBDA, token.line, token.column);
+        nodelist_init(&lam->as.lambda.params);
+        lam->as.lambda.return_type   = NULL;
+        lam->as.lambda.lambda_id     = 0;
+        lam->as.lambda.resolved_type = NULL;
+        if (match_token(parser, TOK_ARROW)) {
+            lam->as.lambda.return_type = parse_type(parser);
+        }
+        if (match_token(parser, TOK_LBRACE)) {
+            lam->as.lambda.body         = parse_block(parser);
+            lam->as.lambda.is_expr_body = 0;
+        } else {
+            lam->as.lambda.body         = parse_expression(parser);
+            lam->as.lambda.is_expr_body = 1;
+        }
+        return lam;
+    }
     default:
         parse_error(parser, "Expected expression");
         return NULL;

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -481,6 +481,19 @@ void print_ast(Node* node, int depth) {
         printf("TryExpr\n");
         print_ast(node->as.try_expr.expr, depth + 1);
         break;
+    case NODE_LAMBDA:
+        printf("Lambda (%d params%s)\n", node->as.lambda.params.count,
+               node->as.lambda.is_expr_body ? ", expr" : "");
+        print_node_list("Params", &node->as.lambda.params, depth);
+        if (node->as.lambda.return_type) {
+            print_indent(depth + 1);
+            printf("ReturnType: ");
+            print_ast(node->as.lambda.return_type, depth + 2);
+        }
+        print_indent(depth + 1);
+        printf("Body: ");
+        print_ast(node->as.lambda.body, depth + 2);
+        break;
     case NODE_STRING_INTERP:
         printf("StringInterp (%d parts)\n", node->as.string_interp.parts.count);
         print_node_list(NULL, &node->as.string_interp.parts, depth);

--- a/w0/test/errors/error_lambda_capture.w
+++ b/w0/test/errors/error_lambda_capture.w
@@ -1,0 +1,8 @@
+// ERROR TEST: Lambda capture not yet supported
+// Expected error: Cannot capture variable 'x'
+
+func main(): i32 {
+    var x = 42;
+    var f: func(): i64 = || x;
+    return 0;
+}

--- a/w0/test/errors/error_lambda_type_mismatch.w
+++ b/w0/test/errors/error_lambda_type_mismatch.w
@@ -1,0 +1,7 @@
+// ERROR TEST: Lambda type mismatch
+// Expected error: f: expected 'func(i64): string', got 'func(i64): i64'
+
+func main(): i32 {
+    var f: func(i64): string = |x: i64| x * 2;
+    return 0;
+}

--- a/w0/test/run/types/lambda_runtime.w
+++ b/w0/test/run/types/lambda_runtime.w
@@ -1,0 +1,47 @@
+// Expected: PASS: lambda_runtime
+
+func apply(f: func(i64): i64, x: i64): i64 {
+    return f(x);
+}
+
+func apply2(f: func(i64, i64): i64, a: i64, b: i64): i64 {
+    return f(a, b);
+}
+
+test "lambda_runtime" {
+    // Lambda called through variable
+    var square: func(i64): i64 = |x: i64| x * x;
+    assert(square(5) == 25);
+
+    // Lambda passed to higher-order function
+    var result = apply(|x: i64| x + 10, 32);
+    assert(result == 42);
+
+    // Lambda with multiple params
+    var sum = apply2(|a: i64, b: i64| a + b, 20, 22);
+    assert(sum == 42);
+
+    // Block body lambda
+    var abs_val: func(i64): i64 = |x: i64| -> i64 {
+        if (x < 0) {
+            return -x;
+        }
+        return x;
+    };
+    assert(abs_val(-7) == 7);
+    assert(abs_val(3) == 3);
+
+    // Empty params lambda
+    var get42: func(): i64 = || 42;
+    assert(get42() == 42);
+
+    // Direct call
+    var x = (|a: i64| a * 2)(21);
+    assert(x == 42);
+
+    // Multiple lambdas in same function
+    var inc: func(i64): i64 = |x: i64| x + 1;
+    var dec: func(i64): i64 = |x: i64| x - 1;
+    assert(inc(10) == 11);
+    assert(dec(10) == 9);
+}

--- a/w0/test/valid/lambda_basic.w
+++ b/w0/test/valid/lambda_basic.w
@@ -1,0 +1,28 @@
+// Lambda syntax: assignment, type-checking, function arguments
+
+func apply(f: func(i64): i64, x: i64): i64 {
+    return f(x);
+}
+
+func apply_void(f: func(i64): void, x: i64): void {
+    f(x);
+}
+
+func main(): i32 {
+    // Expression body
+    var square: func(i64): i64 = |x: i64| x * x;
+
+    // Block body with return type
+    var add: func(i64, i64): i64 = |a: i64, b: i64| -> i64 { return a + b; };
+
+    // Block body, void return
+    var noop: func(i64): void = |x: i64| { };
+
+    // Empty params
+    var say_hi: func(): i64 = || 42;
+
+    // Lambda passed as function argument
+    var result = apply(|x: i64| x + 1, 42);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add anonymous function expressions with pipe syntax (`|params| body`) that compile to plain C function pointers
- Supports expression bodies (`|x: i64| x * x`), block bodies (`|x: i64| -> i64 { return x; }`), empty params (`|| 42`), explicit return types, and direct calls (`(|x: i64| x + 1)(42)`)
- Variable capture across lambda boundaries is detected and rejected with a clear error, deferring closures to Phase 2

## Changes

**AST**: `NODE_LAMBDA` with params, return_type, body, is_expr_body, lambda_id, resolved_type  
**Parser**: `parse_lambda_expr` for `|params| body` syntax; handles `TOK_PIPE` and `TOK_PIPE_PIPE` (`||`)  
**Checker**: `check_lambda_expr` resolves param/return types and builds `TYPE_FUNC`; `is_captured_variable` walks scopes to detect captures across `is_lambda_boundary`  
**Codegen**: Collects lambdas via AST walk, emits `static` forward decls and definitions as `__lambda_N`, expression emits function pointer name  
**Grammar**: `<lambda-expr>` production added to Primary Expressions

## Test plan

- [x] `make` — builds without warnings
- [x] `make test` — 214/214 tests pass (no regressions)
- [x] `test/valid/lambda_basic.w` — type-check: expression body, block body, void, empty params, func arg
- [x] `test/errors/error_lambda_capture.w` — rejects variable capture
- [x] `test/errors/error_lambda_type_mismatch.w` — rejects type mismatch
- [x] `test/run/types/lambda_runtime.w` — runtime: call through variable, higher-order, multi-param, block body, empty params, direct call, multiple lambdas

Closes #85