### PR TITLE
feat: method-level generic type parameters

### DIFF
--- a/lib/collections.w
+++ b/lib/collections.w
@@ -191,3 +191,21 @@ func (Vec<T>) all(pred: func(T) :bool): bool {
     }
     return true;
 }
+
+func (Vec<T>) map<K>(transform: func(T) :K): Vec<K> {
+    var result = new Vec<K>{};
+    foreach (const elem in self) {
+        result.push(transform(elem));
+    }
+    return result;
+}
+
+func (Vec<T>) filter(pred: func(T) :bool): Vec<T> {
+    var result = new Vec<T>{};
+    foreach (const elem in self) {
+        if (pred(elem)) {
+            result.push(elem);
+        }
+    }
+    return result;
+}

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -218,6 +218,7 @@ void checker_free(Checker* checker) {
         free(checker->generics.func_defs[i].type_params);
         free(checker->generics.func_defs[i].type_param_bounds);
         free((void*)checker->generics.func_defs[i].source_module);
+        free(checker->generics.func_defs[i].receiver_type);
     }
     free(checker->generics.func_defs);
     // Free generic free function instances
@@ -225,6 +226,7 @@ void checker_free(Checker* checker) {
         free(checker->generics.func_instances[i].mangled_name);
         free(checker->generics.func_instances[i].base_name);
         free(checker->generics.func_instances[i].type_args);
+        free(checker->generics.func_instances[i].receiver_type);
         node_free(checker->generics.func_instances[i].body);
     }
     free(checker->generics.func_instances);
@@ -1384,6 +1386,41 @@ static int try_register_generic_func_or_method(Checker* checker, Node* node) {
     if (!is_method && fdn->type_param_count > 0) {
         register_generic_func_def(checker, name, fdn->type_params, fdn->type_param_bounds,
                                   fdn->type_param_count, node);
+        return 1;
+    }
+
+    // Method-level generic: func (Vec<T>) map<K>(...): Vec<K>
+    // Must be checked BEFORE the plain generic receiver method branch
+    if (is_method && has_typearg && fdn->type_param_count > 0) {
+        GenericDef* def = lookup_generic_def(checker, receiver);
+        if (!def) {
+            check_error(checker, node->line, node->column, "Unknown generic type '%s'", receiver);
+            return 1;
+        }
+        if (fdn->receiver_type_args.count != def->type_param_count) {
+            check_error(checker, node->line, node->column,
+                        "Generic type '%s' expects %d type parameters, got %d", receiver,
+                        def->type_param_count, fdn->receiver_type_args.count);
+            return 1;
+        }
+        // Build combined type params: receiver's params + method's own type_params
+        int    recv_count   = def->type_param_count;
+        int    method_count = fdn->type_param_count;
+        int    combined     = recv_count + method_count;
+        char** params       = xmalloc(combined * sizeof(char*));
+        char** bounds       = xmalloc(combined * sizeof(char*));
+        for (int i = 0; i < recv_count; i++) {
+            params[i] = def->type_params[i];
+            bounds[i] = def->type_param_bounds[i];
+        }
+        for (int i = 0; i < method_count; i++) {
+            params[recv_count + i] = fdn->type_params[i];
+            bounds[recv_count + i] = fdn->type_param_bounds[i];
+        }
+        register_generic_method_func_def(checker, receiver, name, params, bounds, combined,
+                                         recv_count, node);
+        free(params);
+        free(bounds);
         return 1;
     }
 

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -100,6 +100,9 @@ typedef struct {
 } VecInstance;
 
 // Generic free function definition (template)
+// Also used for method-level generics: func (Vec<T>) map<K>(...): Vec<K>
+// For methods: type_params = combined receiver + method params ["T", "K"],
+//   receiver_param_count = 1 (count of receiver's params)
 typedef struct {
     char*       name;
     char**      type_params;       // ["T"] or ["T", "U"]
@@ -107,16 +110,23 @@ typedef struct {
     int         type_param_count;
     Node*       decl; // Original AST node (NODE_FUNC_DECL)
     const char* source_module;
+    // Method-level generics (NULL/0 for free functions)
+    char* receiver_type;        // "Vec" for methods, NULL for free funcs
+    int   receiver_param_count; // Count of receiver type params (e.g., 1 for Vec<T>)
 } GenericFuncDef;
 
-// Instantiated generic free function
+// Instantiated generic free function (also used for method-level generics)
 typedef struct {
-    char*  mangled_name; // "identity_i64"
-    char*  base_name;    // "identity"
+    char*  mangled_name; // "identity_i64" or "Vec_i64_map_string"
+    char*  base_name;    // "identity" or "Vec.map"
     Type*  func_type;    // Concrete TYPE_FUNC
     Type** type_args;
     int    type_arg_count;
     Node*  body; // Cloned + type-checked body
+    // Method-level generic fields (0/NULL for free functions)
+    int   is_method;         // 1 if method instance, 0 for free func
+    char* receiver_type;     // "Vec" for methods, NULL for free funcs
+    Type* receiver_concrete; // Concrete receiver type (e.g., TYPE_VEC with elem=i64)
 } GenericFuncInstance;
 
 // Module import tracking

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1416,6 +1416,173 @@ static Type* try_check_generic_free_function_call(Checker* checker, Node* node) 
     return ret;
 }
 
+// Determine the base receiver type name and type arguments for method-level generics.
+// For Vec<i64>: base_name = "Vec", recv_args = [i64], count = 1
+// For Box<i64> (generic struct): base_name = "Box", recv_args = [i64], count = 1
+// Returns NULL base_name if the type cannot be a generic method receiver.
+static const char* get_receiver_info(Checker* checker, Type* recv_type, Type*** out_args,
+                                     int* out_count) {
+    *out_args  = NULL;
+    *out_count = 0;
+
+    if (recv_type->kind == TYPE_VEC) {
+        *out_args      = xmalloc(sizeof(Type*));
+        (*out_args)[0] = recv_type->as.vec.elem;
+        *out_count     = 1;
+        return "Vec";
+    }
+
+    if (recv_type->kind == TYPE_STRUCT) {
+        // Look up the GenericInstance to find the base name
+        for (int i = 0; i < checker->generics.instance_count; i++) {
+            GenericInstance* inst = &checker->generics.instances[i];
+            if (strcmp(inst->mangled_name, recv_type->as.struc.name) == 0) {
+                *out_args = xmalloc(inst->type_arg_count * sizeof(Type*));
+                for (int j = 0; j < inst->type_arg_count; j++) {
+                    (*out_args)[j] = inst->type_args[j];
+                }
+                *out_count = inst->type_arg_count;
+                return inst->base_name;
+            }
+        }
+        // Non-generic struct — use struct name as-is (no type args)
+        return recv_type->as.struc.name;
+    }
+
+    return NULL;
+}
+
+// Try to resolve a method-level generic call: items.map(|x| x * 2)
+// Returns the return type if this is a method-level generic call, or NULL if not.
+static Type* try_check_generic_method_call(Checker* checker, Node* node) {
+    Node* callee = node->as.call.func;
+    if (callee->type != NODE_MEMBER) {
+        return NULL;
+    }
+
+    // Skip module-qualified calls (e.g., std.print) and type references (e.g., Point.move)
+    // These are not method calls on a receiver object. We must check this BEFORE calling
+    // check_expression on the object, because module names are not variables in scope.
+    if (callee->as.member.object->type == NODE_IDENT) {
+        const char* name = callee->as.member.object->as.ident.name;
+        if (is_imported_module(checker, name)) {
+            return NULL;
+        }
+        Symbol* sym = checker_lookup(checker, name);
+        if (sym && sym->kind == SYM_TYPE) {
+            return NULL;
+        }
+    }
+
+    // Type-check the receiver object
+    Type* recv_type = check_expression(checker, callee->as.member.object);
+    if (recv_type->kind == TYPE_ERROR) {
+        return NULL;
+    }
+
+    Type**      recv_args      = NULL;
+    int         recv_arg_count = 0;
+    const char* base_name      = get_receiver_info(checker, recv_type, &recv_args, &recv_arg_count);
+    const char* method_name    = callee->as.member.name;
+    if (!base_name) {
+        return NULL;
+    }
+
+    // Look up method-level generic definition
+    GenericFuncDef* gdef = lookup_generic_method_func_def(checker, base_name, method_name);
+    if (!gdef) {
+        free(recv_args);
+        return NULL;
+    }
+
+    func_decl_node* fdn = &gdef->decl->as.func_decl;
+
+    // Validate argument count (method params, not counting self)
+    if (node->as.call.args.count != fdn->params.count) {
+        check_error(checker, node->line, node->column, "Method '%s' expects %d arguments, got %d",
+                    method_name, fdn->params.count, node->as.call.args.count);
+        free(recv_args);
+        return type_error;
+    }
+
+    // Type-check all arguments
+    int    arg_count = node->as.call.args.count;
+    Type** arg_types = xmalloc(arg_count * sizeof(Type*));
+    int    has_error = 0;
+    for (int i = 0; i < arg_count; i++) {
+        arg_types[i] = check_expression(checker, node->as.call.args.nodes[i]);
+        if (arg_types[i]->kind == TYPE_ERROR) {
+            has_error = 1;
+        }
+    }
+    if (has_error) {
+        free(arg_types);
+        free(recv_args);
+        return type_error;
+    }
+
+    // Pre-fill inference array: receiver type params are known from the receiver type
+    Type** inferred = xcalloc(gdef->type_param_count, sizeof(Type*));
+
+    for (int i = 0; i < recv_arg_count && i < gdef->receiver_param_count; i++) {
+        inferred[i] = recv_args[i];
+    }
+    free(recv_args);
+
+    // Infer remaining type params from arguments
+    for (int i = 0; i < arg_count; i++) {
+        Node* param_type_node = fdn->params.nodes[i]->as.param.type;
+        infer_type_param(checker, gdef, param_type_node, arg_types[i], inferred);
+    }
+
+    // Check all type params were inferred
+    for (int i = 0; i < gdef->type_param_count; i++) {
+        if (!inferred[i]) {
+            check_error(checker, node->line, node->column,
+                        "Cannot infer type parameter '%s' for generic method '%s.%s'",
+                        gdef->type_params[i], base_name, method_name);
+            free(arg_types);
+            free(inferred);
+            return type_error;
+        }
+    }
+
+    // Check trait bounds
+    for (int i = 0; i < gdef->type_param_count; i++) {
+        const char* bound = gdef->type_param_bounds[i];
+        if (!bound) {
+            continue;
+        }
+        if (!type_satisfies_trait_bound(checker, inferred[i], bound)) {
+            check_error(checker, node->line, node->column,
+                        "Type '%s' does not implement trait '%s' required by '%s.%s'",
+                        type_name(inferred[i]), bound, base_name, method_name);
+            free(arg_types);
+            free(inferred);
+            return type_error;
+        }
+    }
+
+    // Instantiate
+    GenericFuncInstance* inst = instantiate_generic_method_func(
+        checker, gdef, inferred, gdef->type_param_count, recv_type, node->line, node->column);
+    free(arg_types);
+    free(inferred);
+
+    if (!inst) {
+        return type_error;
+    }
+
+    // Set resolved_name for codegen dispatch
+    node->as.call.resolved_name = xstrdup(inst->mangled_name);
+    Type* ret                   = inst->func_type->as.func.return_type;
+    if (type_is_rc_managed(ret)) {
+        node->is_owned_temp   = 1;
+        node->owned_temp_type = ret;
+    }
+    return ret;
+}
+
 static int check_call_arg_count(Checker* checker, Node* node, Type* func_type) {
     if (func_type->as.func.is_varargs) {
         if (node->as.call.args.count < func_type->as.func.param_count) {
@@ -1464,6 +1631,11 @@ static Type* check_call_expr(Checker* checker, Node* node) {
     Type* generic_call_type = try_check_generic_free_function_call(checker, node);
     if (generic_call_type) {
         return generic_call_type;
+    }
+
+    Type* generic_method_type = try_check_generic_method_call(checker, node);
+    if (generic_method_type) {
+        return generic_method_type;
     }
 
     Type* func_type = check_expression(checker, node->as.call.func);

--- a/w0/checker_internal.h
+++ b/w0/checker_internal.h
@@ -35,6 +35,17 @@ GenericFuncInstance* instantiate_generic_func(Checker* checker, GenericFuncDef* 
                                               Type** type_args, int type_arg_count, int line,
                                               int col);
 
+// --- From checker_types.c: method-level generic function management ---
+void                 register_generic_method_func_def(Checker* checker, const char* receiver_type,
+                                                      const char* method_name, char** combined_params,
+                                                      char** combined_bounds, int combined_count,
+                                                      int receiver_param_count, Node* decl);
+GenericFuncDef*      lookup_generic_method_func_def(Checker* checker, const char* receiver_type,
+                                                    const char* method_name);
+GenericFuncInstance* instantiate_generic_method_func(Checker* checker, GenericFuncDef* def,
+                                                     Type** combined_args, int combined_count,
+                                                     Type* receiver_concrete, int line, int col);
+
 // --- From checker_expr.c: expression checking ---
 Type* check_expression(Checker* checker, Node* node);
 

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -125,6 +125,8 @@ void register_generic_func_def(Checker* checker, const char* name, char** type_p
     def->decl             = decl;
     def->source_module =
         checker->modules.current_module ? xstrdup(checker->modules.current_module) : NULL;
+    def->receiver_type        = NULL;
+    def->receiver_param_count = 0;
 }
 
 // Look up a generic free function definition by name
@@ -237,8 +239,188 @@ GenericFuncInstance* instantiate_generic_func(Checker* checker, GenericFuncDef* 
     for (int i = 0; i < type_arg_count; i++) {
         inst->type_args[i] = type_args[i];
     }
-    inst->type_arg_count = type_arg_count;
-    inst->body           = body;
+    inst->type_arg_count    = type_arg_count;
+    inst->body              = body;
+    inst->is_method         = 0;
+    inst->receiver_type     = NULL;
+    inst->receiver_concrete = NULL;
+
+    free(mangled);
+    return inst;
+}
+
+// =============================================================================
+// Generic method-level function helpers (func (Vec<T>) map<K>(...): Vec<K>)
+// =============================================================================
+
+// Register a method-level generic function definition.
+// Combined type_params = receiver params (from GenericDef) + method's own type_params.
+// Keyed as "ReceiverType.method_name" to avoid collision with free functions.
+void register_generic_method_func_def(Checker* checker, const char* receiver_type,
+                                      const char* method_name, char** combined_params,
+                                      char** combined_bounds, int combined_count,
+                                      int receiver_param_count, Node* decl) {
+    // Build key: "Vec.map"
+    size_t key_len = strlen(receiver_type) + 1 + strlen(method_name) + 1;
+    char*  key     = xmalloc(key_len);
+    snprintf(key, key_len, "%s.%s", receiver_type, method_name);
+
+    // Check for duplicate
+    for (int i = 0; i < checker->generics.func_def_count; i++) {
+        if (strcmp(checker->generics.func_defs[i].name, key) == 0) {
+            free(key);
+            return;
+        }
+    }
+
+    VEC_GROW(checker->generics.func_defs, checker->generics.func_def_count,
+             checker->generics.func_def_capacity);
+    GenericFuncDef* def    = &checker->generics.func_defs[checker->generics.func_def_count++];
+    def->name              = key;
+    def->type_params       = xmalloc(combined_count * sizeof(char*));
+    def->type_param_bounds = xmalloc(combined_count * sizeof(char*));
+    for (int i = 0; i < combined_count; i++) {
+        def->type_params[i] = xstrdup(combined_params[i]);
+        def->type_param_bounds[i] =
+            (combined_bounds && combined_bounds[i]) ? xstrdup(combined_bounds[i]) : NULL;
+    }
+    def->type_param_count = combined_count;
+    def->decl             = decl;
+    def->source_module =
+        checker->modules.current_module ? xstrdup(checker->modules.current_module) : NULL;
+    def->receiver_type        = xstrdup(receiver_type);
+    def->receiver_param_count = receiver_param_count;
+}
+
+// Look up a method-level generic function definition by receiver type and method name.
+GenericFuncDef* lookup_generic_method_func_def(Checker* checker, const char* receiver_type,
+                                               const char* method_name) {
+    char key[256];
+    snprintf(key, sizeof(key), "%s.%s", receiver_type, method_name);
+    for (int i = 0; i < checker->generics.func_def_count; i++) {
+        if (strcmp(checker->generics.func_defs[i].name, key) == 0) {
+            return &checker->generics.func_defs[i];
+        }
+    }
+    return NULL;
+}
+
+// Instantiate a method-level generic function with concrete type arguments.
+// combined_args = receiver type args (T→i64) + method type args (K→string).
+GenericFuncInstance* instantiate_generic_method_func(Checker* checker, GenericFuncDef* def,
+                                                     Type** combined_args, int combined_count,
+                                                     Type* receiver_concrete, int line, int col) {
+    (void)line;
+    (void)col;
+
+    // Build mangled name: receiver mangled + "_" + method_name + "_" + method args mangled
+    // e.g. "Vec_i64_map_string"
+    func_decl_node* fdn = &def->decl->as.func_decl;
+
+    // Build receiver part: "Vec_i64"
+    char* recv_mangled =
+        type_mangle_generic(def->receiver_type, combined_args, def->receiver_param_count);
+
+    // Build method args part (the params after receiver params)
+    int    method_arg_count = combined_count - def->receiver_param_count;
+    Type** method_args      = combined_args + def->receiver_param_count;
+    char*  method_mangled   = type_mangle_generic(fdn->name, method_args, method_arg_count);
+
+    // Combine: "Vec_i64_map_string"
+    size_t mangled_len = strlen(recv_mangled) + 1 + strlen(method_mangled) + 1;
+    char*  mangled     = xmalloc(mangled_len);
+    snprintf(mangled, mangled_len, "%s_%s", recv_mangled, method_mangled);
+    free(recv_mangled);
+    free(method_mangled);
+
+    // Check cache
+    GenericFuncInstance* existing = lookup_generic_func_instance(checker, mangled);
+    if (existing) {
+        free(mangled);
+        return existing;
+    }
+
+    // Save and set up substitution context (combined params + args)
+    char** old_params = checker->generics.current_type_params;
+    Type** old_args   = checker->generics.current_type_args;
+    int    old_count  = checker->generics.current_type_param_count;
+
+    checker->generics.current_type_params      = def->type_params;
+    checker->generics.current_type_args        = combined_args;
+    checker->generics.current_type_param_count = def->type_param_count;
+
+    // Resolve concrete parameter types and return type
+    int    param_count = fdn->params.count;
+    Type** param_types = NULL;
+    if (param_count > 0) {
+        param_types = xmalloc(param_count * sizeof(Type*));
+    }
+    for (int i = 0; i < param_count; i++) {
+        Node* param    = fdn->params.nodes[i];
+        param_types[i] = resolve_type(checker, param->as.param.type);
+    }
+    Type* return_type = type_void;
+    if (fdn->return_type) {
+        return_type = resolve_type(checker, fdn->return_type);
+    }
+
+    Type* func_type = type_func(param_types, param_count, return_type, fdn->is_varargs);
+
+    // Pre-declare the mangled function in the symbol table for recursion
+    checker_define(checker, mangled, SYM_FUNC, func_type, 1, fdn->is_public,
+                   checker->modules.current_module);
+
+    // Clone and type-check the body
+    Node* body = node_clone(fdn->body);
+
+    // Push scope for self + params
+    checker_push_scope(checker);
+
+    // Define 'self' with the concrete receiver type
+    checker_define(checker, "self", SYM_VAR, receiver_concrete, fdn->receiver_is_const, 0, NULL);
+
+    for (int i = 0; i < param_count; i++) {
+        Node* param = fdn->params.nodes[i];
+        checker_define(checker, param->as.param.name, SYM_VAR, param_types[i],
+                       param->as.param.is_const, 0, NULL);
+    }
+
+    // Set function return type context
+    Type* old_return             = checker->current_func_return;
+    checker->current_func_return = return_type;
+
+    // Type-check body statements
+    if (body && body->type == NODE_BLOCK) {
+        for (int s = 0; s < body->as.block.stmts.count; s++) {
+            check_statement(checker, body->as.block.stmts.nodes[s]);
+        }
+    }
+
+    checker->current_func_return = old_return;
+    checker_pop_scope(checker);
+
+    // Restore substitution context
+    checker->generics.current_type_params      = old_params;
+    checker->generics.current_type_args        = old_args;
+    checker->generics.current_type_param_count = old_count;
+
+    // Store the instance
+    VEC_GROW(checker->generics.func_instances, checker->generics.func_instance_count,
+             checker->generics.func_instance_capacity);
+    GenericFuncInstance* inst =
+        &checker->generics.func_instances[checker->generics.func_instance_count++];
+    inst->mangled_name = xstrdup(mangled);
+    inst->base_name    = xstrdup(def->name);
+    inst->func_type    = func_type;
+    inst->type_args    = xmalloc(combined_count * sizeof(Type*));
+    for (int i = 0; i < combined_count; i++) {
+        inst->type_args[i] = combined_args[i];
+    }
+    inst->type_arg_count    = combined_count;
+    inst->body              = body;
+    inst->is_method         = 1;
+    inst->receiver_type     = xstrdup(def->receiver_type);
+    inst->receiver_concrete = receiver_concrete;
 
     free(mangled);
     return inst;

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -390,9 +390,12 @@ void collect_generic_methods(Node* ast, const char* struct_name, Node*** methods
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
             // Direct generic methods: func (Box<T>) get(): T
+            // Exclude method-level generics (type_param_count > 0) — those go through
+            // GenericFuncInstance
             if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.body != NULL &&
                 decl->as.func_decl.receiver_type != NULL &&
                 decl->as.func_decl.receiver_type_args.count > 0 &&
+                decl->as.func_decl.type_param_count == 0 &&
                 strcmp(decl->as.func_decl.receiver_type, struct_name) == 0) {
                 VEC_GROW(methods, count, capacity);
                 methods[count++] = decl;
@@ -404,6 +407,7 @@ void collect_generic_methods(Node* ast, const char* struct_name, Node*** methods
                     if (method->type == NODE_FUNC_DECL && method->as.func_decl.body != NULL &&
                         method->as.func_decl.receiver_type != NULL &&
                         method->as.func_decl.receiver_type_args.count > 0 &&
+                        method->as.func_decl.type_param_count == 0 &&
                         strcmp(method->as.func_decl.receiver_type, struct_name) == 0) {
                         VEC_GROW(methods, count, capacity);
                         methods[count++] = method;
@@ -1691,6 +1695,41 @@ static void emit_generic_method_impls(CodeGen* gen, Node* ast) {
     }
 }
 
+// Find a method-level generic function declaration in the AST.
+// Matches func (ReceiverType<...>) MethodName<...>(...): ...
+static Node* find_generic_method_func_decl(Node* ast, const char* receiver_type,
+                                           const char* method_name) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int d = 0; d < mod->as.module.decls.count; d++) {
+            Node* decl = mod->as.module.decls.nodes[d];
+            // Direct method: func (Vec<T>) map<K>(...): Vec<K>
+            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.receiver_type != NULL &&
+                decl->as.func_decl.type_param_count > 0 &&
+                strcmp(decl->as.func_decl.receiver_type, receiver_type) == 0 &&
+                strcmp(decl->as.func_decl.name, method_name) == 0) {
+                return decl;
+            }
+            // Inside impl blocks
+            if (decl->type == NODE_IMPL_DECL) {
+                for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
+                    Node* method = decl->as.impl_decl.methods.nodes[j];
+                    if (method->type == NODE_FUNC_DECL &&
+                        method->as.func_decl.receiver_type != NULL &&
+                        method->as.func_decl.type_param_count > 0 &&
+                        strcmp(method->as.func_decl.receiver_type, receiver_type) == 0 &&
+                        strcmp(method->as.func_decl.name, method_name) == 0) {
+                        return method;
+                    }
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
 // Find a generic free function declaration in the AST by name
 static Node* find_generic_func_decl(Node* ast, const char* name) {
     for (int m = 0; m < ast->as.program.modules.count; m++) {
@@ -1708,10 +1747,153 @@ static Node* find_generic_func_decl(Node* ast, const char* name) {
     return NULL;
 }
 
+// Parse a "Type.method" base_name to extract receiver_type and method_name.
+// Returns 1 if found, 0 if not a method key.
+static int parse_method_key(const char* base_name, char* recv_out, int recv_size, char* method_out,
+                            int method_size) {
+    const char* dot = strchr(base_name, '.');
+    if (!dot)
+        return 0;
+    int recv_len = (int)(dot - base_name);
+    if (recv_len >= recv_size)
+        recv_len = recv_size - 1;
+    memcpy(recv_out, base_name, recv_len);
+    recv_out[recv_len] = '\0';
+    int method_len     = (int)strlen(dot + 1);
+    if (method_len >= method_size)
+        method_len = method_size - 1;
+    memcpy(method_out, dot + 1, method_len);
+    method_out[method_len] = '\0';
+    return 1;
+}
+
+// Emit a method-level generic function implementation
+static void emit_generic_method_func_impl(CodeGen* gen, Node* ast, GenericFuncInstance* inst) {
+    char recv_name[128], method_name[128];
+    if (!parse_method_key(inst->base_name, recv_name, sizeof(recv_name), method_name,
+                          sizeof(method_name))) {
+        return;
+    }
+
+    Node* tmpl = find_generic_method_func_decl(ast, recv_name, method_name);
+    if (!tmpl)
+        return;
+
+    func_decl_node* fdn = &tmpl->as.func_decl;
+
+    // Build combined substitution: receiver params (from GenericDef) + method params
+    // The GenericFuncDef stores the combined param names; instance stores combined args.
+    // But we need to get the combined param names from the definition.
+    // Reconstruct them from receiver_type_args + type_params.
+    int    recv_param_count   = fdn->receiver_type_args.count;
+    int    method_param_count = fdn->type_param_count;
+    int    combined_count     = recv_param_count + method_param_count;
+    char** combined_params    = xmalloc(combined_count * sizeof(char*));
+
+    for (int p = 0; p < recv_param_count; p++) {
+        Node* arg          = fdn->receiver_type_args.nodes[p];
+        combined_params[p] = arg->as.ident.name;
+    }
+    for (int p = 0; p < method_param_count; p++) {
+        combined_params[recv_param_count + p] = fdn->type_params[p];
+    }
+
+    TypeSubstContext subst_ctx;
+    subst_ctx.type_params = combined_params;
+    subst_ctx.type_args   = inst->type_args;
+    subst_ctx.count       = combined_count;
+    gen->generics.subst   = &subst_ctx;
+
+    int is_void = return_type_is_void(fdn->return_type);
+
+    // Return type
+    emit_func_return_type(gen, fdn);
+
+    // Function name + self parameter
+    emit(gen, " %s(", inst->mangled_name);
+    if (fdn->receiver_is_const) {
+        emit(gen, "const ");
+    }
+    emit_resolved_type(gen, inst->receiver_concrete);
+    emit(gen, " self");
+
+    // Other parameters
+    for (int p = 0; p < fdn->params.count; p++) {
+        emit(gen, ", ");
+        Node* param = fdn->params.nodes[p];
+        if (param->as.param.is_const) {
+            emit(gen, "const ");
+        }
+        emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+    }
+    emit(gen, ") {\n");
+
+    // Clear defer stack for this function
+    defer_clear(gen);
+    gen->defer.return_type     = fdn->return_type;
+    gen->generics.modules      = fdn->accessible_modules;
+    gen->generics.module_count = fdn->accessible_modules_count;
+
+    int has_defers = 0;
+    if (inst->body) {
+        for (int s = 0; s < inst->body->as.block.stmts.count; s++) {
+            Node* stmt = inst->body->as.block.stmts.nodes[s];
+            if (stmt && stmt->type == NODE_DEFER) {
+                has_defers = 1;
+                break;
+            }
+        }
+    }
+
+    gen->out.indent++;
+
+    if (has_defers && !is_void) {
+        emit_indent(gen);
+        emit_type(gen, fdn->return_type);
+        emit(gen, " __ret;\n");
+    }
+
+    if (inst->body) {
+        for (int s = 0; s < inst->body->as.block.stmts.count; s++) {
+            emit_stmt(gen, inst->body->as.block.stmts.nodes[s]);
+        }
+    }
+
+    if (gen->rc.count > 0 && inst->body) {
+        int   sc   = inst->body->as.block.stmts.count;
+        Node* last = sc > 0 ? inst->body->as.block.stmts.nodes[sc - 1] : NULL;
+        if (!last || last->type != NODE_RETURN) {
+            rc_cleanup_all(gen, NULL);
+        }
+    }
+
+    if (has_defers) {
+        for (int d = gen->defer.count - 1; d >= 0; d--) {
+            emit_stmt(gen, gen->defer.stack[d]);
+        }
+    }
+
+    gen->out.indent--;
+    emit(gen, "}\n\n");
+
+    rc_clear_all(gen);
+
+    gen->generics.subst        = NULL;
+    gen->generics.modules      = NULL;
+    gen->generics.module_count = 0;
+    free(combined_params);
+}
+
 // Emit implementations for all instantiated generic free functions
 static void emit_generic_func_impls(CodeGen* gen, Node* ast) {
     for (int i = 0; i < gen->checker.func_instance_count; i++) {
         GenericFuncInstance* inst = &gen->checker.func_instances[i];
+
+        // Method-level generics: use separate handler
+        if (inst->is_method) {
+            emit_generic_method_func_impl(gen, ast, inst);
+            continue;
+        }
 
         // Find template
         Node* tmpl = find_generic_func_decl(ast, inst->base_name);

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -1523,6 +1523,38 @@ static void emit_generic_method_forward_decls(CodeGen* gen, Node* ast) {
     }
 }
 
+// Find a method-level generic function declaration in the AST by receiver type and method name
+static Node* find_generic_method_func_decl_in_ast(Node* ast, const char* receiver_type,
+                                                  const char* method_name) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int d = 0; d < mod->as.module.decls.count; d++) {
+            Node* decl = mod->as.module.decls.nodes[d];
+            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.receiver_type != NULL &&
+                decl->as.func_decl.type_param_count > 0 &&
+                strcmp(decl->as.func_decl.receiver_type, receiver_type) == 0 &&
+                strcmp(decl->as.func_decl.name, method_name) == 0) {
+                return decl;
+            }
+            if (decl->type == NODE_IMPL_DECL) {
+                for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
+                    Node* method = decl->as.impl_decl.methods.nodes[j];
+                    if (method->type == NODE_FUNC_DECL &&
+                        method->as.func_decl.receiver_type != NULL &&
+                        method->as.func_decl.type_param_count > 0 &&
+                        strcmp(method->as.func_decl.receiver_type, receiver_type) == 0 &&
+                        strcmp(method->as.func_decl.name, method_name) == 0) {
+                        return method;
+                    }
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
 static Node* find_generic_func_decl_in_ast(Node* ast, const char* name) {
     for (int m = 0; m < ast->as.program.modules.count; m++) {
         Node* mod = ast->as.program.modules.nodes[m];
@@ -1568,10 +1600,83 @@ static void emit_single_generic_func_forward_decl(CodeGen* gen, GenericFuncInsta
     gen->generics.subst = old_subst;
 }
 
+static void emit_single_generic_method_func_forward_decl(CodeGen* gen, GenericFuncInstance* inst,
+                                                         func_decl_node* fdn) {
+    // Build combined substitution from receiver_type_args + type_params
+    int    recv_param_count   = fdn->receiver_type_args.count;
+    int    method_param_count = fdn->type_param_count;
+    int    combined_count     = recv_param_count + method_param_count;
+    char** combined_params    = xmalloc(combined_count * sizeof(char*));
+
+    for (int p = 0; p < recv_param_count; p++) {
+        Node* arg          = fdn->receiver_type_args.nodes[p];
+        combined_params[p] = arg->as.ident.name;
+    }
+    for (int p = 0; p < method_param_count; p++) {
+        combined_params[recv_param_count + p] = fdn->type_params[p];
+    }
+
+    TypeSubstContext  subst_ctx;
+    TypeSubstContext* old_subst = gen->generics.subst;
+    subst_ctx.type_params       = combined_params;
+    subst_ctx.type_args         = inst->type_args;
+    subst_ctx.count             = combined_count;
+    gen->generics.subst         = &subst_ctx;
+
+    emit_func_return_type(gen, fdn);
+    emit(gen, " %s(", inst->mangled_name);
+
+    // Self parameter
+    if (fdn->receiver_is_const) {
+        emit(gen, "const ");
+    }
+    emit_resolved_type(gen, inst->receiver_concrete);
+    emit(gen, " self");
+
+    // Other parameters
+    for (int p = 0; p < fdn->params.count; p++) {
+        emit(gen, ", ");
+        Node* param = fdn->params.nodes[p];
+        if (param->as.param.is_const) {
+            emit(gen, "const ");
+        }
+        emit_type_with_name(gen, param->as.param.type, param->as.param.name);
+    }
+    emit(gen, ");\n");
+
+    gen->generics.subst = old_subst;
+    free(combined_params);
+}
+
 static void emit_generic_func_forward_decls(CodeGen* gen, Node* ast) {
     for (int i = 0; i < gen->checker.func_instance_count; i++) {
         GenericFuncInstance* inst = &gen->checker.func_instances[i];
-        Node*                tmpl = find_generic_func_decl_in_ast(ast, inst->base_name);
+
+        if (inst->is_method) {
+            // Method-level generic: parse "Vec.map" key
+            const char* dot = strchr(inst->base_name, '.');
+            if (!dot)
+                continue;
+            char recv_name[128], method_name_buf[128];
+            int  recv_len = (int)(dot - inst->base_name);
+            if (recv_len >= (int)sizeof(recv_name))
+                recv_len = (int)sizeof(recv_name) - 1;
+            memcpy(recv_name, inst->base_name, recv_len);
+            recv_name[recv_len] = '\0';
+            int method_len      = (int)strlen(dot + 1);
+            if (method_len >= (int)sizeof(method_name_buf))
+                method_len = (int)sizeof(method_name_buf) - 1;
+            memcpy(method_name_buf, dot + 1, method_len);
+            method_name_buf[method_len] = '\0';
+
+            Node* tmpl = find_generic_method_func_decl_in_ast(ast, recv_name, method_name_buf);
+            if (!tmpl)
+                continue;
+            emit_single_generic_method_func_forward_decl(gen, inst, &tmpl->as.func_decl);
+            continue;
+        }
+
+        Node* tmpl = find_generic_func_decl_in_ast(ast, inst->base_name);
         if (!tmpl) {
             continue;
         }

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -406,6 +406,15 @@ static void emit_call_expr(CodeGen* gen, Node* node) {
         return;
     }
 
+    // Method-level generic call: resolved_name set by checker, callee is NODE_MEMBER
+    if (node->as.call.resolved_name && func->type == NODE_MEMBER) {
+        emit(gen, "%s(", node->as.call.resolved_name);
+        emit_expr(gen, func->as.member.object); // self
+        emit_call_args(gen, node, 1);           // leading comma + remaining args
+        emit(gen, ")");
+        return;
+    }
+
     const char* callee_module_name = NULL;
     const char* callee_struct_name = NULL;
     if (func->type == NODE_MEMBER) {

--- a/w0/parser_decl.c
+++ b/w0/parser_decl.c
@@ -69,9 +69,9 @@ static Node* parse_func_decl(Parser* parser, int is_public) {
     fdn->return_is_const    = 0;
     nodelist_init(&fdn->params);
 
-    // Parse type parameters for generic free functions: func identity<T>(x: T): T
-    // Only for free functions (not methods with receivers)
-    if (!receiver_type && match_token(parser, TOK_LT)) {
+    // Parse type parameters for generic functions: func identity<T>(x: T): T
+    // Also for method-level generics: func (Vec<T>) map<K>(pred: func(T): K): Vec<K>
+    if (match_token(parser, TOK_LT)) {
         int capacity           = 4;
         fdn->type_params       = xmalloc(capacity * sizeof(char*));
         fdn->type_param_bounds = xmalloc(capacity * sizeof(char*));

--- a/w0/test/errors/error_generic_method_args.w
+++ b/w0/test/errors/error_generic_method_args.w
@@ -1,0 +1,13 @@
+// Expected error: Method 'map' expects 1 arguments, got 2
+
+import collections;
+
+func times_two(x: i64): i64 {
+    return x * 2;
+}
+
+func main(): i32 {
+    var nums = new Vec<i64>{};
+    nums.map(times_two, times_two);
+    return 0;
+}

--- a/w0/test/run/collections/vec_map.w
+++ b/w0/test/run/collections/vec_map.w
@@ -1,0 +1,56 @@
+// Expected: PASS: vec_map_basic
+// Expected: PASS: vec_map_type_transform
+// Expected: PASS: vec_filter_basic
+
+import collections;
+
+func times_two(x: i64): i64 {
+    return x * 2;
+}
+
+func is_big(x: i64): bool {
+    return x > 15;
+}
+
+test "vec_map_basic" {
+    var nums = new Vec<i64>{};
+    nums.push(1);
+    nums.push(2);
+    nums.push(3);
+
+    var doubled = nums.map(|x: i64| x * 2);
+    assert(doubled.count == 3);
+    assert(doubled[0] == 2);
+    assert(doubled[1] == 4);
+    assert(doubled[2] == 6);
+}
+
+test "vec_map_type_transform" {
+    var nums = new Vec<i64>{};
+    nums.push(10);
+    nums.push(20);
+
+    // map<K> with i64 -> bool (different type)
+    var flags = nums.map(is_big);
+    assert(flags.count == 2);
+    assert(flags[0] == false);
+    assert(flags[1] == true);
+}
+
+test "vec_filter_basic" {
+    var nums = new Vec<i64>{};
+    nums.push(1);
+    nums.push(2);
+    nums.push(3);
+    nums.push(4);
+    nums.push(5);
+
+    var evens = nums.filter(|x: i64| x % 2 == 0);
+    assert(evens.count == 2);
+    assert(evens[0] == 2);
+    assert(evens[1] == 4);
+}
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/valid/generic_method.w
+++ b/w0/test/valid/generic_method.w
@@ -1,0 +1,19 @@
+// Valid test: method-level generic type parameters parse and type-check
+
+struct Box<T> {
+    value: T,
+}
+
+func (Box<T>) transform<K>(f: func(T) :K): K {
+    return f(self.value);
+}
+
+func to_bool(x: i64): bool {
+    return x > 10;
+}
+
+func main(): i32 {
+    var b = new Box<i64>{value: 42};
+    var result: bool = b.transform(to_bool);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add support for methods that introduce their own type parameters beyond the receiver's, enabling patterns like `func (Vec<T>) map<K>(transform: func(T): K): Vec<K>`
- Extend parser, checker, and codegen to handle combined receiver + method type parameters
- Add `map<K>` and `filter` methods to `Vec<T>` in `lib/collections.w`

## Details

**Parser** (`parser_decl.c`): Removed `!receiver_type` guard so `<K>` type params can coexist with generic receiver type args.

**Checker** (`checker.h`, `checker.c`, `checker_types.c`, `checker_expr.c`, `checker_internal.h`):
- `GenericFuncDef` gains `receiver_type` and `receiver_param_count` for combined param tracking
- `GenericFuncInstance` gains `is_method`, `receiver_type`, `receiver_concrete` fields
- Method-level generics registered as `GenericFuncDef` keyed as `"Vec.map"` (not on `GenericDef.methods`, avoiding VecInstance parallel array assumption)
- `try_check_generic_method_call()` handles type inference with pre-filled receiver params
- `get_receiver_info()` resolves mangled struct names back to base names via `GenericInstance`

**Codegen** (`codegen.c`, `codegen_emit.c`, `codegen_expr.c`):
- `collect_generic_methods` filter excludes method-level generics (`type_param_count == 0`)
- Forward declarations and implementations emitted via combined substitution context
- Call-site intercept: `resolved_name` + `NODE_MEMBER` callee dispatches before struct/module paths

## Test plan

- [x] `make` — clean compile (no warnings)
- [x] `make test` — 200/216 pass (16 pre-existing failures unchanged)
- [x] `make format` — formatted
- [x] New test `vec_map.w` — map with lambdas, cross-type transform (i64→bool), filter
- [x] New test `generic_method.w` — type-check for `Box<T>.transform<K>`
- [x] New error test `error_generic_method_args.w` — wrong argument count
- [x] RC balance verified with `--rc-debug` (no leaks)
- [x] All 13 collection tests pass including hashmap