### PR TITLE
Replace shell test runner with Whist-based runner

### DIFF
--- a/lib/include/whist_runtime.h
+++ b/lib/include/whist_runtime.h
@@ -154,7 +154,7 @@ static inline void __w0_vec_check(int64_t count, int64_t idx, int line, int col)
 }
 
 /* --- Panic --- */
-static inline void __whist_panic(const char* msg) {
+_Noreturn static inline void __whist_panic(const char* msg) {
     fprintf(stderr, "Panic: %s\n", msg);
     exit(1);
 }

--- a/w0/Makefile
+++ b/w0/Makefile
@@ -8,7 +8,7 @@ DEPS = $(SRC:.c=.d)
 BIN = bin
 TARGET = $(BIN)/w0
 
-.PHONY: all clean test test-verbose test-valid test-run test-errors test-whist format metrics complexity
+.PHONY: all clean test test-verbose test-valid test-run test-errors format metrics complexity
 
 all: $(TARGET)
 
@@ -25,24 +25,23 @@ clean:
 	rm -f $(OBJ) $(DEPS)
 	rm -rf $(BIN)
 
-test: $(TARGET)
-	@./scripts/run_tests.sh
+$(BIN)/test_runner: $(TARGET) tools/test_runner.w
+	@$(TARGET) --lib-path ../lib tools/test_runner.w | cc -x c -I../lib/include -o $@ - ../lib/whist_runtime.c
 
-test-verbose: $(TARGET)
-	@./scripts/run_tests.sh --verbose
+test: $(BIN)/test_runner
+	@$(BIN)/test_runner
 
-test-run: $(TARGET)
-	@./scripts/run_tests.sh --run
+test-verbose: $(BIN)/test_runner
+	@$(BIN)/test_runner --verbose
 
-test-valid: $(TARGET)
-	@./scripts/run_tests.sh --run
+test-run: $(BIN)/test_runner
+	@$(BIN)/test_runner --run
 
-test-errors: $(TARGET)
-	@./scripts/run_tests.sh --errors
+test-valid: $(BIN)/test_runner
+	@$(BIN)/test_runner --run
 
-test-whist: $(TARGET)
-	@$(TARGET) --lib-path ../lib tools/test_runner.w | cc -x c -I../lib/include -o $(BIN)/test_runner - ../lib/whist_runtime.c
-	@cd . && $(BIN)/test_runner
+test-errors: $(BIN)/test_runner
+	@$(BIN)/test_runner --errors
 
 format:
 	clang-format -i *.c *.h

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -223,7 +223,11 @@ static void emit_enum_value(CodeGen* gen, Node* node) {
                 if (arg->type == NODE_IDENT && rc_is_tracked(gen, arg->as.ident.name)) {
                     Type*       arg_type = rc_get_var_type(gen, arg->as.ident.name);
                     const char* inc_fn   = get_inc_func_for_type(arg_type);
-                    emit(gen, "%s(%s); ", inc_fn, arg->as.ident.name);
+                    if (arg_type && arg_type->kind == TYPE_STRING) {
+                        emit(gen, "%s((void*)%s); ", inc_fn, arg->as.ident.name);
+                    } else {
+                        emit(gen, "%s(%s); ", inc_fn, arg->as.ident.name);
+                    }
                     free((char*)inc_fn);
                 }
             }
@@ -1144,6 +1148,8 @@ static void emit_try_expr(CodeGen* gen, Node* node) {
         Type* t = gen->rc.vars[i].type;
         if (t && t->kind == TYPE_ENUM && t->as.enm.has_rc_fields) {
             emit(gen, "__rc_dec_%s(%s); ", t->as.enm.name, gen->rc.vars[i].name);
+        } else if (t && t->kind == TYPE_STRING) {
+            emit(gen, "__rc_dec((void*)%s); ", gen->rc.vars[i].name);
         } else {
             emit(gen, "__rc_dec(%s); ", gen->rc.vars[i].name);
         }

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -172,12 +172,24 @@ static void emit_enum_rc_func(CodeGen* gen, const char* ename, Node* enum_decl, 
             if (enum_nm) {
                 emit(gen, "        __rc_%s_%s(v.%.*s.f%d);\n", op, enum_nm,
                      var->as.enum_variant.name_length, var->as.enum_variant.name, t);
-            } else if (tnode->type == NODE_IDENT && strcmp(tnode->as.ident.name, "string") == 0) {
-                emit(gen, "        __rc_%s((void*)v.%.*s.f%d);\n", op,
-                     var->as.enum_variant.name_length, var->as.enum_variant.name, t);
             } else {
-                emit(gen, "        __rc_%s(v.%.*s.f%d);\n", op, var->as.enum_variant.name_length,
-                     var->as.enum_variant.name, t);
+                // Check if this field resolves to a string (directly or via substitution)
+                int is_str = 0;
+                if (tnode->type == NODE_IDENT) {
+                    if (strcmp(tnode->as.ident.name, "string") == 0) {
+                        is_str = 1;
+                    } else {
+                        Type* resolved = subst_lookup(gen, tnode->as.ident.name);
+                        is_str         = (resolved && resolved->kind == TYPE_STRING);
+                    }
+                }
+                if (is_str) {
+                    emit(gen, "        __rc_%s((void*)v.%.*s.f%d);\n", op,
+                         var->as.enum_variant.name_length, var->as.enum_variant.name, t);
+                } else {
+                    emit(gen, "        __rc_%s(v.%.*s.f%d);\n", op,
+                         var->as.enum_variant.name_length, var->as.enum_variant.name, t);
+                }
             }
         }
         emit(gen, "        break;\n");

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -1130,7 +1130,17 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node) {
 static void emit_rc_inc_for_return(CodeGen* gen, const char* value_name) {
     Node* rtype = resolve_alias(gen, gen->defer.return_type);
     emit_indent(gen);
-    if (rtype && rtype->type == NODE_IDENT && strcmp(rtype->as.ident.name, "string") == 0) {
+    // Check if return type is string (directly or via generic substitution)
+    int is_str = 0;
+    if (rtype && rtype->type == NODE_IDENT) {
+        if (strcmp(rtype->as.ident.name, "string") == 0) {
+            is_str = 1;
+        } else {
+            Type* resolved = subst_lookup(gen, rtype->as.ident.name);
+            is_str         = (resolved && resolved->kind == TYPE_STRING);
+        }
+    }
+    if (is_str) {
         emit(gen, "__rc_inc((void*)%s);\n", value_name);
     } else {
         const char* enum_name = resolve_enum_name(gen, rtype);

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -447,29 +447,22 @@ func main() -> i32 {
             var has_main = file_contains(file, "func main(");
 
             if (has_test_blocks) {
-                std::print($"{disp}:".pad_right(45, ' '));
                 var result = run_test_block_file(file, w0, lib_path, verbose);
                 if (result.is_ok()) {
-                    std::println($" {green("PASS")}");
                     run_passed += 1;
                 } else {
-                    std::println($" {red("FAIL")} ({result.error()})");
+                    std::println($"{disp}:".pad_right(45, ' ') + $" {red("FAIL")} ({result.error()})");
                     run_failed += 1;
                 }
             } else if (has_main) {
-                std::print($"{disp}:".pad_right(45, ' '));
                 var result = run_program_test(file, w0, lib_path, verbose);
                 if (result.is_ok()) {
-                    std::println($" {green("PASS")}");
                     run_passed += 1;
                 } else {
-                    std::println($" {red("FAIL")} ({result.error()})");
+                    std::println($"{disp}:".pad_right(45, ' ') + $" {red("FAIL")} ({result.error()})");
                     run_failed += 1;
                 }
             } else {
-                if (verbose) {
-                    std::println($"{gray($"{disp}: SKIP (helper module)")}");
-                }
                 run_skipped += 1;
             }
         }
@@ -485,17 +478,11 @@ func main() -> i32 {
         foreach (const file in files) {
             var disp = display_path(file);
 
-            std::print($"{disp}:".pad_right(45, ' '));
-
             var result = run_error_test(file, w0, lib_path, verbose);
-            if (result is Ok(actual)) {
-                std::println($" {green("PASS")} (correct error)");
-                if (actual != "") {
-                    std::println($"  {gray(actual)}");
-                }
+            if (result.is_ok()) {
                 error_passed += 1;
             } else {
-                std::println($" {red("FAIL")} ({result.error()})");
+                std::println($"{disp}:".pad_right(45, ' ') + $" {red("FAIL")} ({result.error()})");
                 error_failed += 1;
             }
         }


### PR DESCRIPTION
## Summary
- Switch `make test` (and `test-verbose`, `test-run`, `test-errors`) from `scripts/run_tests.sh` to the Whist test runner (`tools/test_runner.w`), with a proper Make target that caches the compiled `bin/test_runner` binary
- Only failing tests produce output, reducing noise and token usage
- Fix C compiler warnings in generated code: `_Noreturn` on `__whist_panic` eliminates `-Wreturn-type` warnings, and generic type parameter substitution resolves string types for `(void*)` casts in enum RC functions, return borrow inc, enum value construction, and try expression cleanup

## Test plan
- [x] `make test` runs all 242 tests via the Whist runner
- [x] Second `make test` invocation skips recompilation (cached binary)
- [x] Zero `-Wincompatible-pointer-types-discards-qualifiers` and `-Wreturn-type` warnings when compiling test_runner