### PR TITLE
feat: add Vec/Set/fs convenience methods and simplify test_runner

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -255,6 +255,9 @@ Create spans using slice syntax: `var s: Span<i64> = arr[:];`
 - `vec.contains(x)` — membership test (when `T` supports equality)
 - `vec.first()` / `vec.last()` — return `Option<T>`
 - `vec.sort()` — in-place sort (for orderable primitive `T`)
+- `vec.is_empty()` — returns `true` if the vec has no elements
+- `vec.find(pred)` — returns `Option::Some(elem)` for the first element matching the predicate, or `Option::None`
+- `vec.extend(other)` — appends all elements from another `Vec<T>`
 - `vec.data` — private (compile error if accessed directly)
 - Slice syntax produces a `Span<T>`: `vec[:]`, `vec[1:3]`, `vec[2:]`
 

--- a/lib/collections.w
+++ b/lib/collections.w
@@ -153,7 +153,7 @@ func (HashMap<K, V>) delete(key: K) -> bool {
             } else {
                 prev.next = entry.next;
             }
-            self.count = self.count - 1;
+            self.count -= 1;
             return true;
         }
         prev = entry;
@@ -182,9 +182,9 @@ struct SetEntry<T: Hashable> {
 }
 
 struct Set<T: Hashable> {
-    buckets: Vec<SetEntry<T>>,
+    private buckets: Vec<SetEntry<T>>,
     count: i64,
-    capacity: i64,
+    private capacity: i64,
 }
 
 impl Set<T> {
@@ -229,7 +229,13 @@ func (Set<T>) insert(value: T) -> void {
         key: value,
     };
     self.buckets[index] = new_entry;
-    self.count = self.count + 1;
+    self.count += 1;
+}
+
+func (Set<T>) insert_all(items: Vec<T>) -> void {
+    foreach (const item in items) {
+        self.insert(item);
+    }
 }
 
 func (Set<T>) contains(value: T) -> bool {
@@ -266,7 +272,7 @@ func (Set<T>) remove(value: T) -> bool {
             } else {
                 prev.next = entry.next;
             }
-            self.count = self.count - 1;
+            self.count -= 1;
             return true;
         }
         prev = entry;

--- a/lib/fs.w
+++ b/lib/fs.w
@@ -192,3 +192,30 @@ func modified_time(path: string) -> i64 {
 func temp_dir() -> string {
     return fs__temp_dir();
 }
+
+// Recursive directory walk
+
+func walk_dir(dir: string) -> Vec<string> {
+    var files = new Vec<string>{};
+    var dirs = new Vec<string>{};
+    var dh = fs__open_dir(dir);
+    if (dh == null) {
+        return files;
+    }
+    var entry = fs__read_dir(dh);
+    while (entry != "") {
+        var path = fs__join_path(dir, entry);
+        if (fs__is_dir(path)) {
+            dirs.push(path);
+        } else {
+            files.push(path);
+        }
+        entry = fs__read_dir(dh);
+    }
+    fs__close_dir(dh);
+    foreach (const subdir in dirs) {
+        var sub_files = walk_dir(subdir);
+        files.extend(sub_files);
+    }
+    return files;
+}

--- a/lib/prelude.w
+++ b/lib/prelude.w
@@ -202,3 +202,22 @@ func (const Vec<T>) each(f: func(T) -> void) -> void {
         f(elem);
     }
 }
+
+func (const Vec<T>) is_empty() -> bool {
+    return self.count == 0;
+}
+
+func (const Vec<T>) find(pred: func(T) -> bool) -> Option<T> {
+    foreach (const elem in self) {
+        if (pred(elem)) {
+            return Option::Some(elem);
+        }
+    }
+    return Option::None;
+}
+
+func (Vec<T>) extend(other: Vec<T>) -> void {
+    foreach (const elem in other) {
+        self.push(elem);
+    }
+}

--- a/test/run/prelude/vec_methods.w
+++ b/test/run/prelude/vec_methods.w
@@ -1,0 +1,42 @@
+// Tests for Vec is_empty, find, extend methods
+
+import std;
+
+// Expected: all passed
+
+func main() -> i32 {
+    // --- is_empty ---
+    var empty = new Vec<i64>{};
+    assert(empty.is_empty());
+
+    var non_empty = new Vec<i64>{1, 2, 3};
+    assert(!non_empty.is_empty());
+
+    // --- find ---
+    var nums = new Vec<i64>{10, 20, 30, 40};
+
+    var found = nums.find(|x| x > 25);
+    assert(found.has_value());
+    assert(found.value() == 30);
+
+    var not_found = nums.find(|x| x > 100);
+    assert(!not_found.has_value());
+
+    // --- extend ---
+    var a = new Vec<i64>{1, 2};
+    var b = new Vec<i64>{3, 4, 5};
+    a.extend(b);
+    assert(a.count == 5);
+    assert(a[0] == 1);
+    assert(a[2] == 3);
+    assert(a[4] == 5);
+
+    // extend with empty
+    var c = new Vec<i64>{10};
+    var d = new Vec<i64>{};
+    c.extend(d);
+    assert(c.count == 1);
+
+    std::println("all passed");
+    return 0;
+}

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -68,25 +68,15 @@ func extract_rc_addresses(output: string, prefix: string) -> Vec<string> {
     return addrs;
 }
 
-func build_address_set(addrs: Vec<string>) -> Set<string> {
-    var cap: i64 = 64;
-    if (addrs.count > cap) {
-        cap = addrs.count * 2;
-    }
-    var s = new Set<string>(cap);
-    foreach (const addr in addrs) {
-        s.insert(addr);
-    }
-    return s;
-}
-
 func check_rc_leaks(stderr: string) -> bool {
     var allocs = extract_rc_addresses(stderr, "RC_ALLOC:");
     var frees = extract_rc_addresses(stderr, "RC_FREE:");
-    if (allocs.count == 0) {
+    if (allocs.is_empty()) {
         return true;
     }
-    var free_set = build_address_set(frees);
+    var cap = std::max_i64(64, frees.count * 2);
+    var free_set = new Set<string>(cap);
+    free_set.insert_all(frees);
     foreach (const addr in allocs) {
         if (!free_set.contains(addr)) {
             return false;
@@ -98,7 +88,9 @@ func check_rc_leaks(stderr: string) -> bool {
 func get_leaked_addresses(stderr: string) -> Vec<string> {
     var allocs = extract_rc_addresses(stderr, "RC_ALLOC:");
     var frees = extract_rc_addresses(stderr, "RC_FREE:");
-    var free_set = build_address_set(frees);
+    var cap = std::max_i64(64, frees.count * 2);
+    var free_set = new Set<string>(cap);
+    free_set.insert_all(frees);
     var leaked = new Vec<string>{};
     foreach (const addr in allocs) {
         if (!free_set.contains(addr)) {
@@ -176,30 +168,6 @@ func filter_rc_lines(output: string) -> string {
 
 // --- File/output helpers ---
 
-func collect_files(dir: string, files: Vec<string>) -> void {
-    var dh = fs::open_dir(dir);
-    if (dh == null) {
-        return;
-    }
-
-    var dirs = new Vec<string>{};
-    var entry = fs::read_dir(dh);
-    while (entry != "") {
-        var path = fs::join_path(dir, entry);
-        if (fs::is_dir(path)) {
-            dirs.push(path);
-        } else if (entry.ends_with(".w")) {
-            files.push(path);
-        }
-        entry = fs::read_dir(dh);
-    }
-    fs::close_dir(dh);
-
-    foreach(const dir in dirs) {
-        collect_files(dir, files);
-    }
-}
-
 func read_expected_lines(path: string, prefix: string) -> Vec<string> {
     var lines = new Vec<string>{};
     var marker = $"// {prefix}: ";
@@ -221,20 +189,11 @@ func display_path(file: string) -> string {
     return file.strip_prefix("test/");
 }
 
-func check_output_contains(output: string, expected: Vec<string>) -> bool {
-    foreach (const line in expected) {
-        if (!output.contains(line)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 func extract_error_message(output: string) -> string {
     foreach (const line in output.split("\n")) {
         var idx = line.index_of("Error:");
         if (idx >= 0) {
-            return line[idx + 6 : line.length()].trim_start();
+            return line[idx + 6:].trim_start();
         }
     }
     return "";
@@ -263,7 +222,7 @@ func run_program_test(file: string, w0: string, lib_path: string, verbose: bool)
     // Check expected exit code
     var expected_exit_lines = read_expected_lines(file, "Expected exit");
     var expected_exit: i64 = 0;
-    if (expected_exit_lines.count > 0) {
+    if (!expected_exit_lines.is_empty()) {
         expected_exit = std::parse_i64(expected_exit_lines[0]);
     }
 
@@ -279,8 +238,8 @@ func run_program_test(file: string, w0: string, lib_path: string, verbose: bool)
 
     // Check expected stdout
     var expected_stdout = read_expected_lines(file, "Expected");
-    if (expected_stdout.count > 0) {
-        if (!check_output_contains(run_result.output, expected_stdout)) {
+    if (!expected_stdout.is_empty()) {
+        if (!expected_stdout.all(|line| run_result.output.contains(line))) {
             if (verbose) {
                 std::println("  stdout mismatch:");
                 std::println($"  actual: {run_result.output}");
@@ -294,9 +253,9 @@ func run_program_test(file: string, w0: string, lib_path: string, verbose: bool)
 
     // Check expected stderr (filter RC debug lines first)
     var expected_stderr = read_expected_lines(file, "Expected stderr");
-    if (expected_stderr.count > 0) {
+    if (!expected_stderr.is_empty()) {
         var filtered_stderr = filter_rc_lines(run_result.error_output);
-        if (!check_output_contains(filtered_stderr, expected_stderr)) {
+        if (!expected_stderr.all(|line| filtered_stderr.contains(line))) {
             if (verbose) {
                 std::println("  stderr mismatch:");
                 std::println($"  actual: {filtered_stderr}");
@@ -307,7 +266,7 @@ func run_program_test(file: string, w0: string, lib_path: string, verbose: bool)
 
     // Check expected RC free order
     var expected_order_lines = read_expected_lines(file, "Expected rc free order");
-    if (expected_order_lines.count > 0) {
+    if (!expected_order_lines.is_empty()) {
         if (!check_rc_free_order(run_result.error_output, expected_order_lines[0])) {
             if (verbose) {
                 std::println("  rc free order mismatch:");
@@ -344,7 +303,7 @@ func run_test_block_file(file: string, w0: string, lib_path: string, verbose: bo
     // Check expected output lines
     var expected_lines = read_expected_lines(file, "Expected");
 
-    if (exit_code != 0 && expected_lines.count == 0) {
+    if (exit_code != 0 && expected_lines.is_empty()) {
         if (verbose) {
             std::println($"  command: {cmd}");
             std::println($"  output:  {combined}");
@@ -352,8 +311,8 @@ func run_test_block_file(file: string, w0: string, lib_path: string, verbose: bo
         return Result::Err("w0 test runtime");
     }
 
-    if (expected_lines.count > 0) {
-        if (!check_output_contains(combined, expected_lines)) {
+    if (!expected_lines.is_empty()) {
+        if (!expected_lines.all(|line| combined.contains(line))) {
             if (verbose) {
                 std::println("  output mismatch:");
                 std::println($"  actual: {combined}");
@@ -405,8 +364,8 @@ func run_error_test(file: string, w0: string, lib_path: string, verbose: bool) -
 
     // Check expected error text
     var expected = read_expected_lines(file, "Expected error");
-    if (expected.count > 0) {
-        if (!check_output_contains(o, expected)) {
+    if (!expected.is_empty()) {
+        if (!expected.all(|line| o.contains(line))) {
             if (verbose) {
                 std::println("  wrong error message:");
                 std::println($"  output: {o}");
@@ -475,8 +434,7 @@ func main() -> i32 {
         std::println($"{cyan("=== Run Tests (test/run/**) ===")}");
 
 
-        var files = new Vec<string>{};
-        collect_files("test/run", files);
+        var files = fs::walk_dir("test/run").filter(|f| f.ends_with(".w"));
         files.sort();
 
         foreach (const file in files) {
@@ -518,8 +476,7 @@ func main() -> i32 {
     if (run_errors) {
         std::println($"{cyan("=== Error Cases (test/errors/**) ===")}");
 
-        var files = new Vec<string>{};
-        collect_files("test/errors", files);
+        var files = fs::walk_dir("test/errors").filter(|f| f.ends_with(".w"));
         files.sort();
 
         foreach (const file in files) {


### PR DESCRIPTION
## Summary
- Add `is_empty()`, `find(pred)`, `extend(other)` methods on `Vec<T>` in prelude
- Add `insert_all(items)` on `Set<T>` in collections
- Add `walk_dir(dir)` recursive directory traversal in fs
- Simplify test_runner by deleting 3 helper functions (`collect_files`, `check_output_contains`, `build_address_set`) and using the new methods
- Replace `.count == 0` / `.count > 0` patterns with `.is_empty()` throughout test_runner
- Add `test/run/prelude/vec_methods.w` exercising the new Vec methods
- Update grammar.md with new Vec method documentation

## Test plan
- [x] `make test` — all 241 tests pass (including new `vec_methods.w`)
- [x] `make test-whist` — Whist test runner compiles and runs successfully with its own changes

Closes #278