### PR TITLE
feat: improve test_runner dogfooding

### DIFF
--- a/lib/collections.w
+++ b/lib/collections.w
@@ -174,49 +174,6 @@ func (HashMap<K, V>) keys(): Vec<K> {
     return result;
 }
 
-func (const Vec<T>) any(pred: func(T) :bool): bool {
-    foreach (const elem in self) {
-        if (pred(elem)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-func (const Vec<T>) all(pred: func(T) :bool): bool {
-    foreach (const elem in self) {
-        if (!pred(elem)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-func (const Vec<T>) map<K>(transform: func(T) :K): Vec<K> {
-    var result = new Vec<K>{};
-    foreach (const elem in self) {
-        result.push(transform(elem));
-    }
-    return result;
-}
-
-func (const Vec<T>) filter(pred: func(T) :bool): Vec<T> {
-    var result = new Vec<T>{};
-    foreach (const elem in self) {
-        if (pred(elem)) {
-            result.push(elem);
-        }
-    }
-    return result;
-}
-
-func (const Vec<T>) each<K>(f: func(T) :K): const Vec<T> {
-    foreach (const elem in self) {
-        f(elem);
-    }
-    return self;
-}
-
 // --- Set ---
 
 struct SetEntry<T: Hashable> {

--- a/lib/prelude.w
+++ b/lib/prelude.w
@@ -158,3 +158,47 @@ trait Drop {
 trait Eq {
     func eq(other: Self): bool;
 }
+
+// --- Vec extension methods ---
+
+func (const Vec<T>) any(pred: func(T) :bool): bool {
+    foreach (const elem in self) {
+        if (pred(elem)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+func (const Vec<T>) all(pred: func(T) :bool): bool {
+    foreach (const elem in self) {
+        if (!pred(elem)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+func (const Vec<T>) map<K>(transform: func(T) :K): Vec<K> {
+    var result = new Vec<K>{};
+    foreach (const elem in self) {
+        result.push(transform(elem));
+    }
+    return result;
+}
+
+func (const Vec<T>) filter(pred: func(T) :bool): Vec<T> {
+    var result = new Vec<T>{};
+    foreach (const elem in self) {
+        if (pred(elem)) {
+            result.push(elem);
+        }
+    }
+    return result;
+}
+
+func (const Vec<T>) each(f: func(T) :void): void {
+    foreach (const elem in self) {
+        f(elem);
+    }
+}

--- a/w0/test/run/collections/vec_map.w
+++ b/w0/test/run/collections/vec_map.w
@@ -1,6 +1,7 @@
 // Expected: PASS: vec_map_basic
 // Expected: PASS: vec_map_type_transform
 // Expected: PASS: vec_filter_basic
+// Expected: PASS: vec_each_basic
 
 import collections;
 
@@ -51,17 +52,19 @@ test "vec_filter_basic" {
     assert(evens[1] == 4);
 }
 
-test "vec_filtervec_each_basic" {
+test "vec_each_basic" {
     var nums = new Vec<i64>{};
     nums.push(1);
     nums.push(2);
     nums.push(3);
     nums.push(4);
     nums.push(5);
-    var count = 0;
 
-    var evens = nums.each(|x| count += 1);
-    assert(count == 5);
+    var collected = new Vec<i64>{};
+    nums.each(|x| collected.push(x));
+    assert(collected.count == 5);
+    assert(collected[0] == 1);
+    assert(collected[4] == 5);
 }
 
 func main(): i32 {

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -58,22 +58,12 @@ func ansi(code: string): string {
 
 func extract_rc_addresses(output: string, prefix: string): Vec<string> {
     var addrs = new Vec<string>{};
-
     output.split("\n").filter(|line| line.starts_with(prefix)).each(|line| {
         var parts = line.split(" ");
         if (parts.count > 1) {
             addrs.push(parts[1]);
         }
     });
-
-    foreach (const line in output.split("\n")) {
-        if (line.starts_with(prefix)) {
-            var parts = line.split(" ");
-            if (parts.count > 1) {
-                addrs.push(parts[1]);
-            }
-        }
-    }
     addrs.sort();
     return addrs;
 }


### PR DESCRIPTION
## Summary
- Replace all string concatenations in `test_runner.w` with string interpolation (`$"..."`)
- Add named color helper functions (`red`, `green`, `blue`, `cyan`, `yellow`, `gray`) using `\e` escape sequences
- Simplify `ansi()` to use `\e` escape and interpolation
- Add `Vec.each()` method and use `.filter().each()` chain in test_runner
- Move Vec extension methods (`map`, `filter`, `any`, `all`, `each`) from `collections.w` to `prelude.w` — Vec is a builtin type so these should be available without explicit import
- Fix `each` to return `void` instead of `const Vec<T>` (avoids RC leak from returning borrowed self)
- Fix `each` test to use Vec capture instead of scalar increment (lambdas capture by value)
- Remove duplicate extraction loop in test_runner

## Test plan
- [x] All 237 tests pass via `make test` (shell runner)
- [x] All 237 tests pass via `make test-whist` (Whist runner)
