### PR TITLE
feat: lambda parameter type inference

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -137,6 +137,7 @@ void checker_init(Checker* checker) {
     checker->traits.deferred_check_capacity = 0;
     checker->alias_depth                    = 0;
     checker->enum_target_hint               = NULL;
+    checker->expected_func_type             = NULL;
     checker->self_type                      = NULL;
     checker->lambda_next_id                 = 0;
     checker->lambda_depth                   = 0;

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -211,6 +211,9 @@ struct Checker {
     // Hint for generic enum type inference (set by var_decl when declared type is known)
     Type* enum_target_hint;
 
+    // Expected function type for lambda parameter inference (set before checking lambda args)
+    Type* expected_func_type;
+
     // Self type: set to TYPE_GENERIC_PARAM("Self") in trait decls,
     // concrete implementing type in impl blocks; NULL otherwise.
     Type* self_type;

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1333,6 +1333,58 @@ static int type_satisfies_trait_bound(Checker* checker, Type* type, const char* 
     return 0;
 }
 
+// Check if a node is a lambda with at least one untyped parameter
+static int has_untyped_lambda_params(Node* node) {
+    if (node->type != NODE_LAMBDA)
+        return 0;
+    for (int i = 0; i < node->as.lambda.params.count; i++) {
+        if (!node->as.lambda.params.nodes[i]->as.param.type)
+            return 1;
+    }
+    return 0;
+}
+
+// Build an expected TYPE_FUNC from a generic parameter type node using partially-inferred types.
+// Only resolves param types whose type nodes are simple ident type params with known inference.
+// Returns NULL if any param type can't be resolved.
+static Type* build_expected_func_type(Checker* checker, Node* param_type_node, GenericFuncDef* gdef,
+                                      Type** inferred) {
+    if (!param_type_node || param_type_node->type != NODE_FUNC_TYPE)
+        return NULL;
+
+    NodeList* ft_params   = &param_type_node->as.func_type.param_types;
+    int       n           = ft_params->count;
+    Type**    param_types = xmalloc(n * sizeof(Type*));
+
+    for (int i = 0; i < n; i++) {
+        Node* pt       = ft_params->nodes[i];
+        param_types[i] = NULL;
+
+        if (pt->type == NODE_IDENT) {
+            // Check if it's a generic type param with known inference
+            for (int j = 0; j < gdef->type_param_count; j++) {
+                if (strcmp(pt->as.ident.name, gdef->type_params[j]) == 0) {
+                    param_types[i] = inferred[j]; // NULL if not yet inferred
+                    break;
+                }
+            }
+            // If not a type param, try to resolve as concrete type
+            if (!param_types[i]) {
+                param_types[i] = resolve_type(checker, pt);
+                if (param_types[i]->kind == TYPE_ERROR)
+                    param_types[i] = NULL;
+            }
+        }
+
+        if (!param_types[i]) {
+            free(param_types);
+            return NULL;
+        }
+    }
+
+    return type_func(param_types, n, NULL, 0);
+}
+
 static Type* try_check_generic_free_function_call(Checker* checker, Node* node) {
     Node* callee = node->as.call.func;
     if (callee->type != NODE_IDENT) {
@@ -1353,12 +1405,15 @@ static Type* try_check_generic_free_function_call(Checker* checker, Node* node) 
     }
 
     int    arg_count = node->as.call.args.count;
-    Type** arg_types = xmalloc(arg_count * sizeof(Type*));
+    Type** arg_types = xcalloc(arg_count, sizeof(Type*));
     int    has_error = 0;
+
+    // Pass 1: Check non-lambda-with-untyped-params arguments
     for (int i = 0; i < arg_count; i++) {
-        arg_types[i] = check_expression(checker, node->as.call.args.nodes[i]);
-        if (arg_types[i]->kind == TYPE_ERROR) {
-            has_error = 1;
+        if (!has_untyped_lambda_params(node->as.call.args.nodes[i])) {
+            arg_types[i] = check_expression(checker, node->as.call.args.nodes[i]);
+            if (arg_types[i]->kind == TYPE_ERROR)
+                has_error = 1;
         }
     }
     if (has_error) {
@@ -1366,10 +1421,41 @@ static Type* try_check_generic_free_function_call(Checker* checker, Node* node) 
         return type_error;
     }
 
+    // Partial inference from pass 1 args
     Type** inferred = xcalloc(gdef->type_param_count, sizeof(Type*));
     for (int i = 0; i < arg_count; i++) {
-        Node* param_type_node = fdn->params.nodes[i]->as.param.type;
-        infer_type_param(checker, gdef, param_type_node, arg_types[i], inferred);
+        if (arg_types[i]) {
+            infer_type_param(checker, gdef, fdn->params.nodes[i]->as.param.type, arg_types[i],
+                             inferred);
+        }
+    }
+
+    // Pass 2: Check lambda args with expected types built from partial inference
+    for (int i = 0; i < arg_count; i++) {
+        if (!arg_types[i]) {
+            Type* old_expected = checker->expected_func_type;
+            Type* expected = build_expected_func_type(checker, fdn->params.nodes[i]->as.param.type,
+                                                      gdef, inferred);
+            if (expected)
+                checker->expected_func_type = expected;
+
+            arg_types[i]                = check_expression(checker, node->as.call.args.nodes[i]);
+            checker->expected_func_type = old_expected;
+
+            if (arg_types[i]->kind == TYPE_ERROR)
+                has_error = 1;
+
+            // Infer from the now-resolved lambda type
+            if (!has_error) {
+                infer_type_param(checker, gdef, fdn->params.nodes[i]->as.param.type, arg_types[i],
+                                 inferred);
+            }
+        }
+    }
+    if (has_error) {
+        free(arg_types);
+        free(inferred);
+        return type_error;
     }
 
     for (int i = 0; i < gdef->type_param_count; i++) {
@@ -1509,30 +1595,39 @@ static Type* try_check_generic_method_call(Checker* checker, Node* node) {
         return type_error;
     }
 
-    // Type-check all arguments
+    // Pre-fill inference array from receiver pattern BEFORE checking args
+    Type** inferred           = xcalloc(gdef->type_param_count, sizeof(Type*));
+    int    recv_pattern_count = fdn->receiver_type_args.count;
+    for (int i = 0; i < recv_arg_count && i < recv_pattern_count; i++) {
+        infer_type_param(checker, gdef, fdn->receiver_type_args.nodes[i], recv_args[i], inferred);
+    }
+    free(recv_args);
+
+    // Type-check all arguments (with expected types for lambda inference)
     int    arg_count = node->as.call.args.count;
     Type** arg_types = xmalloc(arg_count * sizeof(Type*));
     int    has_error = 0;
     for (int i = 0; i < arg_count; i++) {
+        // Build expected type for lambda args from partially-inferred params
+        Type* old_expected    = checker->expected_func_type;
+        Node* param_type_node = fdn->params.nodes[i]->as.param.type;
+        Type* expected        = build_expected_func_type(checker, param_type_node, gdef, inferred);
+        if (expected)
+            checker->expected_func_type = expected;
+
         arg_types[i] = check_expression(checker, node->as.call.args.nodes[i]);
+
+        checker->expected_func_type = old_expected;
+
         if (arg_types[i]->kind == TYPE_ERROR) {
             has_error = 1;
         }
     }
     if (has_error) {
         free(arg_types);
-        free(recv_args);
+        free(inferred);
         return type_error;
     }
-
-    // Pre-fill inference array from receiver pattern + concrete receiver args.
-    Type** inferred = xcalloc(gdef->type_param_count, sizeof(Type*));
-
-    int recv_pattern_count = fdn->receiver_type_args.count;
-    for (int i = 0; i < recv_arg_count && i < recv_pattern_count; i++) {
-        infer_type_param(checker, gdef, fdn->receiver_type_args.nodes[i], recv_args[i], inferred);
-    }
-    free(recv_args);
 
     // Infer remaining type params from arguments
     for (int i = 0; i < arg_count; i++) {
@@ -1608,8 +1703,18 @@ static int check_call_arg_count(Checker* checker, Node* node, Type* func_type) {
 
 static void check_call_named_args(Checker* checker, Node* node, Type* func_type) {
     for (int i = 0; i < func_type->as.func.param_count; i++) {
-        Type* arg_type   = check_expression(checker, node->as.call.args.nodes[i]);
         Type* param_type = func_type->as.func.param_types[i];
+
+        // Set expected type for lambda inference
+        Type* old_expected = checker->expected_func_type;
+        if (param_type->kind == TYPE_FUNC) {
+            checker->expected_func_type = param_type;
+        }
+
+        Type* arg_type = check_expression(checker, node->as.call.args.nodes[i]);
+
+        checker->expected_func_type = old_expected;
+
         if (!type_assignable(param_type, arg_type)) {
             char ctx[32];
             snprintf(ctx, sizeof(ctx), "Argument %d", i + 1);
@@ -2078,13 +2183,18 @@ static Type* check_lambda_expr(Checker* checker, Node* node) {
     }
     for (int i = 0; i < param_count; i++) {
         Node* p = params->nodes[i];
-        if (!p->as.param.type) {
-            check_error(checker, p->line, p->column,
-                        "Lambda parameter '%s' requires a type annotation", p->as.param.name);
+        if (p->as.param.type) {
+            param_types[i] = resolve_type(checker, p->as.param.type);
+        } else if (checker->expected_func_type && checker->expected_func_type->kind == TYPE_FUNC &&
+                   i < checker->expected_func_type->as.func.param_count &&
+                   checker->expected_func_type->as.func.param_types[i]) {
+            param_types[i] = checker->expected_func_type->as.func.param_types[i];
+        } else {
+            check_error(checker, p->line, p->column, "Cannot infer type for lambda parameter '%s'",
+                        p->as.param.name);
             free(param_types);
             return type_error;
         }
-        param_types[i] = resolve_type(checker, p->as.param.type);
         if (param_types[i]->kind == TYPE_ERROR) {
             free(param_types);
             return type_error;

--- a/w0/parser_expr.c
+++ b/w0/parser_expr.c
@@ -552,8 +552,10 @@ static Node* parse_lambda_expr(Parser* parser, Token start) {
             param->as.param.name_length = param_name.length;
             param->as.param.is_const    = 0;
 
-            consume_token(parser, TOK_COLON, "Expected ':' after lambda parameter name");
-            param->as.param.type = parse_type(parser);
+            param->as.param.type = NULL;
+            if (match_token(parser, TOK_COLON)) {
+                param->as.param.type = parse_type(parser);
+            }
 
             nodelist_push(&node->as.lambda.params, param);
 

--- a/w0/test/errors/lambda_infer_error.w
+++ b/w0/test/errors/lambda_infer_error.w
@@ -1,0 +1,7 @@
+// Expected error: Cannot infer type for lambda parameter 'x'
+
+func main(): i32 {
+    // No context to infer from — should error
+    var f = |x| x + 1;
+    return 0;
+}

--- a/w0/test/run/collections/vec_lambda_infer.w
+++ b/w0/test/run/collections/vec_lambda_infer.w
@@ -1,0 +1,48 @@
+// Expected: PASS: map_infer
+// Expected: PASS: filter_infer
+// Expected: PASS: chain_infer
+
+import collections;
+
+test "map_infer" {
+    var nums = new Vec<i64>{};
+    nums.push(1);
+    nums.push(2);
+    nums.push(3);
+    var doubled = nums.map(|x| x * 2);
+    assert(doubled.count == 3);
+    assert(doubled[0] == 2);
+    assert(doubled[1] == 4);
+    assert(doubled[2] == 6);
+}
+
+test "filter_infer" {
+    var nums = new Vec<i64>{};
+    nums.push(1);
+    nums.push(2);
+    nums.push(3);
+    nums.push(4);
+    var evens = nums.filter(|x| x % 2 == 0);
+    assert(evens.count == 2);
+    assert(evens[0] == 2);
+    assert(evens[1] == 4);
+}
+
+test "chain_infer" {
+    var nums = new Vec<i64>{};
+    nums.push(1);
+    nums.push(2);
+    nums.push(3);
+    nums.push(4);
+    nums.push(5);
+    var result = nums.map(|x| x * 3).filter(|x| x > 4);
+    assert(result.count == 4);
+    assert(result[0] == 6);
+    assert(result[1] == 9);
+    assert(result[2] == 12);
+    assert(result[3] == 15);
+}
+
+func main(): i32 {
+    return 0;
+}

--- a/w0/test/valid/lambda_infer.w
+++ b/w0/test/valid/lambda_infer.w
@@ -1,0 +1,16 @@
+// Lambda parameter type inference
+
+func apply(f: func(i64): i64, x: i64): i64 {
+    return f(x);
+}
+
+func main(): i32 {
+    // Infer from regular function param type
+    var result = apply(|x| x + 1, 42);
+
+    // Mixed: some typed, some inferred
+    // (single param inferred)
+    var r2 = apply(|x| x * 2, 10);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Infer lambda parameter types from calling context, enabling `nums.map(|x| x * 3).filter(|x| x > 4)` instead of requiring explicit `|x: i64|` annotations
- Uses bidirectional type propagation via `expected_func_type` on the Checker (same save/restore pattern as `enum_target_hint`)
- Supports regular calls, generic methods (receiver inference first), and generic free functions (two-pass: concrete args first, then lambdas)

## Changes
- **`parser_expr.c`**: Make lambda param type annotations optional (`|x|` parses without `: type`)
- **`checker.h`/`checker.c`**: Add `expected_func_type` field to Checker
- **`checker_expr.c`**: 
  - `check_lambda_expr` — infer param types from `expected_func_type` when no annotation
  - `check_call_named_args` — set expected type for lambda args in non-generic calls
  - `try_check_generic_method_call` — move receiver inference before arg checking, build expected types
  - `try_check_generic_free_function_call` — two-pass inference (concrete args first, then lambdas with expected types)
  - New helpers: `has_untyped_lambda_params()`, `build_expected_func_type()`

## Test plan
- [x] `make` builds successfully
- [x] `make test` — 221/221 tests pass (113 run + 108 error)
- [x] New `test/valid/lambda_infer.w` — type-check with `apply(|x| x + 1, 42)`
- [x] New `test/run/collections/vec_lambda_infer.w` — runtime tests for `map`, `filter`, and chained inference
- [x] New `test/errors/lambda_infer_error.w` — error when no context (`var f = |x| x + 1`)
- [x] `make format` — code formatted