### PR TITLE
feat: add private struct fields

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -100,7 +100,7 @@ as compatible (no deep/shallow immutability distinction yet).
 
 <type-param> ::= <identifier> [ ':' <identifier> ]
 
-<field-decl> ::= [ 'const' ] <identifier> ':' <type> [ ',' ]
+<field-decl> ::= [ 'private' ] [ 'const' ] <identifier> ':' <type> [ ',' ]
 ```
 
 **Generic structs:** Structs can be parameterized by one or more type parameters:

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -805,6 +805,7 @@ Node* node_clone(Node* node) {
         c->as.field.name_length = node->as.field.name_length;
         c->as.field.type        = node_clone(node->as.field.type);
         c->as.field.is_const    = node->as.field.is_const;
+        c->as.field.is_private  = node->as.field.is_private;
         break;
     default:
         fprintf(stderr, "node_clone: unhandled node type %d\n", node->type);

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -516,6 +516,7 @@ struct Node {
             int   name_length;
             Node* type;
             int   is_const;
+            int   is_private;
         } field;
 
         // Enum declaration

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -139,6 +139,7 @@ void checker_init(Checker* checker) {
     checker->enum_target_hint               = NULL;
     checker->expected_func_type             = NULL;
     checker->self_type                      = NULL;
+    checker->current_method_receiver        = NULL;
     checker->lambda_next_id                 = 0;
     checker->lambda_depth                   = 0;
     checker->lambda_stack                   = NULL;
@@ -1766,9 +1767,11 @@ static void check_func_decl(Checker* checker, Node* node) {
     checker->modules.current_accessible_modules = fdn->accessible_modules;
     checker->modules.current_accessible_modules_count = fdn->accessible_modules_count;
 
-    // For methods, inject 'self' into scope.
+    // For methods, inject 'self' into scope and set private field access context.
+    const char* old_receiver = checker->current_method_receiver;
     if (is_method) {
         define_method_self_symbol(checker, receiver_type, fdn->receiver_is_const);
+        checker->current_method_receiver = receiver_type;
     }
 
     define_func_params_in_scope(checker, fdn, func_type);
@@ -1778,7 +1781,8 @@ static void check_func_decl(Checker* checker, Node* node) {
     checker->modules.current_accessible_modules       = old_accessible_modules;
     checker->modules.current_accessible_modules_count = old_accessible_modules_count;
 
-    checker->current_func_return = old_return;
+    checker->current_method_receiver = old_receiver;
+    checker->current_func_return     = old_return;
     checker_pop_scope(checker);
     free(mangled_name);
 }
@@ -1811,16 +1815,18 @@ static void check_struct_decl(Checker* checker, Node* node) {
     Type* struct_type = type_struct(name);
     int   field_count = node->as.struct_decl.fields.count;
 
-    struct_type->as.struc.field_count    = field_count;
-    struct_type->as.struc.field_names    = xmalloc(field_count * sizeof(char*));
-    struct_type->as.struc.field_types    = xmalloc(field_count * sizeof(Type*));
-    struct_type->as.struc.field_is_const = xmalloc(field_count * sizeof(int));
+    struct_type->as.struc.field_count      = field_count;
+    struct_type->as.struc.field_names      = xmalloc(field_count * sizeof(char*));
+    struct_type->as.struc.field_types      = xmalloc(field_count * sizeof(Type*));
+    struct_type->as.struc.field_is_const   = xmalloc(field_count * sizeof(int));
+    struct_type->as.struc.field_is_private = xmalloc(field_count * sizeof(int));
 
     for (int i = 0; i < field_count; i++) {
-        Node* field                             = node->as.struct_decl.fields.nodes[i];
-        struct_type->as.struc.field_names[i]    = xstrdup(field->as.field.name);
-        struct_type->as.struc.field_types[i]    = resolve_type(checker, field->as.field.type);
-        struct_type->as.struc.field_is_const[i] = field->as.field.is_const;
+        Node* field                               = node->as.struct_decl.fields.nodes[i];
+        struct_type->as.struc.field_names[i]      = xstrdup(field->as.field.name);
+        struct_type->as.struc.field_types[i]      = resolve_type(checker, field->as.field.type);
+        struct_type->as.struc.field_is_const[i]   = field->as.field.is_const;
+        struct_type->as.struc.field_is_private[i] = field->as.field.is_private;
     }
 
     // Check if any field is an RC-managed type (struct, Vec, or enum with RC fields)

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -219,6 +219,9 @@ struct Checker {
     // concrete implementing type in impl blocks; NULL otherwise.
     Type* self_type;
 
+    // Private field access: base type name of receiver when inside a method
+    const char* current_method_receiver;
+
     // Lambda tracking
     int    lambda_next_id; // Next lambda ID (monotonically increasing)
     int    lambda_depth;   // >0 when inside a lambda body

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -787,6 +787,15 @@ static Type* check_member_struct(Checker* checker, Node* node, Type* object) {
     // Find field first
     for (int i = 0; i < object->as.struc.field_count; i++) {
         if (strcmp(object->as.struc.field_names[i], member_name) == 0) {
+            // Check private field access
+            if (object->as.struc.field_is_private && object->as.struc.field_is_private[i]) {
+                if (!checker->current_method_receiver ||
+                    strcmp(object->as.struc.base_name, checker->current_method_receiver) != 0) {
+                    check_error(checker, node->line, node->column, "Field '%s' is private",
+                                member_name);
+                    return type_error;
+                }
+            }
             int object_is_const = 0;
             if (node->as.member.object->type == NODE_IDENT) {
                 Symbol* sym     = checker_lookup(checker, node->as.member.object->as.ident.name);
@@ -2580,6 +2589,18 @@ static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type) 
                         struct_type->as.struc.name, field_name);
             had_error = 1;
             continue;
+        }
+
+        // Check private field access in struct init
+        if (struct_type->as.struc.field_is_private &&
+            struct_type->as.struc.field_is_private[field_index]) {
+            if (!checker->current_method_receiver ||
+                strcmp(struct_type->as.struc.base_name, checker->current_method_receiver) != 0) {
+                check_error(checker, field->line, field->column, "Field '%s' is private",
+                            field_name);
+                had_error = 1;
+                continue;
+            }
         }
 
         if (seen[field_index]) {

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -1123,6 +1123,9 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
     // Instantiate: create a new TYPE_STRUCT with substituted field types
     Type* struct_type = type_struct(mangled);
 
+    // Set base_name for generic instances (e.g. "Set" for "Set_i64")
+    struct_type->as.struc.base_name = xstrdup(base_name);
+
     // Register early to handle recursive types
     register_generic_instance(checker, mangled, base_name, struct_type, resolved_args, arg_count);
 
@@ -1139,16 +1142,18 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
     Node* decl        = def->decl;
     int   field_count = decl->as.struct_decl.fields.count;
 
-    struct_type->as.struc.field_count    = field_count;
-    struct_type->as.struc.field_names    = xmalloc(field_count * sizeof(char*));
-    struct_type->as.struc.field_types    = xmalloc(field_count * sizeof(Type*));
-    struct_type->as.struc.field_is_const = xmalloc(field_count * sizeof(int));
+    struct_type->as.struc.field_count      = field_count;
+    struct_type->as.struc.field_names      = xmalloc(field_count * sizeof(char*));
+    struct_type->as.struc.field_types      = xmalloc(field_count * sizeof(Type*));
+    struct_type->as.struc.field_is_const   = xmalloc(field_count * sizeof(int));
+    struct_type->as.struc.field_is_private = xmalloc(field_count * sizeof(int));
 
     for (int i = 0; i < field_count; i++) {
-        Node* field                             = decl->as.struct_decl.fields.nodes[i];
-        struct_type->as.struc.field_names[i]    = xstrdup(field->as.field.name);
-        struct_type->as.struc.field_types[i]    = resolve_type(checker, field->as.field.type);
-        struct_type->as.struc.field_is_const[i] = field->as.field.is_const;
+        Node* field                               = decl->as.struct_decl.fields.nodes[i];
+        struct_type->as.struc.field_names[i]      = xstrdup(field->as.field.name);
+        struct_type->as.struc.field_types[i]      = resolve_type(checker, field->as.field.type);
+        struct_type->as.struc.field_is_const[i]   = field->as.field.is_const;
+        struct_type->as.struc.field_is_private[i] = field->as.field.is_private;
     }
 
     // Check if any field is an RC-managed type (struct, Vec, or enum with RC fields)
@@ -1263,6 +1268,10 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
             checker->modules.current_accessible_modules       = mfdn->accessible_modules;
             checker->modules.current_accessible_modules_count = mfdn->accessible_modules_count;
 
+            // Set private field access context for generic method body
+            const char* old_receiver         = checker->current_method_receiver;
+            checker->current_method_receiver = base_name;
+
             // Inject 'self' into scope
             checker_define(checker, "self", SYM_VAR, struct_type, mfdn->receiver_is_const, 0, NULL);
 
@@ -1280,6 +1289,7 @@ static Type* instantiate_generic_struct(Checker* checker, Node* type_node, Gener
 
             checker->modules.current_accessible_modules       = old_accessible_modules;
             checker->modules.current_accessible_modules_count = old_accessible_modules_count;
+            checker->current_method_receiver                  = old_receiver;
             checker->current_func_return                      = old_return;
             checker_pop_scope(checker);
         }

--- a/w0/parser_decl.c
+++ b/w0/parser_decl.c
@@ -249,6 +249,11 @@ static Node* parse_struct_decl(Parser* parser, int is_public) {
     consume_token(parser, TOK_LBRACE, "Expected '{' after struct name");
 
     while (!check_token(parser, TOK_RBRACE) && !check_token(parser, TOK_EOF)) {
+        int field_is_private = 0;
+        if (match_token(parser, TOK_PRIVATE)) {
+            field_is_private = 1;
+        }
+
         int field_is_const = 0;
         if (match_token(parser, TOK_CONST)) {
             field_is_const = 1;
@@ -261,6 +266,7 @@ static Node* parse_struct_decl(Parser* parser, int is_public) {
         field->as.field.name        = copy_token_string(&field_name);
         field->as.field.name_length = field_name.length;
         field->as.field.is_const    = field_is_const;
+        field->as.field.is_private  = field_is_private;
 
         consume_token(parser, TOK_COLON, "Expected ':' after field name");
         field->as.field.type = parse_type(parser);

--- a/w0/test/errors/error_private_field_init.w
+++ b/w0/test/errors/error_private_field_init.w
@@ -1,0 +1,16 @@
+// ERROR TEST: initializing private field from outside
+// Expected error: Field 'secret' is private
+
+struct Wrapper {
+    public_val: i64,
+    private secret: i64,
+}
+
+func (Wrapper) get_secret() -> i64 {
+    return self.secret;
+}
+
+func main() -> i32 {
+    var w = new Wrapper{public_val: 1, secret: 42};
+    return 0;
+}

--- a/w0/test/errors/error_private_field_read.w
+++ b/w0/test/errors/error_private_field_read.w
@@ -1,0 +1,13 @@
+// ERROR TEST: accessing private field from outside
+// Expected error: Field 'count' is private
+
+struct Counter {
+    private count: i64,
+    value: i64,
+}
+
+func main() -> i32 {
+    var c = new Counter{count: 0, value: 1};
+    var x = c.count;
+    return 0;
+}

--- a/w0/test/errors/error_private_field_write.w
+++ b/w0/test/errors/error_private_field_write.w
@@ -1,0 +1,12 @@
+// ERROR TEST: assigning to private field from outside
+// Expected error: Field 'count' is private
+
+struct Counter {
+    private count: i64,
+}
+
+func main() -> i32 {
+    var c = new Counter{count: 0};
+    c.count = 5;
+    return 0;
+}

--- a/w0/test/valid/private_fields.w
+++ b/w0/test/valid/private_fields.w
@@ -1,0 +1,33 @@
+// Valid test: private fields accessible within methods and impl blocks
+
+struct Counter {
+    private count: i64,
+}
+
+impl Counter {
+    func init(initial: i64) {
+        self.count = initial;
+    }
+}
+
+func (Counter) get() -> i64 {
+    return self.count;
+}
+
+func (Counter) increment() -> void {
+    self.count = self.count + 1;
+}
+
+impl Counter {
+    func reset() -> void {
+        self.count = 0;
+    }
+}
+
+func main() -> i32 {
+    var c = new Counter(10);
+    c.increment();
+    c.reset();
+    var val = c.get();
+    return 0;
+}

--- a/w0/test/valid/private_fields_generic.w
+++ b/w0/test/valid/private_fields_generic.w
@@ -1,0 +1,21 @@
+// Valid test: private fields on generic structs accessible from methods
+
+struct Container<T> {
+    private data: T,
+}
+
+impl Container<T> {
+    func init(val: T) {
+        self.data = val;
+    }
+}
+
+func (Container<T>) get() -> T {
+    return self.data;
+}
+
+func main() -> i32 {
+    var c = new Container<i64>(42);
+    var val = c.get();
+    return 0;
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -84,16 +84,18 @@ Type* type_array(Type* elem, int size) {
 }
 
 Type* type_struct(const char* name) {
-    Type* type                     = type_new(TYPE_STRUCT);
-    type->as.struc.name            = xstrdup(name);
-    type->as.struc.field_names     = NULL;
-    type->as.struc.field_types     = NULL;
-    type->as.struc.field_is_const  = NULL;
-    type->as.struc.field_count     = 0;
-    type->as.struc.method_names    = NULL;
-    type->as.struc.method_types    = NULL;
-    type->as.struc.method_is_const = NULL;
-    type->as.struc.method_count    = 0;
+    Type* type                      = type_new(TYPE_STRUCT);
+    type->as.struc.name             = xstrdup(name);
+    type->as.struc.base_name        = type->as.struc.name; // same allocation for non-generic
+    type->as.struc.field_names      = NULL;
+    type->as.struc.field_types      = NULL;
+    type->as.struc.field_is_const   = NULL;
+    type->as.struc.field_is_private = NULL;
+    type->as.struc.field_count      = 0;
+    type->as.struc.method_names     = NULL;
+    type->as.struc.method_types     = NULL;
+    type->as.struc.method_is_const  = NULL;
+    type->as.struc.method_count     = 0;
     return type;
 }
 

--- a/w0/types.h
+++ b/w0/types.h
@@ -67,9 +67,11 @@ struct Type {
         // Struct
         struct {
             char*  name;
+            char*  base_name; // For generic instances: base type name (e.g. "Set" for "Set_i64")
             char** field_names;
             Type** field_types;
             int*   field_is_const;
+            int*   field_is_private;
             int    field_count;
             // Methods
             char** method_names;


### PR DESCRIPTION
## Summary
- Add `private` keyword for struct fields — private fields are only accessible within the type's own methods (receiver methods and impl blocks)
- Fields are public by default; syntax: `private field_name: Type` or `private const field_name: Type`
- Works with both non-generic and generic structs (e.g. `Set<T>`, `Container<T>`)

## Changes
- **Parser**: check for `TOK_PRIVATE` before field name in struct field parsing
- **AST**: add `is_private` flag to field node, copy in `node_clone()`
- **Type system**: add `field_is_private` parallel array and `base_name` (for matching generic instances to their base type) to `Type.struc`
- **Checker**: add `current_method_receiver` to track when inside a method; enforce private access in `check_member_struct()` and `check_struct_init()`; propagate through generic struct instantiation
- **Grammar**: update `<field-decl>` rule

## Test plan
- [x] 3 error tests: reading, writing, and initializing private fields from outside
- [x] 2 valid tests: private fields accessed from receiver methods, impl blocks, and generic methods
- [x] All 240 tests pass (`make test`)

Closes #273