### PR TITLE
refactor: move misplaced functions to correct domains

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -830,3 +830,230 @@ Node* node_clone(Node* node) {
     node_reset_checker_flags(c);
     return c;
 }
+
+// ============================================================================
+// AST query functions (pure Node* traversals, no codegen state)
+// ============================================================================
+
+// Find a generic struct declaration by name in the AST
+Node* find_generic_struct_decl(Node* ast, const char* name) {
+    if (!ast || ast->type != NODE_PROGRAM)
+        return NULL;
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type == NODE_STRUCT_DECL && decl->as.struct_decl.type_param_count > 0 &&
+                strcmp(decl->as.struct_decl.name, name) == 0) {
+                return decl;
+            }
+        }
+    }
+    return NULL;
+}
+
+// Find a generic enum declaration by name in the AST
+Node* find_generic_enum_decl(Node* ast, const char* name) {
+    if (!ast || ast->type != NODE_PROGRAM)
+        return NULL;
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type == NODE_ENUM_DECL && decl->as.enum_decl.type_param_count > 0 &&
+                strcmp(decl->as.enum_decl.name, name) == 0) {
+                return decl;
+            }
+        }
+    }
+    return NULL;
+}
+
+// Find a generic free function declaration in the AST by name
+Node* find_generic_func_decl(Node* ast, const char* name) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int d = 0; d < mod->as.module.decls.count; d++) {
+            Node* decl = mod->as.module.decls.nodes[d];
+            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.type_param_count > 0 &&
+                strcmp(decl->as.func_decl.name, name) == 0) {
+                return decl;
+            }
+        }
+    }
+    return NULL;
+}
+
+// Find a method-level generic function declaration in the AST.
+// Matches func (ReceiverType<...>) MethodName<...>(...): ...
+Node* find_generic_method_func_decl(Node* ast, const char* receiver_type, const char* method_name) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int d = 0; d < mod->as.module.decls.count; d++) {
+            Node* decl = mod->as.module.decls.nodes[d];
+            // Direct method: func (Vec<T>) map<K>(...) -> Vec<K>
+            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.receiver_type != NULL &&
+                decl->as.func_decl.type_param_count > 0 &&
+                strcmp(decl->as.func_decl.receiver_type, receiver_type) == 0 &&
+                strcmp(decl->as.func_decl.name, method_name) == 0) {
+                return decl;
+            }
+            // Inside impl blocks
+            if (decl->type == NODE_IMPL_DECL) {
+                for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
+                    Node* method = decl->as.impl_decl.methods.nodes[j];
+                    if (method->type == NODE_FUNC_DECL &&
+                        method->as.func_decl.receiver_type != NULL &&
+                        method->as.func_decl.type_param_count > 0 &&
+                        strcmp(method->as.func_decl.receiver_type, receiver_type) == 0 &&
+                        strcmp(method->as.func_decl.name, method_name) == 0) {
+                        return method;
+                    }
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
+// Return whether a function decl is a direct generic-receiver method for `struct_name`.
+static int is_collectible_generic_method(Node* decl, const char* struct_name) {
+    return decl && decl->type == NODE_FUNC_DECL && decl->as.func_decl.body != NULL &&
+           decl->as.func_decl.receiver_type != NULL &&
+           decl->as.func_decl.receiver_type_args.count > 0 &&
+           decl->as.func_decl.type_param_count == 0 &&
+           strcmp(decl->as.func_decl.receiver_type, struct_name) == 0;
+}
+
+// Collect all generic methods for a given struct name
+void collect_generic_methods(Node* ast, const char* struct_name, Node*** methods_out,
+                             int* count_out) {
+    *methods_out = NULL;
+    *count_out   = 0;
+
+    if (!ast || ast->type != NODE_PROGRAM)
+        return;
+
+    int    capacity = 0;
+    Node** methods  = NULL;
+    int    count    = 0;
+
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            // Direct generic methods: func (Box<T>) get() -> T.
+            // Excludes method-level generics (type_param_count > 0), which are handled
+            // via GenericFuncInstance.
+            if (is_collectible_generic_method(decl, struct_name)) {
+                VEC_GROW(methods, count, capacity);
+                methods[count++] = decl;
+            }
+
+            // Methods inside impl blocks: impl Drop for Box { func (Box<T>) drop() -> void }
+            if (decl->type != NODE_IMPL_DECL) {
+                continue;
+            }
+            for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
+                Node* method = decl->as.impl_decl.methods.nodes[j];
+                if (is_collectible_generic_method(method, struct_name)) {
+                    VEC_GROW(methods, count, capacity);
+                    methods[count++] = method;
+                }
+            }
+        }
+    }
+
+    *methods_out = methods;
+    *count_out   = count;
+}
+
+// ============================================================================
+// Owned temp predicates (pure Node* checks)
+// ============================================================================
+
+// Forward declaration for mutual recursion
+static int has_owned_temps_children(Node* node);
+
+// Return whether a new-expression subtree contains any owned temps.
+static int has_owned_temps_new_expr(Node* node) {
+    if (node->as.new_expr.init) {
+        for (int i = 0; i < node->as.new_expr.init->as.struct_init.fields.count; i++) {
+            Node* field = node->as.new_expr.init->as.struct_init.fields.nodes[i];
+            if (field && field->type == NODE_FIELD_INIT &&
+                has_owned_temps(field->as.field_init.value)) {
+                return 1;
+            }
+        }
+    }
+    for (int i = 0; i < node->as.new_expr.args.count; i++) {
+        if (has_owned_temps(node->as.new_expr.args.nodes[i])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+// Return whether any child expression for this node contains owned temps.
+static int has_owned_temps_children(Node* node) {
+    switch (node->type) {
+    case NODE_CALL:
+        if (has_owned_temps(node->as.call.func))
+            return 1;
+        for (int i = 0; i < node->as.call.args.count; i++) {
+            if (has_owned_temps(node->as.call.args.nodes[i]))
+                return 1;
+        }
+        return 0;
+    case NODE_BINARY:
+        return has_owned_temps(node->as.binary.left) || has_owned_temps(node->as.binary.right);
+    case NODE_UNARY:
+        return has_owned_temps(node->as.unary.operand);
+    case NODE_MEMBER:
+        return has_owned_temps(node->as.member.object);
+    case NODE_INDEX:
+        return has_owned_temps(node->as.index.object) || has_owned_temps(node->as.index.index);
+    case NODE_SLICE:
+        return has_owned_temps(node->as.slice.object) || has_owned_temps(node->as.slice.start) ||
+               has_owned_temps(node->as.slice.end);
+    case NODE_NEW_EXPR:
+        return has_owned_temps_new_expr(node);
+    case NODE_CAST:
+        return has_owned_temps(node->as.cast_expr.expr);
+    case NODE_STRING_INTERP:
+        for (int i = 0; i < node->as.string_interp.part_count; i++) {
+            if (has_owned_temps(node->as.string_interp.parts.nodes[i]))
+                return 1;
+        }
+        return 0;
+    case NODE_ASSIGN:
+        return has_owned_temps(node->as.assign.target) || has_owned_temps(node->as.assign.value);
+    case NODE_ENUM_VALUE:
+        for (int i = 0; i < node->as.enum_value.args.count; i++) {
+            if (has_owned_temps(node->as.enum_value.args.nodes[i]))
+                return 1;
+        }
+        return 0;
+    default:
+        return 0;
+    }
+}
+
+// Check if an expression tree contains any owned temps.
+int has_owned_temps(Node* node) {
+    if (!node)
+        return 0;
+    if (node->is_owned_temp)
+        return 1;
+    return has_owned_temps_children(node);
+}

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -623,4 +623,15 @@ void nodelist_free(NodeList* list);
 // Match helpers
 int match_stmt_has_wildcard_arm(Node* node);
 
+// Owned temp predicates
+int has_owned_temps(Node* node);
+
+// AST query functions
+Node* find_generic_struct_decl(Node* ast, const char* name);
+Node* find_generic_enum_decl(Node* ast, const char* name);
+Node* find_generic_func_decl(Node* ast, const char* name);
+Node* find_generic_method_func_decl(Node* ast, const char* receiver_type, const char* method_name);
+void  collect_generic_methods(Node* ast, const char* struct_name, Node*** methods_out,
+                              int* count_out);
+
 #endif

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -576,16 +576,6 @@ static int check_tuple_destruct_pattern_against_type(Checker* checker, DestructP
     return 0;
 }
 
-// Return the index of a struct field by name, or -1 if not found.
-static int find_struct_field_index(Type* type, const char* field_name) {
-    for (int j = 0; j < type->as.struc.field_count; j++) {
-        if (strcmp(field_name, type->as.struc.field_names[j]) == 0) {
-            return j;
-        }
-    }
-    return -1;
-}
-
 // Validate struct destructuring fields and record resolved field types.
 static int check_struct_destruct_pattern_against_type(Checker* checker, DestructPattern* pattern,
                                                       Type* type, int line, int col) {
@@ -603,7 +593,7 @@ static int check_struct_destruct_pattern_against_type(Checker* checker, Destruct
     }
 
     for (int i = 0; i < pattern->as.struc.count; i++) {
-        int field_idx = find_struct_field_index(type, pattern->as.struc.field_names[i]);
+        int field_idx = type_find_field_index(type, pattern->as.struc.field_names[i]);
         if (field_idx < 0) {
             check_error(checker, line, col, "Struct '%s' has no field '%s'", type->as.struc.name,
                         pattern->as.struc.field_names[i]);

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1199,15 +1199,6 @@ static int find_template_enum_variant(Node* enum_decl, const char* value_name) {
     return -1;
 }
 
-static int find_resolved_enum_variant(Type* enum_type, const char* value_name) {
-    for (int i = 0; i < enum_type->as.enm.value_count; i++) {
-        if (strcmp(enum_type->as.enm.value_names[i], value_name) == 0) {
-            return i;
-        }
-    }
-    return -1;
-}
-
 static int all_type_args_inferred(Type** inferred, int type_param_count) {
     for (int i = 0; i < type_param_count; i++) {
         if (!inferred[i]) {
@@ -1435,7 +1426,7 @@ static Type* check_enum_value_expr(Checker* checker, Node* node) {
     sem_info_set_enum_value_resolved_name(checker->sem, node, enum_type->as.enm.name);
 
     // Check that the value exists in the (possibly instantiated) enum.
-    int variant_idx = find_resolved_enum_variant(enum_type, value_name);
+    int variant_idx = type_enum_variant_index(enum_type, value_name);
     if (variant_idx < 0) {
         check_error(checker, node->line, node->column, "'%s' is not a value of enum '%s'",
                     value_name, enum_type->as.enm.name);
@@ -2319,10 +2310,10 @@ static Type* check_string_interp_expr(Checker* checker, Node* node) {
 // =============================================================================
 
 static int classify_try_enum(Type* enum_type, int* is_option, int* success_idx, int* err_idx) {
-    int ok_idx   = find_resolved_enum_variant(enum_type, "Ok");
-    int err      = find_resolved_enum_variant(enum_type, "Err");
-    int some_idx = find_resolved_enum_variant(enum_type, "Some");
-    int none_idx = find_resolved_enum_variant(enum_type, "None");
+    int ok_idx   = type_enum_variant_index(enum_type, "Ok");
+    int err      = type_enum_variant_index(enum_type, "Err");
+    int some_idx = type_enum_variant_index(enum_type, "Some");
+    int none_idx = type_enum_variant_index(enum_type, "None");
 
     int is_result = (ok_idx >= 0 && err >= 0);
     int option    = (some_idx >= 0 && none_idx >= 0);
@@ -2350,7 +2341,7 @@ static int check_try_return_type_compatibility(Checker* checker, Node* node, Typ
     }
 
     if (is_option) {
-        if (find_resolved_enum_variant(ret_type, "None") < 0) {
+        if (type_enum_variant_index(ret_type, "None") < 0) {
             check_error(checker, node->line, node->column,
                         "'?' on Option requires function return type to have 'None' variant, "
                         "got '%s'",
@@ -2360,7 +2351,7 @@ static int check_try_return_type_compatibility(Checker* checker, Node* node, Typ
         return 1;
     }
 
-    int ret_err_idx = find_resolved_enum_variant(ret_type, "Err");
+    int ret_err_idx = type_enum_variant_index(ret_type, "Err");
     if (ret_err_idx < 0) {
         check_error(checker, node->line, node->column,
                     "'?' on Result requires function return type to have 'Err' variant, got '%s'",

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -12,22 +12,11 @@
 #include "types.h"
 #include "vec.h"
 
-// Check if two tuple types are structurally equal
-int tuple_types_equal(Type* a, Type* b) {
-    if (a->as.tuple.elem_count != b->as.tuple.elem_count)
-        return 0;
-    for (int i = 0; i < a->as.tuple.elem_count; i++) {
-        if (!type_equals(a->as.tuple.elem_types[i], b->as.tuple.elem_types[i]))
-            return 0;
-    }
-    return 1;
-}
-
 // Register a tuple type and return its index (for typedef name)
 static int register_tuple_type(CodeGen* gen, Type* type) {
     // Check if already registered
     for (int i = 0; i < gen->tuple_type_count; i++) {
-        if (tuple_types_equal(gen->tuple_types[i], type))
+        if (type_equals(gen->tuple_types[i], type))
             return i;
     }
     // Add new
@@ -189,66 +178,6 @@ static void collect_tuple_types_from_stmt(CodeGen* gen, Node* node) {
     }
 }
 
-// Build a Type* from a type node (for codegen purposes, simplified)
-Type* type_from_node(Node* type_node) {
-    if (!type_node)
-        return type_void;
-
-    switch (type_node->type) {
-    case NODE_IDENT: {
-        const char* name    = type_node->as.ident.name;
-        Type*       builtin = type_builtin_from_name(name);
-        if (builtin)
-            return builtin;
-        // User-defined type - return a struct type
-        return type_struct(name);
-    }
-    case NODE_ARRAY_TYPE: {
-        Type* elem = type_from_node(type_node->as.array_type.elem_type);
-        int   size = -1;
-        if (type_node->as.array_type.size && type_node->as.array_type.size->type == NODE_INT_LIT) {
-            size = (int)type_node->as.array_type.size->as.int_lit.value;
-        }
-        return type_array(elem, size);
-    }
-    case NODE_TUPLE_TYPE: {
-        int    count = type_node->as.tuple_type.elem_types.count;
-        Type** elems = xmalloc(count * sizeof(Type*));
-        for (int i = 0; i < count; i++) {
-            elems[i] = type_from_node(type_node->as.tuple_type.elem_types.nodes[i]);
-        }
-        return type_tuple(elems, count);
-    }
-    case NODE_GENERIC_TYPE: {
-        const char* base      = type_node->as.generic_type.base_name;
-        int         arg_count = type_node->as.generic_type.type_args.count;
-        Type**      args      = xmalloc(arg_count * sizeof(Type*));
-        for (int i = 0; i < arg_count; i++) {
-            args[i] = type_from_node(type_node->as.generic_type.type_args.nodes[i]);
-        }
-        // Vec and Span are special built-in generic types
-        if (strcmp(base, "Vec") == 0 && arg_count == 1) {
-            Type* result = type_vec(args[0]);
-            free(args);
-            return result;
-        }
-        if (strcmp(base, "Span") == 0 && arg_count == 1) {
-            Type* result = type_span(args[0]);
-            free(args);
-            return result;
-        }
-        // For other generics, build a struct type with the mangled name
-        char* mangled = type_mangle_generic(base, args, arg_count);
-        Type* result  = type_struct(mangled);
-        free(mangled);
-        free(args);
-        return result;
-    }
-    default:
-        return type_error;
-    }
-}
-
 // Collect tuple types from a type node
 static void collect_tuple_types_from_node(CodeGen* gen, Node* type_node) {
     if (!type_node)
@@ -271,44 +200,6 @@ static void collect_tuple_types_from_node(CodeGen* gen, Node* type_node) {
         }
         // Note: generic instances are passed from checker, no need to collect here
     }
-}
-
-// Find a generic struct declaration by name in the AST
-Node* find_generic_struct_decl(Node* ast, const char* name) {
-    if (!ast || ast->type != NODE_PROGRAM)
-        return NULL;
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int i = 0; i < mod->as.module.decls.count; i++) {
-            Node* decl = mod->as.module.decls.nodes[i];
-            if (decl->type == NODE_STRUCT_DECL && decl->as.struct_decl.type_param_count > 0 &&
-                strcmp(decl->as.struct_decl.name, name) == 0) {
-                return decl;
-            }
-        }
-    }
-    return NULL;
-}
-
-// Find a generic enum declaration by name in the AST
-Node* find_generic_enum_decl(Node* ast, const char* name) {
-    if (!ast || ast->type != NODE_PROGRAM)
-        return NULL;
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int i = 0; i < mod->as.module.decls.count; i++) {
-            Node* decl = mod->as.module.decls.nodes[i];
-            if (decl->type == NODE_ENUM_DECL && decl->as.enum_decl.type_param_count > 0 &&
-                strcmp(decl->as.enum_decl.name, name) == 0) {
-                return decl;
-            }
-        }
-    }
-    return NULL;
 }
 
 // Look up a type parameter name in the current generic substitution context.
@@ -368,60 +259,6 @@ char* build_mangled_name_from_generic_node(CodeGen* gen, Node* type_node) {
 // static const char* type_arg_mangle_name(Type* type) {
 //     ... preserved for potential future use
 // }
-
-// Return whether a function decl is a direct generic-receiver method for `struct_name`.
-static int is_collectible_generic_method(Node* decl, const char* struct_name) {
-    return decl && decl->type == NODE_FUNC_DECL && decl->as.func_decl.body != NULL &&
-           decl->as.func_decl.receiver_type != NULL &&
-           decl->as.func_decl.receiver_type_args.count > 0 &&
-           decl->as.func_decl.type_param_count == 0 &&
-           strcmp(decl->as.func_decl.receiver_type, struct_name) == 0;
-}
-
-// Collect all generic methods for a given struct name
-void collect_generic_methods(Node* ast, const char* struct_name, Node*** methods_out,
-                             int* count_out) {
-    *methods_out = NULL;
-    *count_out   = 0;
-
-    if (!ast || ast->type != NODE_PROGRAM)
-        return;
-
-    int    capacity = 0;
-    Node** methods  = NULL;
-    int    count    = 0;
-
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int i = 0; i < mod->as.module.decls.count; i++) {
-            Node* decl = mod->as.module.decls.nodes[i];
-            // Direct generic methods: func (Box<T>) get() -> T.
-            // Excludes method-level generics (type_param_count > 0), which are handled
-            // via GenericFuncInstance.
-            if (is_collectible_generic_method(decl, struct_name)) {
-                VEC_GROW(methods, count, capacity);
-                methods[count++] = decl;
-            }
-
-            // Methods inside impl blocks: impl Drop for Box { func (Box<T>) drop() -> void }
-            if (decl->type != NODE_IMPL_DECL) {
-                continue;
-            }
-            for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
-                Node* method = decl->as.impl_decl.methods.nodes[j];
-                if (is_collectible_generic_method(method, struct_name)) {
-                    VEC_GROW(methods, count, capacity);
-                    methods[count++] = method;
-                }
-            }
-        }
-    }
-
-    *methods_out = methods;
-    *count_out   = count;
-}
 
 // Collect all tuple types from a declaration
 static void collect_tuple_types_from_decl(CodeGen* gen, Node* decl) {
@@ -1342,130 +1179,6 @@ static void emit_main_wrapper(CodeGen* gen) {
     emit(gen, "}\n\n");
 }
 
-// Append a C string into a bounded stringify buffer.
-static void stringify_append_cstr(char* buf, int buf_size, int* pos, const char* s) {
-    while (*s && *pos < buf_size - 1) {
-        buf[(*pos)++] = *s++;
-    }
-}
-
-// Append a fixed-length byte slice into a bounded stringify buffer.
-static void stringify_append_n(char* buf, int buf_size, int* pos, const char* s, int n) {
-    for (int i = 0; i < n && *pos < buf_size - 1; i++) {
-        buf[(*pos)++] = s[i];
-    }
-}
-
-// Append a single character into a bounded stringify buffer.
-static void stringify_append_char(char* buf, int buf_size, int* pos, char c) {
-    if (*pos < buf_size - 1) {
-        buf[(*pos)++] = c;
-    }
-}
-
-// Append a string literal with escaping and surrounding quotes.
-static void stringify_append_string_lit(char* buf, int buf_size, int* pos, const char* s) {
-    stringify_append_cstr(buf, buf_size, pos, "\\\"");
-    while (*s && *pos < buf_size - 1) {
-        if (*s == '"') {
-            stringify_append_cstr(buf, buf_size, pos, "\\\"");
-        } else if (*s == '\\') {
-            stringify_append_cstr(buf, buf_size, pos, "\\\\");
-        } else if (*s == '\n') {
-            stringify_append_cstr(buf, buf_size, pos, "\\n");
-        } else if (*s == '\t') {
-            stringify_append_cstr(buf, buf_size, pos, "\\t");
-        } else if (*s == '\r') {
-            stringify_append_cstr(buf, buf_size, pos, "\\r");
-        } else {
-            stringify_append_char(buf, buf_size, pos, *s);
-        }
-        s++;
-    }
-    stringify_append_cstr(buf, buf_size, pos, "\\\"");
-}
-
-// Stringify an expression AST node into a human-readable string for assert messages
-static void stringify_expr_to(Node* node, char* buf, int buf_size, int* pos) {
-    if (!node || *pos >= buf_size - 1)
-        return;
-
-    switch (node->type) {
-    case NODE_INT_LIT: {
-        char tmp[32];
-        snprintf(tmp, sizeof(tmp), "%ld", node->as.int_lit.value);
-        stringify_append_cstr(buf, buf_size, pos, tmp);
-        break;
-    }
-    case NODE_FLOAT_LIT: {
-        char tmp[32];
-        snprintf(tmp, sizeof(tmp), "%g", node->as.float_lit.value);
-        stringify_append_cstr(buf, buf_size, pos, tmp);
-        break;
-    }
-    case NODE_BOOL_LIT:
-        stringify_append_cstr(buf, buf_size, pos, node->as.bool_lit.value ? "true" : "false");
-        break;
-    case NODE_STRING_LIT:
-        stringify_append_string_lit(buf, buf_size, pos, node->as.string_lit.value);
-        break;
-    case NODE_NULL_LIT:
-        stringify_append_cstr(buf, buf_size, pos, "null");
-        break;
-    case NODE_IDENT:
-        stringify_append_n(buf, buf_size, pos, node->as.ident.name, node->as.ident.length);
-        break;
-    case NODE_BINARY: {
-        stringify_append_cstr(buf, buf_size, pos, "(");
-        stringify_expr_to(node->as.binary.left, buf, buf_size, pos);
-        stringify_append_cstr(buf, buf_size, pos, " ");
-        stringify_append_cstr(buf, buf_size, pos, token_type_symbol(node->as.binary.op));
-        stringify_append_cstr(buf, buf_size, pos, " ");
-        stringify_expr_to(node->as.binary.right, buf, buf_size, pos);
-        stringify_append_cstr(buf, buf_size, pos, ")");
-        break;
-    }
-    case NODE_UNARY:
-        stringify_append_cstr(buf, buf_size, pos, token_type_symbol(node->as.unary.op));
-        stringify_expr_to(node->as.unary.operand, buf, buf_size, pos);
-        break;
-    case NODE_CALL: {
-        stringify_expr_to(node->as.call.func, buf, buf_size, pos);
-        stringify_append_cstr(buf, buf_size, pos, "(");
-        for (int i = 0; i < node->as.call.args.count; i++) {
-            if (i > 0) {
-                stringify_append_cstr(buf, buf_size, pos, ", ");
-            }
-            stringify_expr_to(node->as.call.args.nodes[i], buf, buf_size, pos);
-        }
-        stringify_append_cstr(buf, buf_size, pos, ")");
-        break;
-    }
-    case NODE_MEMBER:
-        stringify_expr_to(node->as.member.object, buf, buf_size, pos);
-        stringify_append_cstr(buf, buf_size, pos, ".");
-        stringify_append_n(buf, buf_size, pos, node->as.member.name, node->as.member.length);
-        break;
-    case NODE_INDEX:
-        stringify_expr_to(node->as.index.object, buf, buf_size, pos);
-        stringify_append_cstr(buf, buf_size, pos, "[");
-        stringify_expr_to(node->as.index.index, buf, buf_size, pos);
-        stringify_append_cstr(buf, buf_size, pos, "]");
-        break;
-    default:
-        stringify_append_cstr(buf, buf_size, pos, "...");
-        break;
-    }
-}
-
-char* stringify_expr(Node* node) {
-    static char buf[512];
-    int         pos = 0;
-    stringify_expr_to(node, buf, sizeof(buf), &pos);
-    buf[pos] = '\0';
-    return buf;
-}
-
 // Collect all NODE_TEST_DECL nodes from the program AST
 typedef struct {
     Node** tests;
@@ -1943,57 +1656,6 @@ static void emit_generic_method_impls(CodeGen* gen, Node* ast) {
 
         free(methods);
     }
-}
-
-// Find a method-level generic function declaration in the AST.
-// Matches func (ReceiverType<...>) MethodName<...>(...): ...
-Node* find_generic_method_func_decl(Node* ast, const char* receiver_type, const char* method_name) {
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int d = 0; d < mod->as.module.decls.count; d++) {
-            Node* decl = mod->as.module.decls.nodes[d];
-            // Direct method: func (Vec<T>) map<K>(...) -> Vec<K>
-            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.receiver_type != NULL &&
-                decl->as.func_decl.type_param_count > 0 &&
-                strcmp(decl->as.func_decl.receiver_type, receiver_type) == 0 &&
-                strcmp(decl->as.func_decl.name, method_name) == 0) {
-                return decl;
-            }
-            // Inside impl blocks
-            if (decl->type == NODE_IMPL_DECL) {
-                for (int j = 0; j < decl->as.impl_decl.methods.count; j++) {
-                    Node* method = decl->as.impl_decl.methods.nodes[j];
-                    if (method->type == NODE_FUNC_DECL &&
-                        method->as.func_decl.receiver_type != NULL &&
-                        method->as.func_decl.type_param_count > 0 &&
-                        strcmp(method->as.func_decl.receiver_type, receiver_type) == 0 &&
-                        strcmp(method->as.func_decl.name, method_name) == 0) {
-                        return method;
-                    }
-                }
-            }
-        }
-    }
-    return NULL;
-}
-
-// Find a generic free function declaration in the AST by name
-Node* find_generic_func_decl(Node* ast, const char* name) {
-    for (int m = 0; m < ast->as.program.modules.count; m++) {
-        Node* mod = ast->as.program.modules.nodes[m];
-        if (!mod || mod->type != NODE_MODULE)
-            continue;
-        for (int d = 0; d < mod->as.module.decls.count; d++) {
-            Node* decl = mod->as.module.decls.nodes[d];
-            if (decl->type == NODE_FUNC_DECL && decl->as.func_decl.type_param_count > 0 &&
-                strcmp(decl->as.func_decl.name, name) == 0) {
-                return decl;
-            }
-        }
-    }
-    return NULL;
 }
 
 GenericFuncDef* lookup_generic_func_def_for_instance(CodeGen* gen, const char* base_name) {

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -51,7 +51,7 @@ int codegen_find_tuple_type_index(CodeGen* gen, Type* tuple_type) {
         return -1;
     }
     for (int i = 0; i < gen->tuple_type_count; i++) {
-        if (tuple_types_equal(gen->tuple_types[i], tuple_type)) {
+        if (type_equals(gen->tuple_types[i], tuple_type)) {
             return i;
         }
     }

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -3,17 +3,15 @@
 
 #include "codegen_emit.h"
 #include "codegen_types.h"
+#include "print_ast.h"
 
 // --- From codegen.c: generic substitution ---
 Type*           subst_lookup(CodeGen* gen, const char* name);
-char*           stringify_expr(Node* node);
 int             lookup_string_lit(CodeGen* gen, const char* value, int length);
 GenericFuncDef* lookup_generic_func_def_for_instance(CodeGen* gen, const char* base_name);
-Node* find_generic_method_func_decl(Node* ast, const char* receiver_type, const char* method_name);
-Node* find_generic_func_decl(Node* ast, const char* name);
-int   parse_method_key(const char* base_name, char* recv_out, int recv_size, char* method_out,
-                       int method_size);
-void  register_thunk(CodeGen* gen, const char* c_name, Type* func_type);
+int  parse_method_key(const char* base_name, char* recv_out, int recv_size, char* method_out,
+                      int method_size);
+void register_thunk(CodeGen* gen, const char* c_name, Type* func_type);
 
 // --- From codegen_emit.c: shared helpers ---
 void        defer_push(CodeGen* gen, Node* node);
@@ -47,7 +45,6 @@ Node* lookup_generic_template_field_type(CodeGen* gen, const char* field_name);
 
 // --- From codegen_stmt.c: statement emission ---
 void emit_block_contents(CodeGen* gen, Node* block);
-int  has_owned_temps(Node* node);
 int  hoist_owned_temps(CodeGen* gen, Node* expr);
 void cleanup_owned_temps(CodeGen* gen, int saved_count);
 

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -12,7 +12,6 @@ static void emit_var_decl_stmt(CodeGen* gen, Node* node);
 static void emit_return_stmt(CodeGen* gen, Node* node);
 static void emit_match_stmt(CodeGen* gen, Node* node);
 static void collect_owned_temps(Node* node, Node*** temps, int* count, int* cap);
-int         has_owned_temps(Node* node);
 
 // Walk a destructuring pattern and RC-track any identifiers with RC-managed types
 static void rc_track_destruct_pattern(CodeGen* gen, DestructPattern* pattern) {
@@ -46,19 +45,6 @@ void emit_block_contents(CodeGen* gen, Node* block) {
     }
     rc_cleanup_scope(gen, gen->rc.depth);
     gen->rc.depth--;
-}
-
-// Look up a struct field type by field name.
-static Type* find_struct_field_type(Type* struct_type, const char* field_name) {
-    if (!struct_type || struct_type->kind != TYPE_STRUCT) {
-        return NULL;
-    }
-    for (int i = 0; i < struct_type->as.struc.field_count; i++) {
-        if (strcmp(struct_type->as.struc.field_names[i], field_name) == 0) {
-            return struct_type->as.struc.field_types[i];
-        }
-    }
-    return NULL;
 }
 
 // Record a hoisted expression node and its temporary name.
@@ -396,9 +382,10 @@ static int emit_rc_member_assign_stmt(CodeGen* gen, Node* expr) {
                     rc_is_tracked(gen, member->as.member.object->as.ident.name);
 
     if (obj_is_rc) {
-        const char* obj_name = member->as.member.object->as.ident.name;
-        Type*       obj_type = rc_get_var_type(gen, obj_name);
-        Type*       field_ty = find_struct_field_type(obj_type, member->as.member.name);
+        const char* obj_name  = member->as.member.object->as.ident.name;
+        Type*       obj_type  = rc_get_var_type(gen, obj_name);
+        int         field_idx = type_find_field_index(obj_type, member->as.member.name);
+        Type*       field_ty  = field_idx >= 0 ? obj_type->as.struc.field_types[field_idx] : NULL;
 
         if (emit_rc_member_assign_enum_field(gen, expr, member, field_ty)) {
             return 1;
@@ -459,80 +446,6 @@ static int emit_vec_index_assign_stmt(CodeGen* gen, Node* expr) {
     emit_expr(gen, expr->as.assign.value);
     emit(gen, ";\n");
     return 1;
-}
-
-// Check if an expression tree contains any owned temps.
-// Return whether a new-expression subtree contains any owned temps.
-static int has_owned_temps_new_expr(Node* node) {
-    if (node->as.new_expr.init) {
-        for (int i = 0; i < node->as.new_expr.init->as.struct_init.fields.count; i++) {
-            Node* field = node->as.new_expr.init->as.struct_init.fields.nodes[i];
-            if (field && field->type == NODE_FIELD_INIT &&
-                has_owned_temps(field->as.field_init.value)) {
-                return 1;
-            }
-        }
-    }
-    for (int i = 0; i < node->as.new_expr.args.count; i++) {
-        if (has_owned_temps(node->as.new_expr.args.nodes[i])) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-// Return whether any child expression for this node contains owned temps.
-static int has_owned_temps_children(Node* node) {
-    switch (node->type) {
-    case NODE_CALL:
-        if (has_owned_temps(node->as.call.func))
-            return 1;
-        for (int i = 0; i < node->as.call.args.count; i++) {
-            if (has_owned_temps(node->as.call.args.nodes[i]))
-                return 1;
-        }
-        return 0;
-    case NODE_BINARY:
-        return has_owned_temps(node->as.binary.left) || has_owned_temps(node->as.binary.right);
-    case NODE_UNARY:
-        return has_owned_temps(node->as.unary.operand);
-    case NODE_MEMBER:
-        return has_owned_temps(node->as.member.object);
-    case NODE_INDEX:
-        return has_owned_temps(node->as.index.object) || has_owned_temps(node->as.index.index);
-    case NODE_SLICE:
-        return has_owned_temps(node->as.slice.object) || has_owned_temps(node->as.slice.start) ||
-               has_owned_temps(node->as.slice.end);
-    case NODE_NEW_EXPR:
-        return has_owned_temps_new_expr(node);
-    case NODE_CAST:
-        return has_owned_temps(node->as.cast_expr.expr);
-    case NODE_STRING_INTERP:
-        for (int i = 0; i < node->as.string_interp.part_count; i++) {
-            if (has_owned_temps(node->as.string_interp.parts.nodes[i]))
-                return 1;
-        }
-        return 0;
-    case NODE_ASSIGN:
-        return has_owned_temps(node->as.assign.target) || has_owned_temps(node->as.assign.value);
-    case NODE_ENUM_VALUE:
-        for (int i = 0; i < node->as.enum_value.args.count; i++) {
-            if (has_owned_temps(node->as.enum_value.args.nodes[i]))
-                return 1;
-        }
-        return 0;
-    default:
-        return 0;
-    }
-}
-
-// Check if an expression tree contains any owned temps.
-int has_owned_temps(Node* node) {
-    if (!node)
-        return 0;
-    if (node->is_owned_temp)
-        return 1;
-    return has_owned_temps_children(node);
 }
 
 // Emit an expression statement (NODE_EXPR_STMT).

--- a/w0/codegen_types.h
+++ b/w0/codegen_types.h
@@ -19,14 +19,6 @@ int codegen_extract_method_bindings(NodeList* pattern_args, Type** concrete_args
                                     char*** out_params, Type*** out_args, int* out_count);
 
 // Shared helpers (defined in codegen.c)
-int   tuple_types_equal(Type* a, Type* b);
-Type* type_from_node(Node* type_node);
 char* build_mangled_name_from_generic_node(CodeGen* gen, Node* type_node);
-
-// Generic AST lookup helpers (defined in codegen.c)
-Node* find_generic_struct_decl(Node* ast, const char* name);
-Node* find_generic_enum_decl(Node* ast, const char* name);
-void  collect_generic_methods(Node* ast, const char* struct_name, Node*** methods_out,
-                              int* count_out);
 
 #endif

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -1184,3 +1184,131 @@ void print_ast_checked(Node* node, int depth) {
         break;
     }
 }
+
+// ============================================================================
+// Stringify: render AST expression to string (for assert messages)
+// ============================================================================
+
+// Append a C string into a bounded stringify buffer.
+static void stringify_append_cstr(char* buf, int buf_size, int* pos, const char* s) {
+    while (*s && *pos < buf_size - 1) {
+        buf[(*pos)++] = *s++;
+    }
+}
+
+// Append a fixed-length byte slice into a bounded stringify buffer.
+static void stringify_append_n(char* buf, int buf_size, int* pos, const char* s, int n) {
+    for (int i = 0; i < n && *pos < buf_size - 1; i++) {
+        buf[(*pos)++] = s[i];
+    }
+}
+
+// Append a single character into a bounded stringify buffer.
+static void stringify_append_char(char* buf, int buf_size, int* pos, char c) {
+    if (*pos < buf_size - 1) {
+        buf[(*pos)++] = c;
+    }
+}
+
+// Append a string literal with escaping and surrounding quotes.
+static void stringify_append_string_lit(char* buf, int buf_size, int* pos, const char* s) {
+    stringify_append_cstr(buf, buf_size, pos, "\\\"");
+    while (*s && *pos < buf_size - 1) {
+        if (*s == '"') {
+            stringify_append_cstr(buf, buf_size, pos, "\\\"");
+        } else if (*s == '\\') {
+            stringify_append_cstr(buf, buf_size, pos, "\\\\");
+        } else if (*s == '\n') {
+            stringify_append_cstr(buf, buf_size, pos, "\\n");
+        } else if (*s == '\t') {
+            stringify_append_cstr(buf, buf_size, pos, "\\t");
+        } else if (*s == '\r') {
+            stringify_append_cstr(buf, buf_size, pos, "\\r");
+        } else {
+            stringify_append_char(buf, buf_size, pos, *s);
+        }
+        s++;
+    }
+    stringify_append_cstr(buf, buf_size, pos, "\\\"");
+}
+
+// Stringify an expression AST node into a human-readable string for assert messages
+static void stringify_expr_to(Node* node, char* buf, int buf_size, int* pos) {
+    if (!node || *pos >= buf_size - 1)
+        return;
+
+    switch (node->type) {
+    case NODE_INT_LIT: {
+        char tmp[32];
+        snprintf(tmp, sizeof(tmp), "%ld", node->as.int_lit.value);
+        stringify_append_cstr(buf, buf_size, pos, tmp);
+        break;
+    }
+    case NODE_FLOAT_LIT: {
+        char tmp[32];
+        snprintf(tmp, sizeof(tmp), "%g", node->as.float_lit.value);
+        stringify_append_cstr(buf, buf_size, pos, tmp);
+        break;
+    }
+    case NODE_BOOL_LIT:
+        stringify_append_cstr(buf, buf_size, pos, node->as.bool_lit.value ? "true" : "false");
+        break;
+    case NODE_STRING_LIT:
+        stringify_append_string_lit(buf, buf_size, pos, node->as.string_lit.value);
+        break;
+    case NODE_NULL_LIT:
+        stringify_append_cstr(buf, buf_size, pos, "null");
+        break;
+    case NODE_IDENT:
+        stringify_append_n(buf, buf_size, pos, node->as.ident.name, node->as.ident.length);
+        break;
+    case NODE_BINARY: {
+        stringify_append_cstr(buf, buf_size, pos, "(");
+        stringify_expr_to(node->as.binary.left, buf, buf_size, pos);
+        stringify_append_cstr(buf, buf_size, pos, " ");
+        stringify_append_cstr(buf, buf_size, pos, token_type_symbol(node->as.binary.op));
+        stringify_append_cstr(buf, buf_size, pos, " ");
+        stringify_expr_to(node->as.binary.right, buf, buf_size, pos);
+        stringify_append_cstr(buf, buf_size, pos, ")");
+        break;
+    }
+    case NODE_UNARY:
+        stringify_append_cstr(buf, buf_size, pos, token_type_symbol(node->as.unary.op));
+        stringify_expr_to(node->as.unary.operand, buf, buf_size, pos);
+        break;
+    case NODE_CALL: {
+        stringify_expr_to(node->as.call.func, buf, buf_size, pos);
+        stringify_append_cstr(buf, buf_size, pos, "(");
+        for (int i = 0; i < node->as.call.args.count; i++) {
+            if (i > 0) {
+                stringify_append_cstr(buf, buf_size, pos, ", ");
+            }
+            stringify_expr_to(node->as.call.args.nodes[i], buf, buf_size, pos);
+        }
+        stringify_append_cstr(buf, buf_size, pos, ")");
+        break;
+    }
+    case NODE_MEMBER:
+        stringify_expr_to(node->as.member.object, buf, buf_size, pos);
+        stringify_append_cstr(buf, buf_size, pos, ".");
+        stringify_append_n(buf, buf_size, pos, node->as.member.name, node->as.member.length);
+        break;
+    case NODE_INDEX:
+        stringify_expr_to(node->as.index.object, buf, buf_size, pos);
+        stringify_append_cstr(buf, buf_size, pos, "[");
+        stringify_expr_to(node->as.index.index, buf, buf_size, pos);
+        stringify_append_cstr(buf, buf_size, pos, "]");
+        break;
+    default:
+        stringify_append_cstr(buf, buf_size, pos, "...");
+        break;
+    }
+}
+
+char* stringify_expr(Node* node) {
+    static char buf[512];
+    int         pos = 0;
+    stringify_expr_to(node, buf, sizeof(buf), &pos);
+    buf[pos] = '\0';
+    return buf;
+}

--- a/w0/print_ast.h
+++ b/w0/print_ast.h
@@ -3,7 +3,8 @@
 
 #include "ast.h"
 
-void print_ast(Node* node, int depth);
-void print_ast_checked(Node* node, int depth);
+void  print_ast(Node* node, int depth);
+void  print_ast_checked(Node* node, int depth);
+char* stringify_expr(Node* node);
 
 #endif

--- a/w0/types.c
+++ b/w0/types.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "alloc.h"
+#include "ast.h"
 #include "vec.h"
 
 // Built-in type singletons
@@ -411,6 +413,18 @@ int type_is_rc_managed(Type* type) {
     return 0;
 }
 
+int type_find_field_index(Type* type, const char* field_name) {
+    if (!type || type->kind != TYPE_STRUCT) {
+        return -1;
+    }
+    for (int i = 0; i < type->as.struc.field_count; i++) {
+        if (strcmp(type->as.struc.field_names[i], field_name) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 int type_assignable(Type* target, Type* value) {
     if (type_equals(target, value))
         return 1;
@@ -766,4 +780,64 @@ void typelist_free(TypeList* list) {
     list->types    = NULL;
     list->count    = 0;
     list->capacity = 0;
+}
+
+// Build a Type* from a type node (simplified, for codegen/tuple collection)
+Type* type_from_node(Node* type_node) {
+    if (!type_node)
+        return type_void;
+
+    switch (type_node->type) {
+    case NODE_IDENT: {
+        const char* name    = type_node->as.ident.name;
+        Type*       builtin = type_builtin_from_name(name);
+        if (builtin)
+            return builtin;
+        // User-defined type - return a struct type
+        return type_struct(name);
+    }
+    case NODE_ARRAY_TYPE: {
+        Type* elem = type_from_node(type_node->as.array_type.elem_type);
+        int   size = -1;
+        if (type_node->as.array_type.size && type_node->as.array_type.size->type == NODE_INT_LIT) {
+            size = (int)type_node->as.array_type.size->as.int_lit.value;
+        }
+        return type_array(elem, size);
+    }
+    case NODE_TUPLE_TYPE: {
+        int    count = type_node->as.tuple_type.elem_types.count;
+        Type** elems = xmalloc(count * sizeof(Type*));
+        for (int i = 0; i < count; i++) {
+            elems[i] = type_from_node(type_node->as.tuple_type.elem_types.nodes[i]);
+        }
+        return type_tuple(elems, count);
+    }
+    case NODE_GENERIC_TYPE: {
+        const char* base      = type_node->as.generic_type.base_name;
+        int         arg_count = type_node->as.generic_type.type_args.count;
+        Type**      args      = xmalloc(arg_count * sizeof(Type*));
+        for (int i = 0; i < arg_count; i++) {
+            args[i] = type_from_node(type_node->as.generic_type.type_args.nodes[i]);
+        }
+        // Vec and Span are special built-in generic types
+        if (strcmp(base, "Vec") == 0 && arg_count == 1) {
+            Type* result = type_vec(args[0]);
+            free(args);
+            return result;
+        }
+        if (strcmp(base, "Span") == 0 && arg_count == 1) {
+            Type* result = type_span(args[0]);
+            free(args);
+            return result;
+        }
+        // For other generics, build a struct type with the mangled name
+        char* mangled = type_mangle_generic(base, args, arg_count);
+        Type* result  = type_struct(mangled);
+        free(mangled);
+        free(args);
+        return result;
+    }
+    default:
+        return type_error;
+    }
 }

--- a/w0/types.h
+++ b/w0/types.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+// Forward declaration for type_from_node
+typedef struct Node Node;
+
 typedef enum {
     TYPE_VOID,
     TYPE_BOOL,
@@ -177,6 +180,7 @@ int         type_is_rc_managed(Type* type);             // Is this an RC-managed
 int         type_is_signed_integer(Type* type);         // Is this a signed integer type?
 int         type_is_unsigned_integer(Type* type);       // Is this an unsigned integer type?
 int         type_enum_variant_index(Type* enum_type, const char* variant_name);
+int         type_find_field_index(Type* type, const char* field_name);
 int         type_supports_vec_contains(Type* type); // Can Vec<T>.contains compare this type?
 int         type_supports_vec_sort(Type* type);     // Is this type sortable by Vec<T>.sort?
 int         type_supports_equality(Type* type);     // Can this type be compared with ==?
@@ -186,6 +190,9 @@ const char* type_name(Type* type);
 Type*       type_builtin_from_name(const char* name); // Returns builtin Type* or NULL
 const char* type_c_name(const char* name);            // Returns C type string or NULL
 int         type_is_builtin_name(const char* name);   // Is this a builtin type name?
+
+// AST-to-Type conversion
+Type* type_from_node(Node* type_node);
 
 // TypeList operations
 void typelist_init(TypeList* list);


### PR DESCRIPTION
## Summary

- Move pure AST queries and type predicates out of codegen files into their proper modules (`ast.c`, `types.c`, `print_ast.c`) and eliminate duplicate implementations across checker and codegen
- Eliminates 7 net lines while improving module boundaries — no functional changes, all 242 tests pass

## Changes

- **Eliminate duplicates**: `tuple_types_equal` → `type_equals`, `find_resolved_enum_variant` → `type_enum_variant_index`, `find_struct_field_index`/`find_struct_field_type` → `type_find_field_index`
- **Move to `types.c`**: `type_from_node` (pure AST→Type conversion), `type_find_field_index` (new consolidated function)
- **Move to `ast.c`**: `find_generic_struct_decl`, `find_generic_enum_decl`, `find_generic_func_decl`, `find_generic_method_func_decl`, `collect_generic_methods`, `has_owned_temps` family (3 functions)
- **Move to `print_ast.c`**: `stringify_expr` family (6 functions)

## Test plan

- [x] `make` — clean build, no warnings
- [x] `make test` — all 242 tests pass
- [x] `make format` — clean formatting