### PR TITLE
feat: add Set collection type (#264)

### DIFF
--- a/lib/collections.w
+++ b/lib/collections.w
@@ -209,3 +209,105 @@ func (const Vec<T>) filter(pred: func(T) :bool): Vec<T> {
     }
     return result;
 }
+
+// --- Set ---
+
+struct SetEntry<T: Hashable> {
+    next: SetEntry<T>,
+    key: T,
+}
+
+struct Set<T: Hashable> {
+    buckets: Vec<SetEntry<T>>,
+    count: i64,
+    capacity: i64,
+}
+
+func (Set<T>) init(cap: i64): void {
+    self.buckets.clear();
+    self.count = 0;
+    self.capacity = cap;
+    foreach (const i in 0..cap) {
+        self.buckets.push(null);
+    }
+}
+
+func (Set<T>) insert(value: T): void {
+    var h: i32 = value.hash();
+    if (h < 0) {
+        h = -h;
+    }
+    var index: i64 = h % self.capacity;
+
+    // Check if value already exists
+    var entry: SetEntry<T> = self.buckets[index];
+    while (entry != null) {
+        if (entry.key == value) {
+            return;
+        }
+        entry = entry.next;
+    }
+
+    // Not found, insert at head of bucket
+    var new_entry: SetEntry<T> = new SetEntry<T>{
+        next: self.buckets[index],
+        key: value,
+    };
+    self.buckets[index] = new_entry;
+    self.count = self.count + 1;
+}
+
+func (Set<T>) contains(value: T): bool {
+    var h: i32 = value.hash();
+    if (h < 0) {
+        h = -h;
+    }
+    var index: i64 = h % self.capacity;
+
+    var entry: SetEntry<T> = self.buckets[index];
+    while (entry != null) {
+        if (entry.key == value) {
+            return true;
+        }
+        entry = entry.next;
+    }
+    return false;
+}
+
+func (Set<T>) remove(value: T): bool {
+    var h: i32 = value.hash();
+    if (h < 0) {
+        h = -h;
+    }
+    var index: i64 = h % self.capacity;
+
+    var entry: SetEntry<T> = self.buckets[index];
+    var prev: SetEntry<T> = null;
+
+    while (entry != null) {
+        if (entry.key == value) {
+            if (prev == null) {
+                self.buckets[index] = entry.next;
+            } else {
+                prev.next = entry.next;
+            }
+            self.count = self.count - 1;
+            return true;
+        }
+        prev = entry;
+        entry = entry.next;
+    }
+    return false;
+}
+
+func (Set<T>) values(): Vec<T> {
+    var result = new Vec<T>{};
+    foreach (const i in 0..self.capacity) {
+        var entry: SetEntry<T> = self.buckets[i];
+        while (entry != null) {
+            result.push(entry.key);
+            entry = entry.next;
+        }
+    }
+    return result;
+}

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -651,6 +651,29 @@ static void emit_var_decl_rc_new_struct(CodeGen* gen, Node* node) {
                 // Vec index read of RC element — inc the borrowed reference
                 emit_indent(gen);
                 emit(gen, "__rc_inc(%s->%s);\n", node->as.var_decl.name, field->as.field_init.name);
+            } else if (val->type == NODE_IDENT && !rc_is_tracked(gen, val->as.ident.name)) {
+                // Untracked ident (e.g. function parameter) — check if the struct
+                // field type is RC-managed and inc if so
+                const char* fname = field->as.field_init.name;
+                for (int j = 0; j < rtype->as.struc.field_count; j++) {
+                    if (strcmp(rtype->as.struc.field_names[j], fname) == 0) {
+                        Type* ftype = rtype->as.struc.field_types[j];
+                        if (ftype && (ftype->kind == TYPE_STRING || ftype->kind == TYPE_STRUCT ||
+                                      ftype->kind == TYPE_VEC ||
+                                      (ftype->kind == TYPE_ENUM && ftype->as.enm.has_rc_fields))) {
+                            const char* inc_fn = get_inc_func_for_type(ftype);
+                            emit_indent(gen);
+                            if (ftype->kind == TYPE_STRING) {
+                                emit(gen, "%s((void*)%s->%s);\n", inc_fn, node->as.var_decl.name,
+                                     fname);
+                            } else {
+                                emit(gen, "%s(%s->%s);\n", inc_fn, node->as.var_decl.name, fname);
+                            }
+                            free((char*)inc_fn);
+                        }
+                        break;
+                    }
+                }
             }
         }
     }

--- a/w0/test/run/collections/collections_set.w
+++ b/w0/test/run/collections/collections_set.w
@@ -1,0 +1,95 @@
+// Expected: PASS: collections_set
+import collections;
+
+test "collections_set" {
+    // Test string set
+    var s = new Set<string>{
+        buckets: new Vec<SetEntry<string>>{},
+        count: 0, capacity: 0,
+    };
+    s.init(16);
+
+    // Test insert and contains
+    s.insert("hello");
+    s.insert("world");
+    s.insert("foo");
+
+    assert(s.count == 3);
+    assert(s.contains("hello"));
+    assert(s.contains("world"));
+    assert(s.contains("foo"));
+    assert(!s.contains("bar"));
+
+    // Test duplicate insert (no-op)
+    s.insert("hello");
+    assert(s.count == 3);
+
+    // Test remove
+    var removed = s.remove("world");
+    assert(removed);
+    assert(s.count == 2);
+    assert(!s.contains("world"));
+
+    // Test remove non-existent
+    var removed2 = s.remove("nonexistent");
+    assert(!removed2);
+    assert(s.count == 2);
+
+    // Test values
+    var vals = s.values();
+    assert(vals.count == 2);
+
+    // Test i64 set
+    var s2 = new Set<i64>{
+        buckets: new Vec<SetEntry<i64>>{},
+        count: 0, capacity: 0,
+    };
+    s2.init(8);
+
+    s2.insert(100);
+    s2.insert(200);
+    s2.insert(300);
+
+    assert(s2.count == 3);
+    assert(s2.contains(100));
+    assert(s2.contains(200));
+    assert(s2.contains(300));
+    assert(!s2.contains(400));
+
+    // Duplicate
+    s2.insert(200);
+    assert(s2.count == 3);
+
+    // Remove
+    s2.remove(200);
+    assert(!s2.contains(200));
+    assert(s2.count == 2);
+
+    // Test hash collisions via small capacity
+    var s3 = new Set<i64>{
+        buckets: new Vec<SetEntry<i64>>{},
+        count: 0, capacity: 0,
+    };
+    s3.init(2);
+
+    s3.insert(1);
+    s3.insert(2);
+    s3.insert(3);
+    s3.insert(4);
+
+    assert(s3.count == 4);
+    assert(s3.contains(1));
+    assert(s3.contains(2));
+    assert(s3.contains(3));
+    assert(s3.contains(4));
+
+    // Remove from collision chain
+    s3.remove(3);
+    assert(s3.count == 3);
+    assert(!s3.contains(3));
+    assert(s3.contains(1));
+    assert(s3.contains(4));
+
+    var vals3 = s3.values();
+    assert(vals3.count == 3);
+}

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -56,14 +56,31 @@ func extract_rc_addresses(output: string, prefix: string): Vec<string> {
     return addrs;
 }
 
+func build_address_set(addrs: Vec<string>): Set<string> {
+    var s = new Set<string>{
+        buckets: new Vec<SetEntry<string>>{},
+        count: 0, capacity: 0,
+    };
+    var cap: i64 = 64;
+    if (addrs.count > cap) {
+        cap = addrs.count * 2;
+    }
+    s.init(cap);
+    foreach (const addr in addrs) {
+        s.insert(addr);
+    }
+    return s;
+}
+
 func check_rc_leaks(stderr: string): bool {
     var allocs = extract_rc_addresses(stderr, "RC_ALLOC:");
     var frees = extract_rc_addresses(stderr, "RC_FREE:");
     if (allocs.count == 0) {
         return true;
     }
+    var free_set = build_address_set(frees);
     foreach (const addr in allocs) {
-        if (!frees.contains(addr)) {
+        if (!free_set.contains(addr)) {
             return false;
         }
     }
@@ -73,9 +90,10 @@ func check_rc_leaks(stderr: string): bool {
 func get_leaked_addresses(stderr: string): Vec<string> {
     var allocs = extract_rc_addresses(stderr, "RC_ALLOC:");
     var frees = extract_rc_addresses(stderr, "RC_FREE:");
+    var free_set = build_address_set(frees);
     var leaked = new Vec<string>{};
     foreach (const addr in allocs) {
-        if (!frees.contains(addr)) {
+        if (!free_set.contains(addr)) {
             leaked.push(addr);
         }
     }


### PR DESCRIPTION
## Summary
- Add `Set<T: Hashable>` to `lib/collections.w` with `init`, `insert`, `contains`, `remove`, and `values` methods — mirrors HashMap's chained-bucket pattern
- Use `Set<string>` in the test runner's `check_rc_leaks` / `get_leaked_addresses` for O(1) lookup instead of O(n) `Vec.contains`, fixing the O(n²) performance issue
- Fix a codegen bug in `emit_var_decl_rc_new_struct` where `new Struct{field: param}` with an untracked RC identifier (e.g. function parameter) didn't emit `__rc_inc`, causing use-after-free when the struct's cleanup decremented the field

Closes #264

## Test plan
- [x] `make && make test` — all 236 tests pass (including new `collections_set.w`)
- [x] `make test-whist` — Whist test runner (now using Set) passes all 236 tests
- [x] New test covers string/i64 element types, duplicate insert, remove non-existent, hash collisions via small capacity