### PR TITLE
feat: renaming on struct destructuring

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -181,12 +181,14 @@ Aliases are fully interchangeable with the underlying type: `var id: UserId = 42
 <destruct-element> ::= <identifier>
                     | <destruct-pattern>
 
-<struct-destruct> ::= '{' <identifier> { ',' <identifier> } '}'
+<struct-destruct> ::= '{' <struct-destruct-field> { ',' <struct-destruct-field> } '}'
+
+<struct-destruct-field> ::= <identifier> [ ':' <identifier> ]
 ```
 
 **Tuple destructuring:** `var (a, b) = expr;` and `const (a, b) = expr;` unpack a tuple into individual bindings. The number of elements must match the tuple's arity. Nested patterns are supported: `var (x, (y, z)) = (1, (2, 3));` unpacks nested tuples.
 
-**Struct destructuring:** `var {field1, field2} = expr;` extracts named fields from a struct into local variables with the same names. The expression must evaluate to a struct type, and each identifier must match a field name on that struct. Partial destructuring is allowed (not all fields need to be listed). The underlying struct is kept alive as an RC-tracked temporary for the enclosing scope.
+**Struct destructuring:** `var {field1, field2} = expr;` extracts named fields from a struct into local variables with the same names. The expression must evaluate to a struct type, and each identifier must match a field name on that struct. Partial destructuring is allowed (not all fields need to be listed). The underlying struct is kept alive as an RC-tracked temporary for the enclosing scope. Fields can be renamed with `var {field: local_name} = expr;` to bind a field to a different local variable name.
 
 ### Test Declaration
 

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -41,6 +41,8 @@ DestructPattern* pattern_new_struct(int capacity) {
     pattern->kind                        = PATTERN_STRUCT;
     pattern->as.struc.field_names        = xmalloc(capacity * sizeof(char*));
     pattern->as.struc.field_name_lengths = xmalloc(capacity * sizeof(int));
+    pattern->as.struc.local_names        = xmalloc(capacity * sizeof(char*));
+    pattern->as.struc.local_name_lengths = xmalloc(capacity * sizeof(int));
     pattern->as.struc.field_types        = xcalloc(capacity, sizeof(Type*));
     pattern->as.struc.count              = 0;
     pattern->as.struc.capacity           = capacity;
@@ -48,12 +50,17 @@ DestructPattern* pattern_new_struct(int capacity) {
     return pattern;
 }
 
-void pattern_struct_push(DestructPattern* pattern, const char* name, int length) {
+void pattern_struct_push(DestructPattern* pattern, const char* name, int length,
+                         const char* local_name, int local_length) {
     if (pattern->as.struc.count >= pattern->as.struc.capacity) {
         pattern->as.struc.capacity *= 2;
         pattern->as.struc.field_names =
             xrealloc(pattern->as.struc.field_names, pattern->as.struc.capacity * sizeof(char*));
         pattern->as.struc.field_name_lengths = xrealloc(pattern->as.struc.field_name_lengths,
+                                                        pattern->as.struc.capacity * sizeof(int));
+        pattern->as.struc.local_names =
+            xrealloc(pattern->as.struc.local_names, pattern->as.struc.capacity * sizeof(char*));
+        pattern->as.struc.local_name_lengths = xrealloc(pattern->as.struc.local_name_lengths,
                                                         pattern->as.struc.capacity * sizeof(int));
         pattern->as.struc.field_types =
             xrealloc(pattern->as.struc.field_types, pattern->as.struc.capacity * sizeof(Type*));
@@ -63,6 +70,11 @@ void pattern_struct_push(DestructPattern* pattern, const char* name, int length)
     memcpy(pattern->as.struc.field_names[i], name, length);
     pattern->as.struc.field_names[i][length] = '\0';
     pattern->as.struc.field_name_lengths[i]  = length;
+
+    pattern->as.struc.local_names[i] = xmalloc(local_length + 1);
+    memcpy(pattern->as.struc.local_names[i], local_name, local_length);
+    pattern->as.struc.local_names[i][local_length] = '\0';
+    pattern->as.struc.local_name_lengths[i]        = local_length;
 }
 
 void pattern_free(DestructPattern* pattern) {
@@ -82,9 +94,12 @@ void pattern_free(DestructPattern* pattern) {
     case PATTERN_STRUCT:
         for (int i = 0; i < pattern->as.struc.count; i++) {
             free(pattern->as.struc.field_names[i]);
+            free(pattern->as.struc.local_names[i]);
         }
         free(pattern->as.struc.field_names);
         free(pattern->as.struc.field_name_lengths);
+        free(pattern->as.struc.local_names);
+        free(pattern->as.struc.local_name_lengths);
         free(pattern->as.struc.field_types);
         break;
     }
@@ -116,10 +131,14 @@ DestructPattern* pattern_clone(DestructPattern* pattern) {
         c->as.struc.capacity           = pattern->as.struc.count;
         c->as.struc.field_names        = xmalloc(sizeof(char*) * pattern->as.struc.count);
         c->as.struc.field_name_lengths = xmalloc(sizeof(int) * pattern->as.struc.count);
+        c->as.struc.local_names        = xmalloc(sizeof(char*) * pattern->as.struc.count);
+        c->as.struc.local_name_lengths = xmalloc(sizeof(int) * pattern->as.struc.count);
         c->as.struc.field_types        = NULL; // checker-set, will be re-populated
         for (int i = 0; i < pattern->as.struc.count; i++) {
             c->as.struc.field_names[i]        = xstrdup(pattern->as.struc.field_names[i]);
             c->as.struc.field_name_lengths[i] = pattern->as.struc.field_name_lengths[i];
+            c->as.struc.local_names[i]        = xstrdup(pattern->as.struc.local_names[i]);
+            c->as.struc.local_name_lengths[i] = pattern->as.struc.local_name_lengths[i];
         }
         break;
     }

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -29,6 +29,8 @@ struct DestructPattern {
         struct {
             char** field_names;
             int*   field_name_lengths;
+            char** local_names; // Rename targets (same as field_names if no rename)
+            int*   local_name_lengths;
             int    count;
             int    capacity;
             Type** field_types; // Set by checker (parallel array)
@@ -42,7 +44,8 @@ DestructPattern* pattern_new_ident(const char* name, int length);
 DestructPattern* pattern_new_tuple(int capacity);
 void             pattern_tuple_push(DestructPattern* pattern, DestructPattern* elem);
 DestructPattern* pattern_new_struct(int capacity);
-void             pattern_struct_push(DestructPattern* pattern, const char* name, int length);
+void             pattern_struct_push(DestructPattern* pattern, const char* name, int length,
+                                     const char* local_name, int local_length);
 void             pattern_free(DestructPattern* pattern);
 DestructPattern* pattern_clone(DestructPattern* pattern);
 

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -506,7 +506,7 @@ static int check_destruct_pattern_redefinitions_internal(Checker* checker, Destr
 
     case PATTERN_STRUCT:
         for (int i = 0; i < pattern->as.struc.count; i++) {
-            const char* name = pattern->as.struc.field_names[i];
+            const char* name = pattern->as.struc.local_names[i];
 
             if (checker_lookup_local(checker, name)) {
                 check_error(checker, line, col, "Redefinition of '%s'", name);
@@ -641,7 +641,7 @@ static void define_destruct_pattern_vars(Checker* checker, DestructPattern* patt
 
     case PATTERN_STRUCT:
         for (int i = 0; i < pattern->as.struc.count; i++) {
-            checker_define(checker, pattern->as.struc.field_names[i], SYM_VAR,
+            checker_define(checker, pattern->as.struc.local_names[i], SYM_VAR,
                            pattern->as.struc.field_types[i], is_const, is_public,
                            checker->modules.current_module);
         }

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -1537,7 +1537,7 @@ void emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* t
                 emit(gen, "const ");
             }
             emit_resolved_type(gen, pattern->as.struc.field_types[i]);
-            emit(gen, " %s = %s->%s;\n", pattern->as.struc.field_names[i], temp_prefix,
+            emit(gen, " %s = %s->%s;\n", pattern->as.struc.local_names[i], temp_prefix,
                  pattern->as.struc.field_names[i]);
         }
         break;

--- a/w0/parser_stmt.c
+++ b/w0/parser_stmt.c
@@ -452,16 +452,28 @@ Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
 
         DestructPattern* pattern = pattern_new_struct(4);
 
-        // Parse first field name (required)
+        // Parse first field (required): field_name or field_name: local_name
         Token field = parser->current;
         consume_token(parser, TOK_IDENT, "Expected field name");
-        pattern_struct_push(pattern, field.start, field.length);
+        if (match_token(parser, TOK_COLON)) {
+            Token local = parser->current;
+            consume_token(parser, TOK_IDENT, "Expected local variable name after ':'");
+            pattern_struct_push(pattern, field.start, field.length, local.start, local.length);
+        } else {
+            pattern_struct_push(pattern, field.start, field.length, field.start, field.length);
+        }
 
-        // Parse remaining comma-separated field names
+        // Parse remaining comma-separated fields
         while (match_token(parser, TOK_COMMA)) {
             field = parser->current;
             consume_token(parser, TOK_IDENT, "Expected field name");
-            pattern_struct_push(pattern, field.start, field.length);
+            if (match_token(parser, TOK_COLON)) {
+                Token local = parser->current;
+                consume_token(parser, TOK_IDENT, "Expected local variable name after ':'");
+                pattern_struct_push(pattern, field.start, field.length, local.start, local.length);
+            } else {
+                pattern_struct_push(pattern, field.start, field.length, field.start, field.length);
+            }
         }
 
         consume_token(parser, TOK_RBRACE, "Expected '}'");

--- a/w0/test/errors/error_struct_destruct_rename_duplicate.w
+++ b/w0/test/errors/error_struct_destruct_rename_duplicate.w
@@ -1,0 +1,12 @@
+// Test: duplicate local names in struct destructuring with rename
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+func main(): i32 {
+    var {x: a, y: a} = new Point {x: 1, y: 2};
+    // Expected error: Redefinition of 'a'
+    return 0;
+}

--- a/w0/test/run/types/struct_destructure_rename.w
+++ b/w0/test/run/types/struct_destructure_rename.w
@@ -1,0 +1,45 @@
+// Expected: PASS: struct_destructure_rename
+// Test struct destructuring with field renaming: var {field: local} = expr;
+
+struct Point {
+    x: i64,
+    y: i64,
+}
+
+struct Info {
+    code: i64,
+    value: i64,
+    extra: i64,
+}
+
+func make_point(a: i64, b: i64): Point {
+    return new Point {x: a, y: b};
+}
+
+test "struct_destructure_rename" {
+    // Basic: rename both fields
+    var {x: px, y: py} = new Point {x: 10, y: 20};
+    assert(px == 10);
+    assert(py == 20);
+
+    // Mix renamed and non-renamed fields
+    var {code, value: val} = new Info {code: 42, value: 7, extra: 99};
+    assert(code == 42);
+    assert(val == 7);
+
+    // Const with rename
+    const {x: cx, y: cy} = new Point {x: 30, y: 40};
+    assert(cx == 30);
+    assert(cy == 40);
+
+    // Partial destructure with rename
+    var {extra: e} = new Info {code: 1, value: 2, extra: 3};
+    assert(e == 3);
+
+    // Destructure from function return with rename
+    if (true) {
+        var {x: fx, y: fy} = make_point(50, 60);
+        assert(fx == 50);
+        assert(fy == 60);
+    }
+}


### PR DESCRIPTION
## Summary

- Add JS-style field renaming to struct destructuring: `var {x: px, y: py} = expr;` binds field `x` to local var `px`
- Renamed and non-renamed fields can be mixed: `var {x, y: py} = expr;`
- Works with `const`, partial destructuring, and function return values

Closes #252

## Test plan

- [x] New run test `struct_destructure_rename.w` covers: basic rename, mixed rename/non-rename, const, partial, function return
- [x] New error test `error_struct_destruct_rename_duplicate.w` covers duplicate local names
- [x] All 221 existing tests pass (no regressions)