### PR TITLE
fix: RC leak in chained method calls

### DIFF
--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -765,7 +765,18 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
                 emit_var_decl_rc_new_struct(gen, node);
             }
         } else {
+            // Hoist nested owned temps (e.g., intermediate in nums.map(...).filter(...))
+            int has_temps = has_owned_temps(node->as.var_decl.init);
+            int saved     = 0;
+            if (has_temps) {
+                saved = hoist_owned_temps(gen, node->as.var_decl.init);
+            }
+
             emit_var_decl_rc_copy(gen, node);
+
+            if (has_temps) {
+                cleanup_owned_temps(gen, saved);
+            }
         }
         return;
     }

--- a/w0/test/run/memory/rc_owned_temp_chain.w
+++ b/w0/test/run/memory/rc_owned_temp_chain.w
@@ -1,0 +1,24 @@
+// Expected: PASS: rc_chain_map_filter
+
+import collections;
+
+test "rc_chain_map_filter" {
+    var nums = new Vec<i64>{};
+    nums.push(1);
+    nums.push(2);
+    nums.push(3);
+    nums.push(4);
+    nums.push(5);
+
+    // Chained method calls: map() intermediate must be decremented
+    var result = nums.map(|x: i64| x * 3).filter(|x: i64| x > 4);
+    assert(result.count == 4);
+    assert(result[0] == 6);
+    assert(result[1] == 9);
+    assert(result[2] == 12);
+    assert(result[3] == 15);
+}
+
+func main(): i32 {
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes #248

- Hoist intermediate owned temps in the RC var decl copy path so chained calls like `nums.map(...).filter(...)` properly decrement the intermediate allocation
- The `map()` result was previously passed directly to `filter()` but never decremented, leaking memory

**Generated C before (leak):**
```c
__Vec_i64* result = __Vec_i64_filter(Vec_i64_map_i64(nums, __lambda_0), __lambda_1);
```

**Generated C after (correct):**
```c
__Vec_i64* __rc_tmp3 = Vec_i64_map_i64(nums, __lambda_1);
__Vec_i64* result = __Vec_i64_filter(__rc_tmp3, __lambda_2);
__rc_dec(__rc_tmp3);
```

## Test plan

- [x] `make test` — 219/219 tests pass
- [x] New test `rc_owned_temp_chain.w` verifies chained `map().filter()` produces correct results
- [x] `--rc-debug` confirms every `RC_ALLOC` has a matching `RC_FREE` (3 allocs, 3 frees)