### PR TITLE
feat: use compound assignment operators and add missing tests

### DIFF
--- a/w0/test/errors/error_compound_assign_type.w
+++ b/w0/test/errors/error_compound_assign_type.w
@@ -1,0 +1,7 @@
+// Expected error: Invalid operands for compound assignment
+
+func main(): i32 {
+    var s = "hello";
+    s += " world";
+    return 0;
+}

--- a/w0/test/run/basics/basics.w
+++ b/w0/test/run/basics/basics.w
@@ -2,6 +2,7 @@
 // Expected: PASS: variables
 // Expected: PASS: integers
 // Expected: PASS: operators
+// Expected: PASS: bitwise_assign
 // Expected: PASS: shift_assign
 // Expected: PASS: control_flow
 // Expected: PASS: functions
@@ -127,6 +128,25 @@ test "operators" {
     a /= 2;
 
     assert(a == 19);
+}
+
+// Test modulo, bitwise compound assignment operators
+test "bitwise_assign" {
+    var a: i64 = 17;
+    a %= 5;
+    assert(a == 2);
+
+    var b: i64 = 0xFF;
+    b &= 0x0F;
+    assert(b == 0x0F);
+
+    var c: i64 = 0x0F;
+    c |= 0xF0;
+    assert(c == 0xFF);
+
+    var d: i64 = 0xFF;
+    d ^= 0x0F;
+    assert(d == 0xF0);
 }
 
 // Test shift assignment operators <<= and >>=

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -123,7 +123,7 @@ func check_rc_free_order(stderr: string, expected: string): bool {
                     right_pos = pos;
                 }
             }
-            pos = pos + 1;
+            pos += 1;
         }
     }
 
@@ -156,7 +156,7 @@ func pad_right(s: string, width: i64): string {
     var i = s.length();
     while (i < width) {
         sb.append(" ");
-        i = i + 1;
+        i += 1;
     }
     return sb.to_string();
 }
@@ -483,11 +483,11 @@ func main(): i32 {
                 match (run_test_block_file(file, w0, lib_path, verbose)) {
                     Ok(_) => {
                         std::println(" " + ansi("1;32") + "PASS" + ansi("0"));
-                        run_passed = run_passed + 1;
+                        run_passed += 1;
                     }
                     Err(msg) => {
                         std::println(" " + ansi("1;31") + "FAIL (" + msg + ")" + ansi("0"));
-                        run_failed = run_failed + 1;
+                        run_failed += 1;
                     }
                 }
             } else if (has_main) {
@@ -495,18 +495,18 @@ func main(): i32 {
                 match (run_program_test(file, w0, lib_path, verbose)) {
                     Ok(_) => {
                         std::println(" " + ansi("1;32") + "PASS" + ansi("0"));
-                        run_passed = run_passed + 1;
+                        run_passed += 1;
                     }
                     Err(msg) => {
                         std::println(" " + ansi("1;31") + "FAIL (" + msg + ")" + ansi("0"));
-                        run_failed = run_failed + 1;
+                        run_failed += 1;
                     }
                 }
             } else {
                 if (verbose) {
                     std::println(ansi("90") + $"{disp}: SKIP (helper module)" + ansi("0"));
                 }
-                run_skipped = run_skipped + 1;
+                run_skipped += 1;
             }
         }
         std::println("");
@@ -530,11 +530,11 @@ func main(): i32 {
                     if (actual != "") {
                         std::println("  " + ansi("90") + actual + ansi("0"));
                     }
-                    error_passed = error_passed + 1;
+                    error_passed += 1;
                 }
                 Err(msg) => {
                     std::println(" " + ansi("1;31") + "FAIL (" + msg + ")" + ansi("0"));
-                    error_failed = error_failed + 1;
+                    error_failed += 1;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace 9 instances of `x = x + 1` with `x += 1` in `tools/test_runner.w` (dogfooding gap)
- Add `bitwise_assign` test covering `%=`, `&=`, `|=`, `^=` in `test/run/basics/basics.w`
- Add error test for compound assignment on non-numeric types (`s += " world"`)

Closes #262

## Test plan
- [x] `make test` — 230/230 tests pass
- [x] `make test-whist` — 230/230 tests pass (test runner compiles and runs with `+=` changes)