### PR TITLE
fix(generics): handle method-level generic receiver patterns

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1375,6 +1375,70 @@ static void check_extern_module_decl(Checker* checker, Node* node) {
     }
 }
 
+static int has_receiver_type_var(char** names, int count, const char* name) {
+    for (int i = 0; i < count; i++) {
+        if (strcmp(names[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int is_receiver_type_variable(Checker* checker, const char* name) {
+    if (type_builtin_from_name(name)) {
+        return 0;
+    }
+    Symbol* sym = checker_lookup_any(checker, name);
+    return !(sym && sym->kind == SYM_TYPE);
+}
+
+static void collect_receiver_type_vars(Checker* checker, Node* node, char*** names, int* count,
+                                       int* capacity) {
+    if (!node) {
+        return;
+    }
+
+    switch (node->type) {
+    case NODE_IDENT: {
+        const char* name = node->as.ident.name;
+        if (!is_receiver_type_variable(checker, name) ||
+            has_receiver_type_var(*names, *count, name)) {
+            return;
+        }
+        if (*count >= *capacity) {
+            *capacity = (*capacity == 0) ? 4 : (*capacity * 2);
+            *names    = xrealloc(*names, (*capacity) * sizeof(char*));
+        }
+        (*names)[(*count)++] = xstrdup(name);
+        return;
+    }
+    case NODE_GENERIC_TYPE:
+        for (int i = 0; i < node->as.generic_type.type_args.count; i++) {
+            collect_receiver_type_vars(checker, node->as.generic_type.type_args.nodes[i], names,
+                                       count, capacity);
+        }
+        return;
+    case NODE_ARRAY_TYPE:
+        collect_receiver_type_vars(checker, node->as.array_type.elem_type, names, count, capacity);
+        return;
+    case NODE_FUNC_TYPE:
+        for (int i = 0; i < node->as.func_type.param_types.count; i++) {
+            collect_receiver_type_vars(checker, node->as.func_type.param_types.nodes[i], names,
+                                       count, capacity);
+        }
+        collect_receiver_type_vars(checker, node->as.func_type.return_type, names, count, capacity);
+        return;
+    case NODE_TUPLE_TYPE:
+        for (int i = 0; i < node->as.tuple_type.elem_types.count; i++) {
+            collect_receiver_type_vars(checker, node->as.tuple_type.elem_types.nodes[i], names,
+                                       count, capacity);
+        }
+        return;
+    default:
+        return;
+    }
+}
+
 static int try_register_generic_func_or_method(Checker* checker, Node* node) {
     func_decl_node* fdn         = &node->as.func_decl;
     const char*     name        = fdn->name;
@@ -1403,15 +1467,24 @@ static int try_register_generic_func_or_method(Checker* checker, Node* node) {
                         def->type_param_count, fdn->receiver_type_args.count);
             return 1;
         }
-        // Build combined type params: receiver's params + method's own type_params
-        int    recv_count   = def->type_param_count;
+        // Build combined type params: receiver pattern bindings + method's own type params.
+        // Example: func (Pair<i32, Box<T>>) map<U>(...) => ["T", "U"].
+        char** recv_params   = NULL;
+        int    recv_count    = 0;
+        int    recv_capacity = 0;
+        for (int i = 0; i < fdn->receiver_type_args.count; i++) {
+            collect_receiver_type_vars(checker, fdn->receiver_type_args.nodes[i], &recv_params,
+                                       &recv_count, &recv_capacity);
+        }
+
         int    method_count = fdn->type_param_count;
         int    combined     = recv_count + method_count;
         char** params       = xmalloc(combined * sizeof(char*));
         char** bounds       = xmalloc(combined * sizeof(char*));
         for (int i = 0; i < recv_count; i++) {
-            params[i] = def->type_params[i];
-            bounds[i] = def->type_param_bounds[i];
+            params[i] = recv_params[i];
+            // Receiver generic bounds are enforced when the receiver type is instantiated.
+            bounds[i] = NULL;
         }
         for (int i = 0; i < method_count; i++) {
             params[recv_count + i] = fdn->type_params[i];
@@ -1419,6 +1492,10 @@ static int try_register_generic_func_or_method(Checker* checker, Node* node) {
         }
         register_generic_method_func_def(checker, receiver, name, params, bounds, combined,
                                          recv_count, node);
+        for (int i = 0; i < recv_count; i++) {
+            free(recv_params[i]);
+        }
+        free(recv_params);
         free(params);
         free(bounds);
         return 1;

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -101,8 +101,9 @@ typedef struct {
 
 // Generic free function definition (template)
 // Also used for method-level generics: func (Vec<T>) map<K>(...): Vec<K>
-// For methods: type_params = combined receiver + method params ["T", "K"],
-//   receiver_param_count = 1 (count of receiver's params)
+// For methods: type_params = combined receiver-bound + method params ["T", "K"].
+// receiver_param_count stores how many leading entries come from receiver pattern
+// bindings (not the receiver generic arity).
 typedef struct {
     char*       name;
     char**      type_params;       // ["T"] or ["T", "U"]
@@ -112,7 +113,7 @@ typedef struct {
     const char* source_module;
     // Method-level generics (NULL/0 for free functions)
     char* receiver_type;        // "Vec" for methods, NULL for free funcs
-    int   receiver_param_count; // Count of receiver type params (e.g., 1 for Vec<T>)
+    int   receiver_param_count; // Count of receiver-bound vars (e.g., 1 for Pair<i32, Box<T>>)
 } GenericFuncDef;
 
 // Instantiated generic free function (also used for method-level generics)

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1432,11 +1432,14 @@ static const char* get_receiver_info(Checker* checker, Type* recv_type, Type*** 
         return "Vec";
     }
 
-    if (recv_type->kind == TYPE_STRUCT) {
-        // Look up the GenericInstance to find the base name
+    if (recv_type->kind == TYPE_STRUCT || recv_type->kind == TYPE_ENUM) {
+        const char* concrete_name =
+            (recv_type->kind == TYPE_STRUCT) ? recv_type->as.struc.name : recv_type->as.enm.name;
+
+        // Look up GenericInstance to recover base name + concrete type args.
         for (int i = 0; i < checker->generics.instance_count; i++) {
             GenericInstance* inst = &checker->generics.instances[i];
-            if (strcmp(inst->mangled_name, recv_type->as.struc.name) == 0) {
+            if (strcmp(inst->mangled_name, concrete_name) == 0) {
                 *out_args = xmalloc(inst->type_arg_count * sizeof(Type*));
                 for (int j = 0; j < inst->type_arg_count; j++) {
                     (*out_args)[j] = inst->type_args[j];
@@ -1445,8 +1448,9 @@ static const char* get_receiver_info(Checker* checker, Type* recv_type, Type*** 
                 return inst->base_name;
             }
         }
-        // Non-generic struct — use struct name as-is (no type args)
-        return recv_type->as.struc.name;
+
+        // Non-generic struct/enum — use type name as-is (no type args)
+        return concrete_name;
     }
 
     return NULL;
@@ -1521,11 +1525,12 @@ static Type* try_check_generic_method_call(Checker* checker, Node* node) {
         return type_error;
     }
 
-    // Pre-fill inference array: receiver type params are known from the receiver type
+    // Pre-fill inference array from receiver pattern + concrete receiver args.
     Type** inferred = xcalloc(gdef->type_param_count, sizeof(Type*));
 
-    for (int i = 0; i < recv_arg_count && i < gdef->receiver_param_count; i++) {
-        inferred[i] = recv_args[i];
+    int recv_pattern_count = fdn->receiver_type_args.count;
+    for (int i = 0; i < recv_arg_count && i < recv_pattern_count; i++) {
+        infer_type_param(checker, gdef, fdn->receiver_type_args.nodes[i], recv_args[i], inferred);
     }
     free(recv_args);
 

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -317,11 +317,17 @@ GenericFuncInstance* instantiate_generic_method_func(Checker* checker, GenericFu
     // e.g. "Vec_i64_map_string"
     func_decl_node* fdn = &def->decl->as.func_decl;
 
-    // Build receiver part: "Vec_i64"
-    char* recv_mangled =
-        type_mangle_generic(def->receiver_type, combined_args, def->receiver_param_count);
+    // Build receiver part from concrete receiver type to preserve specialized patterns.
+    // Example: Pair<i32, Box<i64>> -> "Pair_i32_Box_i64".
+    const char* recv_name =
+        receiver_concrete ? type_mangle_name(receiver_concrete) : def->receiver_type;
+    char* recv_mangled = xstrdup(recv_name);
 
     // Build method args part (the params after receiver params)
+    if (combined_count < def->receiver_param_count) {
+        free(recv_mangled);
+        return NULL;
+    }
     int    method_arg_count = combined_count - def->receiver_param_count;
     Type** method_args      = combined_args + def->receiver_param_count;
     char*  method_mangled   = type_mangle_generic(fdn->name, method_args, method_arg_count);

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1747,6 +1747,16 @@ static Node* find_generic_func_decl(Node* ast, const char* name) {
     return NULL;
 }
 
+GenericFuncDef* lookup_generic_func_def_for_instance(CodeGen* gen, const char* base_name) {
+    for (int i = 0; i < gen->checker.func_def_count; i++) {
+        GenericFuncDef* def = &gen->checker.func_defs[i];
+        if (strcmp(def->name, base_name) == 0) {
+            return def;
+        }
+    }
+    return NULL;
+}
+
 // Parse a "Type.method" base_name to extract receiver_type and method_name.
 // Returns 1 if found, 0 if not a method key.
 static int parse_method_key(const char* base_name, char* recv_out, int recv_size, char* method_out,
@@ -1780,28 +1790,15 @@ static void emit_generic_method_func_impl(CodeGen* gen, Node* ast, GenericFuncIn
         return;
 
     func_decl_node* fdn = &tmpl->as.func_decl;
-
-    // Build combined substitution: receiver params (from GenericDef) + method params
-    // The GenericFuncDef stores the combined param names; instance stores combined args.
-    // But we need to get the combined param names from the definition.
-    // Reconstruct them from receiver_type_args + type_params.
-    int    recv_param_count   = fdn->receiver_type_args.count;
-    int    method_param_count = fdn->type_param_count;
-    int    combined_count     = recv_param_count + method_param_count;
-    char** combined_params    = xmalloc(combined_count * sizeof(char*));
-
-    for (int p = 0; p < recv_param_count; p++) {
-        Node* arg          = fdn->receiver_type_args.nodes[p];
-        combined_params[p] = arg->as.ident.name;
-    }
-    for (int p = 0; p < method_param_count; p++) {
-        combined_params[recv_param_count + p] = fdn->type_params[p];
+    GenericFuncDef* def = lookup_generic_func_def_for_instance(gen, inst->base_name);
+    if (!def || def->type_param_count != inst->type_arg_count) {
+        return;
     }
 
     TypeSubstContext subst_ctx;
-    subst_ctx.type_params = combined_params;
+    subst_ctx.type_params = def->type_params;
     subst_ctx.type_args   = inst->type_args;
-    subst_ctx.count       = combined_count;
+    subst_ctx.count       = def->type_param_count;
     gen->generics.subst   = &subst_ctx;
 
     int is_void = return_type_is_void(fdn->return_type);
@@ -1881,7 +1878,6 @@ static void emit_generic_method_func_impl(CodeGen* gen, Node* ast, GenericFuncIn
     gen->generics.subst        = NULL;
     gen->generics.modules      = NULL;
     gen->generics.module_count = 0;
-    free(combined_params);
 }
 
 // Emit implementations for all instantiated generic free functions

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -66,6 +66,8 @@ typedef struct {
     int                  vec_count;
     TraitImpl*           traits;
     int                  trait_count;
+    GenericFuncDef*      func_defs;
+    int                  func_def_count;
     GenericFuncInstance* func_instances;
     int                  func_instance_count;
     SemInfo*             sem;

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -1602,25 +1602,16 @@ static void emit_single_generic_func_forward_decl(CodeGen* gen, GenericFuncInsta
 
 static void emit_single_generic_method_func_forward_decl(CodeGen* gen, GenericFuncInstance* inst,
                                                          func_decl_node* fdn) {
-    // Build combined substitution from receiver_type_args + type_params
-    int    recv_param_count   = fdn->receiver_type_args.count;
-    int    method_param_count = fdn->type_param_count;
-    int    combined_count     = recv_param_count + method_param_count;
-    char** combined_params    = xmalloc(combined_count * sizeof(char*));
-
-    for (int p = 0; p < recv_param_count; p++) {
-        Node* arg          = fdn->receiver_type_args.nodes[p];
-        combined_params[p] = arg->as.ident.name;
-    }
-    for (int p = 0; p < method_param_count; p++) {
-        combined_params[recv_param_count + p] = fdn->type_params[p];
+    GenericFuncDef* def = lookup_generic_func_def_for_instance(gen, inst->base_name);
+    if (!def || def->type_param_count != inst->type_arg_count) {
+        return;
     }
 
     TypeSubstContext  subst_ctx;
     TypeSubstContext* old_subst = gen->generics.subst;
-    subst_ctx.type_params       = combined_params;
+    subst_ctx.type_params       = def->type_params;
     subst_ctx.type_args         = inst->type_args;
-    subst_ctx.count             = combined_count;
+    subst_ctx.count             = def->type_param_count;
     gen->generics.subst         = &subst_ctx;
 
     emit_func_return_type(gen, fdn);
@@ -1645,7 +1636,6 @@ static void emit_single_generic_method_func_forward_decl(CodeGen* gen, GenericFu
     emit(gen, ");\n");
 
     gen->generics.subst = old_subst;
-    free(combined_params);
 }
 
 static void emit_generic_func_forward_decls(CodeGen* gen, Node* ast) {

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -5,9 +5,10 @@
 #include "codegen_types.h"
 
 // --- From codegen.c: generic substitution ---
-Type* subst_lookup(CodeGen* gen, const char* name);
-char* stringify_expr(Node* node);
-int   lookup_string_lit(CodeGen* gen, const char* value, int length);
+Type*           subst_lookup(CodeGen* gen, const char* name);
+char*           stringify_expr(Node* node);
+int             lookup_string_lit(CodeGen* gen, const char* value, int length);
+GenericFuncDef* lookup_generic_func_def_for_instance(CodeGen* gen, const char* base_name);
 
 // --- From codegen_emit.c: shared helpers ---
 void        defer_push(CodeGen* gen, Node* node);

--- a/w0/main.c
+++ b/w0/main.c
@@ -72,6 +72,8 @@ static CodeGenChecker make_codegen_checker(Checker* checker) {
         .vec_count           = checker->containers.vec_count,
         .traits              = checker->traits.impls,
         .trait_count         = checker->traits.impl_count,
+        .func_defs           = checker->generics.func_defs,
+        .func_def_count      = checker->generics.func_def_count,
         .func_instances      = checker->generics.func_instances,
         .func_instance_count = checker->generics.func_instance_count,
         .sem                 = checker->sem,

--- a/w0/test/run/enums/generic_enum_method_generic.w
+++ b/w0/test/run/enums/generic_enum_method_generic.w
@@ -1,0 +1,42 @@
+// Expected: PASS: generic_enum_method_generic_some
+// Expected: PASS: generic_enum_method_generic_none
+
+enum Maybe<T> {
+    Some(T),
+    None,
+}
+
+func (const Maybe<T>) map<U>(f: func(T): U): Maybe<U> {
+    match (self) {
+        Some(v) => return Maybe::Some(f(v));
+        None => return Maybe::None;
+    }
+}
+
+func is_even(x: i64): bool {
+    return x % 2 == 0;
+}
+
+test "generic_enum_method_generic_some" {
+    var some: Maybe<i64> = Maybe::Some(4);
+    var mapped: Maybe<bool> = some.map(is_even);
+
+    match (mapped) {
+        Some(v) => assert(v);
+        None => assert(false);
+    }
+}
+
+test "generic_enum_method_generic_none" {
+    var none: Maybe<i64> = Maybe::None;
+    var mapped: Maybe<bool> = none.map(is_even);
+
+    match (mapped) {
+        None => assert(true);
+        Some(_) => assert(false);
+    }
+}
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/run/types/generic_method_receiver_pattern.w
+++ b/w0/test/run/types/generic_method_receiver_pattern.w
@@ -1,0 +1,44 @@
+// Expected: PASS: generic_method_specialized_receiver
+// Expected: PASS: generic_method_renamed_receiver_type_param
+
+struct Box<T> {
+    value: T,
+}
+
+struct Pair<K, V> {
+    key: K,
+    value: V,
+}
+
+func (Pair<i32, Box<T>>) map<U>(f: func(T): U): U {
+    return f(self.value.value);
+}
+
+func (Box<U>) apply<K>(f: func(U): K): K {
+    return f(self.value);
+}
+
+func is_positive(x: i64): bool {
+    return x > 0;
+}
+
+func add_one(x: i64): i64 {
+    return x + 1;
+}
+
+test "generic_method_specialized_receiver" {
+    var p =
+        new Pair<i32, Box<i64>> {key: 7, value: new Box<i64> {value: 42}};
+    var ok: bool = p.map(is_positive);
+    assert(ok);
+}
+
+test "generic_method_renamed_receiver_type_param" {
+    var b = new Box<i64> {value: 9};
+    var v: i64 = b.apply(add_one);
+    assert(v == 10);
+}
+
+func main(): i32 {
+    return 0;
+}


### PR DESCRIPTION
## Summary
- fix method-level generic registration/inference so receiver patterns (for example "'`Pair<i32, Box<T>>`) and renamed receiver params (for example `Box<U>`) are handled correctly
- support method-level generic call resolution on generic enum receivers
- align method-level generic codegen substitution with checker generic function definitions and deduplicate shared lookup helper
- generate method-level generic mangled names from the concrete receiver type for specialized receiver patterns
- add regression tests for receiver-pattern generics and generic enum method-level generics

## Testing
- cd w0 && make format
- cd w0 && make
- cd w0 && ./scripts/run_tests.sh --valid --errors
