### PR TITLE
feat: implement hex, octal, and \e escape sequences

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -539,20 +539,18 @@ var      while
                | '{' <expression> '}'
 
 <string-char> ::= <any-char-except-quote-or-backslash>
-               | <string-escape-sequence>
+               | <escape-sequence>
 
-<char-literal> ::= '\'' ( <char-char> | <char-escape-sequence> ) '\''
+<char-literal> ::= '\'' ( <char-char> | <escape-sequence> ) '\''
 
 <char-char> ::= <any-char-except-quote-or-backslash>
 
-<string-escape-sequence> ::= '\\' ( 'n' | 't' | 'r' | '0' | '\\' | '\'' | '"' )
-
-<char-escape-sequence> ::= <string-escape-sequence>
-                         | '\\x' <hex-digit> <hex-digit>
-                         | '\\' <octal-digit> [ <octal-digit> [ <octal-digit> ] ]
+<escape-sequence> ::= '\\' ( 'n' | 't' | 'r' | '0' | '\\' | '\'' | '"' | 'e' )
+                   | '\\x' <hex-digit> <hex-digit>
+                   | '\\' <octal-digit> [ <octal-digit> [ <octal-digit> ] ]
 ```
 
-Current bootstrap limitation: string/char semantic decoding only handles simple escapes (`\n`, `\t`, `\r`, `\0`, `\\`, `\'`, `\"`). Hex/octal char escapes are tokenized but not numerically decoded yet.
+`\e` is a shorthand for ESC (0x1b). Hex escapes (`\x41` = 'A') and octal escapes (`\101` = 'A') are supported in both strings and character literals.
 
 **String interpolation:** `$"Hello {name}!"` embeds expressions inside `{...}` braces. Any expression that resolves to a printable type (`i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `bool`, `char`, `string`) can appear inside braces. Use `{{` and `}}` for literal brace characters. Interpolated strings produce a `string` value.
 

--- a/w0/lexer.c
+++ b/w0/lexer.c
@@ -228,10 +228,41 @@ static Token number(Lexer* lexer) {
     return make_token(lexer, type);
 }
 
+// Skip a valid escape sequence after the backslash has been consumed.
+// Returns 0 on success, or an error message string on failure.
+static const char* skip_escape(Lexer* lexer) {
+    char escaped = peek(lexer);
+    if (escaped == 'x') {
+        // Hex escape: \xNN
+        advance(lexer);
+        for (int i = 0; i < 2; i++) {
+            if (!isxdigit(peek(lexer))) {
+                return "Invalid hex escape in string literal";
+            }
+            advance(lexer);
+        }
+        return NULL;
+    } else if (escaped >= '0' && escaped <= '7') {
+        // Octal escape: up to 3 digits
+        for (int i = 0; i < 3 && peek(lexer) >= '0' && peek(lexer) <= '7'; i++) {
+            advance(lexer);
+        }
+        return NULL;
+    } else {
+        // Simple escape: \n, \t, \r, \\, \', \", \e, etc.
+        advance(lexer);
+        return NULL;
+    }
+}
+
 static Token string(Lexer* lexer) {
     while (peek(lexer) != '"' && !is_at_end(lexer)) {
         if (peek(lexer) == '\\' && peek_next(lexer) != '\0') {
             advance(lexer); // skip backslash
+            const char* err = skip_escape(lexer);
+            if (err)
+                return error_token(lexer, err);
+            continue;
         }
         advance(lexer);
     }
@@ -255,6 +286,10 @@ static Token triple_string(Lexer* lexer) {
         }
         if (peek(lexer) == '\\' && peek_next(lexer) != '\0') {
             advance(lexer); // skip backslash
+            const char* err = skip_escape(lexer);
+            if (err)
+                return error_token(lexer, err);
+            continue;
         }
         advance(lexer);
     }
@@ -288,6 +323,10 @@ static Token interp_string(Lexer* lexer) {
             }
             if (c == '\\' && peek_next(lexer) != '\0') {
                 advance(lexer); // skip backslash
+                const char* err = skip_escape(lexer);
+                if (err)
+                    return error_token(lexer, err);
+                continue;
             }
             advance(lexer);
         } else {

--- a/w0/parser_expr.c
+++ b/w0/parser_expr.c
@@ -6,23 +6,72 @@
 #include "alloc.h"
 #include "parser_internal.h"
 
-static char decode_escape(char c) {
+// Decode an escape sequence starting at *src (just past the backslash).
+// Advances *src past the consumed escape characters. Returns the decoded char value.
+static char decode_escape(const char** src, const char* end) {
+    char c = **src;
     switch (c) {
     case 'n':
+        (*src)++;
         return '\n';
     case 't':
+        (*src)++;
         return '\t';
     case 'r':
+        (*src)++;
         return '\r';
-    case '0':
-        return '\0';
     case '\\':
+        (*src)++;
         return '\\';
     case '"':
+        (*src)++;
         return '"';
     case '\'':
+        (*src)++;
         return '\'';
+    case 'e':
+        (*src)++;
+        return '\x1b';
+    case 'x': {
+        // Hex escape: \xNN
+        (*src)++; // skip 'x'
+        int value = 0;
+        for (int i = 0; i < 2 && *src < end; i++) {
+            char h = **src;
+            if (h >= '0' && h <= '9')
+                value = value * 16 + (h - '0');
+            else if (h >= 'a' && h <= 'f')
+                value = value * 16 + (h - 'a' + 10);
+            else if (h >= 'A' && h <= 'F')
+                value = value * 16 + (h - 'A' + 10);
+            else
+                break;
+            (*src)++;
+        }
+        return (char)value;
+    }
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7': {
+        // Octal escape: up to 3 digits
+        int value = 0;
+        for (int i = 0; i < 3 && *src < end; i++) {
+            char o = **src;
+            if (o >= '0' && o <= '7')
+                value = value * 8 + (o - '0');
+            else
+                break;
+            (*src)++;
+        }
+        return (char)value;
+    }
     default:
+        (*src)++;
         return c;
     }
 }
@@ -142,8 +191,7 @@ static Node* parse_interp_string(Parser* parser) {
         if (*src == '\\' && src + 1 < end) {
             // Escape sequence in text
             src++;
-            buf[buf_len++] = decode_escape(*src);
-            src++;
+            buf[buf_len++] = decode_escape(&src, end);
         } else if (*src == '{') {
             if (src + 1 < end && src[1] == '{') {
                 // Escaped brace: {{ -> literal {
@@ -309,7 +357,7 @@ static Node* parse_string_lit(Token token) {
     while (src < end) {
         if (*src == '\\' && src + 1 < end) {
             src++;
-            raw[raw_len++] = decode_escape(*src++);
+            raw[raw_len++] = decode_escape(&src, end);
         } else {
             raw[raw_len++] = *src++;
         }
@@ -392,7 +440,9 @@ static Node* parse_string_lit(Token token) {
 static Node* parse_char_lit(Token token) {
     Node* node = node_new(NODE_CHAR_LIT, token.line, token.column);
     if (token.start[1] == '\\') {
-        node->as.char_lit.value = decode_escape(token.start[2]);
+        const char* src = token.start + 2;
+        const char* end = token.start + token.length - 1; // before closing '
+        node->as.char_lit.value = decode_escape(&src, end);
     } else {
         node->as.char_lit.value = token.start[1];
     }

--- a/w0/test/errors/error_invalid_hex_escape_string.w
+++ b/w0/test/errors/error_invalid_hex_escape_string.w
@@ -1,0 +1,7 @@
+// ERROR TEST: Invalid hex escape in string literal
+// Expected error: Invalid hex escape in string literal
+
+func main(): i32 {
+    var s: string = "\xGG";
+    return 0;
+}

--- a/w0/test/run/basics/char_escapes.w
+++ b/w0/test/run/basics/char_escapes.w
@@ -1,5 +1,5 @@
 // Test character escape sequences
-// Expected exit: 1
+// Expected exit: 0
 
 func main(): i32 {
     // Simple escapes
@@ -10,6 +10,7 @@ func main(): i32 {
     var single_quote: char = '\'';
     var double_quote: char = '\"';
     var null_char: char = '\0';
+    var esc: char = '\e';
 
     // Hex escapes
     var hex_A: char = '\x41';      // 'A'
@@ -23,8 +24,20 @@ func main(): i32 {
     var regular: char = 'X';
 
     // Verify hex escape produces correct value
-    if (hex_A == 'A') {
-        return 0;
+    if (hex_A != 'A') {
+        return 1;
     }
-    return 1;
+    // Verify octal escape produces correct value
+    if (octal_A != 'A') {
+        return 2;
+    }
+    // Verify \e produces ESC (0x1b = 27)
+    if (esc != '\x1b') {
+        return 3;
+    }
+    // Verify hex newline matches simple escape
+    if (hex_newline != '\n') {
+        return 4;
+    }
+    return 0;
 }

--- a/w0/test/run/strings/string_hex_escape.w
+++ b/w0/test/run/strings/string_hex_escape.w
@@ -1,0 +1,31 @@
+// Test hex, octal, and \e escape sequences in strings
+// Expected exit: 0
+
+func main(): i32 {
+    // Hex escape in string
+    var hex_str: string = "\x41\x42\x43";
+    if (hex_str != "ABC") {
+        return 1;
+    }
+
+    // Octal escape in string
+    var octal_str: string = "\101\102\103";
+    if (octal_str != "ABC") {
+        return 2;
+    }
+
+    // \e escape (ESC = 0x1b)
+    var esc_str: string = "\e[31m";
+    var hex_esc_str: string = "\x1b[31m";
+    if (esc_str != hex_esc_str) {
+        return 3;
+    }
+
+    // Mixed escapes
+    var mixed: string = "\x48ello\n";
+    if (mixed != "Hello\n") {
+        return 4;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Refactored `decode_escape` in `parser_expr.c` from single-char to pointer-based to handle `\xNN` (hex), `\NNN` (octal), and `\e` (ESC) escape sequences in strings, interpolated strings, and char literals
- Added `skip_escape()` validation to lexer `string()`, `triple_string()`, and `interp_string()` so invalid hex escapes like `"\xGG"` are caught at lex time
- Unified grammar escape sequence rules (`<string-escape-sequence>` + `<char-escape-sequence>` → single `<escape-sequence>`) and removed bootstrap limitation note

Closes #261

## Test plan

- [x] `make` builds cleanly
- [x] `make test` — all 229 tests pass
- [x] Existing `char_escapes.w` updated: now expects exit 0 (hex/octal/`\e` assertions)
- [x] New `string_hex_escape.w` tests hex, octal, and `\e` in strings
- [x] New `error_invalid_hex_escape_string.w` tests `"\xGG"` lexer error