### PR TITLE
Update VS Code syntax highlighter to match current grammar

### DIFF
--- a/editors/vscode/syntaxes/whist.tmLanguage.json
+++ b/editors/vscode/syntaxes/whist.tmLanguage.json
@@ -5,6 +5,7 @@
   "patterns": [
     { "include": "#comments" },
     { "include": "#interp-strings" },
+    { "include": "#triple-strings" },
     { "include": "#strings" },
     { "include": "#characters" },
     { "include": "#numbers" },
@@ -20,6 +21,7 @@
     { "include": "#keywords" },
     { "include": "#constants" },
     { "include": "#builtin-types" },
+    { "include": "#wildcard" },
     { "include": "#enum-variant-access" },
     { "include": "#function-call" },
     { "include": "#operators" }
@@ -67,6 +69,21 @@
               },
               "patterns": [{ "include": "$self" }]
             },
+            {
+              "name": "constant.character.escape.whist",
+              "match": "\\\\(x[0-9a-fA-F]{2}|[0-7]{1,3}|[nrt\\\\'\"/0])"
+            }
+          ]
+        }
+      ]
+    },
+    "triple-strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.triple.whist",
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "patterns": [
             {
               "name": "constant.character.escape.whist",
               "match": "\\\\(x[0-9a-fA-F]{2}|[0-7]{1,3}|[nrt\\\\'\"/0])"
@@ -141,7 +158,7 @@
         },
         {
           "name": "keyword.other.whist",
-          "match": "\\b(as|func|new|self|defer)\\b"
+          "match": "\\b(as|func|new|self|defer|test)\\b"
         },
         {
           "name": "storage.type.whist",
@@ -174,11 +191,23 @@
         {
           "name": "support.type.primitive.whist",
           "match": "\\b(void|bool|i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|char|string|voidptr)\\b"
+        },
+        {
+          "name": "support.type.builtin.whist",
+          "match": "\\b(Option|Vec|Span|StringBuilder|Result)\\b"
+        }
+      ]
+    },
+    "wildcard": {
+      "patterns": [
+        {
+          "name": "variable.language.wildcard.whist",
+          "match": "\\b_\\b"
         }
       ]
     },
     "function-declaration": {
-      "comment": "Top-level function: func name(",
+      "comment": "Top-level function: func name( or func name<",
       "match": "\\b(func)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\(|<)",
       "captures": {
         "1": { "name": "keyword.other.func.whist" },
@@ -217,13 +246,26 @@
       }
     },
     "impl-declaration": {
-      "match": "\\b(impl)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s+(for)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-      "captures": {
-        "1": { "name": "storage.type.impl.whist" },
-        "2": { "name": "entity.name.type.whist" },
-        "3": { "name": "keyword.other.for.whist" },
-        "4": { "name": "entity.name.type.whist" }
-      }
+      "patterns": [
+        {
+          "comment": "Trait impl: impl Trait for Type or impl Trait for Type<...>",
+          "match": "\\b(impl)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s+(for)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:<[^>]*>)?",
+          "captures": {
+            "1": { "name": "storage.type.impl.whist" },
+            "2": { "name": "entity.name.type.whist" },
+            "3": { "name": "keyword.other.for.whist" },
+            "4": { "name": "entity.name.type.whist" }
+          }
+        },
+        {
+          "comment": "Inherent impl: impl Type { or impl Type<...> {",
+          "match": "\\b(impl)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:<[^>]*>)?\\s*(?=\\{)",
+          "captures": {
+            "1": { "name": "storage.type.impl.whist" },
+            "2": { "name": "entity.name.type.whist" }
+          }
+        }
+      ]
     },
     "type-declaration": {
       "match": "\\b(type)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:<[^>]*>)?\\s*(=)",
@@ -297,8 +339,16 @@
           "match": "(\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>=|=)"
         },
         {
+          "name": "keyword.operator.variadic.whist",
+          "match": "\\.\\.\\."
+        },
+        {
           "name": "keyword.operator.range.whist",
           "match": "\\.\\."
+        },
+        {
+          "name": "keyword.operator.try.whist",
+          "match": "\\?"
         },
         {
           "name": "keyword.operator.arrow.whist",


### PR DESCRIPTION
## Summary
- Add `test` keyword highlighting
- Add triple-string literal (`"""..."""`) support
- Add try operator (`?`) and variadic (`...`) operator highlighting
- Add inherent impl (`impl Type {`) pattern alongside existing trait impl
- Add builtin generic types (`Option`, `Vec`, `Span`, `StringBuilder`, `Result`)
- Add `_` wildcard highlighting for match patterns

## Test plan
- [ ] Open a `.w` file in VS Code with the extension loaded
- [ ] Verify `test "name" { }` highlights `test` as a keyword
- [ ] Verify triple-string literals are highlighted as strings
- [ ] Verify `?` and `...` are highlighted as operators
- [ ] Verify `impl Point {` highlights both `impl` and `Point`
- [ ] Verify `Option`, `Vec`, etc. are highlighted as builtin types
- [ ] Verify `_` in match arms gets wildcard highlighting