### PR TITLE
feat: add Box<T> built-in type with auto-deref

### DIFF
--- a/w0/ast.c
+++ b/w0/ast.c
@@ -489,6 +489,7 @@ static void node_reset_checker_flags(Node* node) {
     // Top-level flags (apply to all expression node types)
     node->is_owned_temp   = 0;
     node->owned_temp_type = NULL;
+    node->is_box_deref    = 0;
 
     switch (node->type) {
     case NODE_BINARY:

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -185,6 +185,7 @@ struct Node {
     int      column;
     int      is_owned_temp;   // Set by checker: expression produces an owned RC value
     Type*    owned_temp_type; // Set by checker: the RC type of the owned temporary
+    int      is_box_deref;    // Set by checker: auto-deref Box<T> to T (emit ->value)
 
     union {
         // Literals

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -123,6 +123,10 @@ void checker_init(Checker* checker) {
     checker->containers.vecs         = NULL;
     checker->containers.vec_count    = 0;
     checker->containers.vec_capacity = 0;
+    // Box support
+    checker->containers.boxes        = NULL;
+    checker->containers.box_count    = 0;
+    checker->containers.box_capacity = 0;
     // Trait support
     checker->traits.impls         = NULL;
     checker->traits.impl_count    = 0;
@@ -253,6 +257,11 @@ void checker_free(Checker* checker) {
         free(checker->containers.vecs[i].method_bodies);
     }
     free(checker->containers.vecs);
+    // Free box instances
+    for (int i = 0; i < checker->containers.box_count; i++) {
+        free(checker->containers.boxes[i].mangled_name);
+    }
+    free(checker->containers.boxes);
     // Free trait implementations
     for (int i = 0; i < checker->traits.impl_count; i++) {
         free(checker->traits.impls[i].trait_name);
@@ -694,6 +703,12 @@ static Type* check_var_decl_initializer(Checker* checker, Type* decl_type, Node*
 static Type* resolve_var_decl_type(Checker* checker, Node* node, const char* name, Type* decl_type,
                                    Type* init_type) {
     if (decl_type && init_type) {
+        // Auto-deref Box<T> when declared type is T
+        if (!type_assignable(decl_type, init_type) && init_type->kind == TYPE_BOX &&
+            type_assignable(decl_type, init_type->as.box.elem) && node->as.var_decl.init) {
+            node->as.var_decl.init->is_box_deref = 1;
+            init_type                            = init_type->as.box.elem;
+        }
         // Both specified - check compatibility
         if (!type_assignable(decl_type, init_type)) {
             check_error_type(checker, node->line, node->column, name, decl_type, init_type);
@@ -761,7 +776,8 @@ static void maybe_mark_var_decl_rc_from_init(Checker* checker, Node* node, Symbo
 
     if (init->type == NODE_NEW_EXPR) {
         mark_var_decl_rc(node, sym, init->as.new_expr.resolved_type);
-    } else if (init->type == NODE_IDENT) {
+    } else if (init->type == NODE_IDENT && !init->is_box_deref) {
+        // Copy from RC var (but not if auto-deref'd from Box — that's a value copy)
         Symbol* src = checker_lookup(checker, init->as.ident.name);
         if (src && src->is_rc) {
             mark_var_decl_rc(node, sym, src->type);
@@ -965,6 +981,14 @@ static void check_return_stmt(Checker* checker, Node* node) {
         }
         Type* actual              = check_expression(checker, node->as.return_stmt.value);
         checker->enum_target_hint = old_hint;
+
+        // Auto-deref Box<T> when returning T
+        if (actual && actual->kind == TYPE_BOX && !type_assignable(expected, actual) &&
+            type_assignable(expected, actual->as.box.elem)) {
+            node->as.return_stmt.value->is_box_deref = 1;
+            actual                                   = actual->as.box.elem;
+        }
+
         if (!type_assignable(expected, actual)) {
             check_error_type(checker, node->line, node->column, "Return", expected, actual);
         }
@@ -2798,6 +2822,18 @@ int checker_check(Checker* checker, Node* ast) {
         register_generic_def(checker, "Vec", vec_params, NULL, 1, NULL);
         free(vec_params[0]);
         free(vec_params);
+    }
+
+    // Register builtin Box<T> as a GenericDef (prelude so user structs can shadow it)
+    {
+        const char* saved_module        = checker->modules.current_module;
+        checker->modules.current_module = "prelude";
+        char** box_params               = xmalloc(sizeof(char*));
+        box_params[0]                   = xstrdup("T");
+        register_generic_def(checker, "Box", box_params, NULL, 1, NULL);
+        free(box_params[0]);
+        free(box_params);
+        checker->modules.current_module = saved_module;
     }
 
     for (size_t i = 0; i < sizeof(k_checker_pass_specs) / sizeof(k_checker_pass_specs[0]); i++) {

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -100,6 +100,13 @@ typedef struct {
     int    methods_instantiated; // Whether user methods have been populated
 } VecInstance;
 
+// Instantiated box type
+typedef struct {
+    char* mangled_name; // "Box_i64"
+    Type* elem_type;    // The element type
+    Type* type;         // The TYPE_BOX instance
+} BoxInstance;
+
 // Generic free function definition (template)
 // Also used for method-level generics: func (Vec<T>) map<K>(...) -> Vec<K>
 // For methods: type_params = combined receiver-bound + method params ["T", "K"].
@@ -160,7 +167,7 @@ typedef struct {
     int                  func_instance_capacity;
 } CheckerGenerics;
 
-// Instantiated container types (Span, Vec)
+// Instantiated container types (Span, Vec, Box)
 typedef struct {
     SpanInstance* spans;
     int           span_count;
@@ -168,6 +175,9 @@ typedef struct {
     VecInstance*  vecs;
     int           vec_count;
     int           vec_capacity;
+    BoxInstance*  boxes;
+    int           box_count;
+    int           box_capacity;
 } CheckerContainers;
 
 // Deferred trait check: body-less method in impl block (duck-type conformance)

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -10,6 +10,15 @@
 // Forward declaration for check_struct_init (called by check_new_expr)
 static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
 
+// Auto-deref Box<T> to T: if type is TYPE_BOX, set is_box_deref flag and return elem type.
+static Type* auto_deref_box(Node* node, Type* type) {
+    if (type && type->kind == TYPE_BOX) {
+        node->is_box_deref = 1;
+        return type->as.box.elem;
+    }
+    return type;
+}
+
 static void infer_type_param(Checker* checker, GenericFuncDef* def, Node* param_type,
                              Type* arg_type, Type** inferred);
 
@@ -376,6 +385,10 @@ static Type* check_binary_expr(Checker* checker, Node* node) {
         return type_error;
     }
 
+    // Auto-deref Box<T> operands
+    left  = auto_deref_box(node->as.binary.left, left);
+    right = auto_deref_box(node->as.binary.right, right);
+
     return check_binary_op_by_token(checker, node, left, right);
 }
 
@@ -386,6 +399,9 @@ static Type* check_unary_expr(Checker* checker, Node* node) {
 
     if (operand->kind == TYPE_ERROR)
         return type_error;
+
+    // Auto-deref Box<T> operand
+    operand = auto_deref_box(node->as.unary.operand, operand);
 
     switch (op) {
     case TOK_MINUS:
@@ -1173,6 +1189,16 @@ static Type* check_assign_expr(Checker* checker, Node* node) {
 
     if (!check_assignment_enum_tag_writable(checker, node)) {
         return type_error;
+    }
+
+    // Auto-deref Box<T> target: `b = 20` becomes `b->value = 20`
+    if (target->kind == TYPE_BOX) {
+        target = auto_deref_box(node->as.assign.target, target);
+    }
+
+    // Auto-deref Box<T> value when assigning to T
+    if (value->kind == TYPE_BOX && type_assignable(target, value->as.box.elem)) {
+        value = auto_deref_box(node->as.assign.value, value);
     }
 
     if (!check_compound_assignment_operands(checker, node, target, value)) {
@@ -1964,6 +1990,12 @@ static void check_call_named_args(Checker* checker, Node* node, Type* func_type)
 
         checker->expected_func_type = old_expected;
 
+        // Auto-deref Box<T> argument when parameter expects T
+        if (!type_assignable(param_type, arg_type) && arg_type->kind == TYPE_BOX &&
+            type_assignable(param_type, arg_type->as.box.elem)) {
+            arg_type = auto_deref_box(node->as.call.args.nodes[i], arg_type);
+        }
+
         if (!type_assignable(param_type, arg_type)) {
             char ctx[32];
             snprintf(ctx, sizeof(ctx), "Argument %d", i + 1);
@@ -2052,6 +2084,26 @@ static Type* lookup_struct_init_method(Type* struct_type) {
 }
 
 static Type* check_new_constructor_call_expr(Checker* checker, Node* node, Type* resolved) {
+    // Box<T>(expr) constructor form
+    if (resolved->kind == TYPE_BOX) {
+        if (node->as.new_expr.args.count != 1) {
+            check_error(checker, node->line, node->column,
+                        "Box constructor requires exactly 1 argument");
+            return type_error;
+        }
+        Type* arg_type = check_expression(checker, node->as.new_expr.args.nodes[0]);
+        if (arg_type->kind == TYPE_ERROR) {
+            return type_error;
+        }
+        if (!type_assignable(resolved->as.box.elem, arg_type)) {
+            check_error_type(checker, node->line, node->column, "Box value", resolved->as.box.elem,
+                             arg_type);
+            return type_error;
+        }
+        set_new_expr_result(node, resolved);
+        return resolved;
+    }
+
     if (resolved->kind != TYPE_STRUCT) {
         check_error(checker, node->line, node->column,
                     "'new' constructor call requires a struct type");
@@ -2165,6 +2217,34 @@ static Type* check_new_expr(Checker* checker, Node* node) {
     // Init-call form: new Type(args)
     if (node->as.new_expr.init == NULL) {
         return check_new_constructor_call_expr(checker, node, resolved);
+    }
+
+    // Box<T> literal form: new Box<T>{value: expr}
+    if (resolved->kind == TYPE_BOX) {
+        Node* init = node->as.new_expr.init;
+        if (init->as.struct_init.fields.count != 1) {
+            check_error(checker, node->line, node->column,
+                        "Box initializer requires exactly 1 field 'value'");
+            return type_error;
+        }
+        Node* field = init->as.struct_init.fields.nodes[0];
+        if (!field || field->type != NODE_FIELD_INIT ||
+            strcmp(field->as.field_init.name, "value") != 0) {
+            check_error(checker, node->line, node->column,
+                        "Box initializer requires field named 'value'");
+            return type_error;
+        }
+        Type* val_type = check_expression(checker, field->as.field_init.value);
+        if (val_type->kind == TYPE_ERROR) {
+            return type_error;
+        }
+        if (!type_assignable(resolved->as.box.elem, val_type)) {
+            check_error_type(checker, field->line, field->column, "Box value",
+                             resolved->as.box.elem, val_type);
+            return type_error;
+        }
+        set_new_expr_result(node, resolved);
+        return resolved;
     }
 
     // Struct literal form below: new Type { fields }

--- a/w0/checker_internal.h
+++ b/w0/checker_internal.h
@@ -15,6 +15,7 @@ void check_statement(Checker* checker, Node* node);
 // --- From checker_types.c: type resolution ---
 Type*        resolve_type(Checker* checker, Node* type_node);
 Type*        ensure_vec_type(Checker* checker, Type* elem_type);
+Type*        ensure_box_type(Checker* checker, Type* elem_type);
 Type*        instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
                                       Type** resolved_args, int arg_count);
 VecInstance* lookup_vec_instance_pub(Checker* checker, const char* mangled_name);

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -1042,6 +1042,69 @@ Type* ensure_vec_type(Checker* checker, Type* elem_type) {
     return vec_type;
 }
 
+// Look up an already-instantiated box type by mangled name
+static BoxInstance* lookup_box_instance(Checker* checker, const char* mangled_name) {
+    for (int i = 0; i < checker->containers.box_count; i++) {
+        if (strcmp(checker->containers.boxes[i].mangled_name, mangled_name) == 0) {
+            return &checker->containers.boxes[i];
+        }
+    }
+    return NULL;
+}
+
+// Register an instantiated box type
+static void register_box_instance(Checker* checker, const char* mangled_name, Type* elem_type,
+                                  Type* box_type) {
+    VEC_GROW(checker->containers.boxes, checker->containers.box_count,
+             checker->containers.box_capacity);
+    BoxInstance* inst  = &checker->containers.boxes[checker->containers.box_count++];
+    inst->mangled_name = xstrdup(mangled_name);
+    inst->elem_type    = elem_type;
+    inst->type         = box_type;
+}
+
+// Resolve Box<T> type: validate single arg, create box type, and register
+static Type* resolve_box_type(Checker* checker, Node* type_node) {
+    int arg_count = type_node->as.generic_type.type_args.count;
+    if (arg_count != 1) {
+        check_error(checker, type_node->line, type_node->column,
+                    "Box requires exactly 1 type argument, got %d", arg_count);
+        return type_error;
+    }
+
+    Type* elem_type = resolve_type(checker, type_node->as.generic_type.type_args.nodes[0]);
+    if (elem_type == type_error) {
+        return type_error;
+    }
+
+    char mangled[256];
+    snprintf(mangled, sizeof(mangled), "Box_%s", type_mangle_name(elem_type));
+
+    BoxInstance* existing = lookup_box_instance(checker, mangled);
+    if (existing) {
+        return existing->type;
+    }
+
+    Type* box_type = type_box(elem_type);
+    register_box_instance(checker, mangled, elem_type, box_type);
+    return box_type;
+}
+
+// Ensure a Box<elem_type> exists (look up or create + register)
+Type* ensure_box_type(Checker* checker, Type* elem_type) {
+    char mangled[256];
+    snprintf(mangled, sizeof(mangled), "Box_%s", type_mangle_name(elem_type));
+
+    BoxInstance* existing = lookup_box_instance(checker, mangled);
+    if (existing) {
+        return existing->type;
+    }
+
+    Type* box_type = type_box(elem_type);
+    register_box_instance(checker, mangled, elem_type, box_type);
+    return box_type;
+}
+
 // Resolve Span<T> type: validate single arg and create span type
 static Type* resolve_span_type(Checker* checker, Node* type_node) {
     int arg_count = type_node->as.generic_type.type_args.count;
@@ -1486,6 +1549,14 @@ static Type* resolve_generic_type_node(Checker* checker, Node* type_node) {
     // Handle builtin Span<T> type.
     if (strcmp(base_name, "Span") == 0) {
         return resolve_span_type(checker, type_node);
+    }
+
+    // Handle builtin Box<T> type (only if no user-defined Box struct exists).
+    if (strcmp(base_name, "Box") == 0) {
+        GenericDef* box_def = lookup_generic_def(checker, "Box");
+        if (!box_def || !box_def->decl) {
+            return resolve_box_type(checker, type_node);
+        }
     }
 
     // Look up the generic definition.

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1897,6 +1897,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     compute_enum_eq_flags(gen, ast);
     emit_struct_forward_decls(gen, ast);
     emit_vec_typedefs(gen);
+    emit_box_typedefs(gen);
     emit_span_typedefs(gen);
     emit_enum_typedefs(gen, ast);
     emit_generic_enum_typedefs(gen, ast);

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -64,6 +64,8 @@ typedef struct {
     int                  span_count;
     VecInstance*         vecs;
     int                  vec_count;
+    BoxInstance*         boxes;
+    int                  box_count;
     TraitImpl*           traits;
     int                  trait_count;
     GenericFuncDef*      func_defs;

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -280,12 +280,22 @@ static void emit_generic_type(CodeGen* gen, Node* type_node) {
     const char* base    = type_node->as.generic_type.base_name;
     int         is_span = (strcmp(base, "Span") == 0);
     int         is_vec  = (strcmp(base, "Vec") == 0);
+    int         is_box  = (strcmp(base, "Box") == 0);
 
     if (is_vec || is_span) {
         emit(gen, "%s", is_vec ? "__Vec_" : "__Span_");
         emit_vec_or_span_type_arg(gen, type_node->as.generic_type.type_args.nodes[0]);
         if (is_vec)
             emit(gen, "*"); // Vec is RC-managed pointer
+        return;
+    }
+
+    if (is_box && gen->checker.box_count > 0) {
+        // Only use builtin Box emission if checker produced BoxInstances
+        // (user-defined Box<T> structs go through regular generic path)
+        emit(gen, "__Box_");
+        emit_vec_or_span_type_arg(gen, type_node->as.generic_type.type_args.nodes[0]);
+        emit(gen, "*"); // Box is RC-managed pointer
         return;
     }
 
@@ -432,6 +442,9 @@ void emit_resolved_type(CodeGen* gen, Type* type) {
         break;
     case TYPE_VEC:
         emit(gen, "__Vec_%s*", type_mangle_name(type->as.vec.elem));
+        break;
+    case TYPE_BOX:
+        emit(gen, "__Box_%s*", type_mangle_name(type->as.box.elem));
         break;
     case TYPE_ENUM:
         emit(gen, "%s", type->as.enm.name);
@@ -956,6 +969,21 @@ void emit_vec_typedefs(CodeGen* gen) {
         emit(gen, "    int64_t count;\n");
         emit(gen, "    int64_t capacity;\n");
         emit(gen, "} __Vec_%s;\n\n", elem_tname);
+    }
+}
+
+// Emit struct typedefs for each instantiated Box type (__Box_T)
+void emit_box_typedefs(CodeGen* gen) {
+    for (int i = 0; i < gen->checker.box_count; i++) {
+        BoxInstance* inst       = &gen->checker.boxes[i];
+        Type*        elem_type  = inst->elem_type;
+        const char*  elem_tname = type_mangle_name(elem_type);
+
+        emit(gen, "typedef struct {\n");
+        emit(gen, "    ");
+        emit_resolved_type(gen, elem_type);
+        emit(gen, " value;\n");
+        emit(gen, "} __Box_%s;\n\n", elem_tname);
     }
 }
 

--- a/w0/codegen_emit.h
+++ b/w0/codegen_emit.h
@@ -31,6 +31,7 @@ void emit_tuple_typedefs(CodeGen* gen);
 void emit_struct_forward_decls(CodeGen* gen, Node* ast);
 void emit_span_typedefs(CodeGen* gen);
 void emit_vec_typedefs(CodeGen* gen);
+void emit_box_typedefs(CodeGen* gen);
 void emit_enum_typedefs(CodeGen* gen, Node* ast);
 void emit_generic_enum_typedefs(CodeGen* gen, Node* ast);
 void emit_struct_body_typedefs(CodeGen* gen, Node* ast);

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -717,6 +717,15 @@ static Type* resolve_new_expr_type(CodeGen* gen, Node* node) {
                     }
                 }
                 free(mangled);
+            } else if (strcmp(tn->as.generic_type.base_name, "Box") == 0) {
+                char* mangled = build_mangled_name_from_generic_node(gen, tn);
+                for (int bi = 0; bi < gen->checker.box_count; bi++) {
+                    if (strcmp(gen->checker.boxes[bi].mangled_name, mangled) == 0) {
+                        rtype = gen->checker.boxes[bi].type;
+                        break;
+                    }
+                }
+                free(mangled);
             } else {
                 char* mangled = build_mangled_name_from_generic_node(gen, tn);
                 for (int gi = 0; gi < gen->checker.instance_count; gi++) {
@@ -743,6 +752,27 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
         fprintf(stderr,
                 "codegen: emit_new_expr: could not resolve type for new expression at line %d\n",
                 node->line);
+        return;
+    }
+    if (rtype->kind == TYPE_BOX) {
+        // new Box<T>{value: expr} or new Box<T>(expr) as inline expression
+        const char* elem_tname = type_mangle_name(rtype->as.box.elem);
+        int         tmp        = gen->out.temp_count++;
+        emit(gen, "({ __Box_%s* __rc_tmp%d = (__Box_%s*)__rc_alloc(sizeof(__Box_%s), NULL); ",
+             elem_tname, tmp, elem_tname, elem_tname);
+        if (node->as.new_expr.init != NULL) {
+            // Struct init form: new Box<T>{value: expr}
+            Node* field = node->as.new_expr.init->as.struct_init.fields.nodes[0];
+            emit(gen, "__rc_tmp%d->value = ", tmp);
+            emit_expr(gen, field->as.field_init.value);
+            emit(gen, ";");
+        } else {
+            // Constructor form: new Box<T>(expr)
+            emit(gen, "__rc_tmp%d->value = ", tmp);
+            emit_expr(gen, node->as.new_expr.args.nodes[0]);
+            emit(gen, ";");
+        }
+        emit(gen, " __rc_tmp%d; })", tmp);
         return;
     }
     if (rtype->kind == TYPE_STRINGBUILDER) {
@@ -845,6 +875,24 @@ void emit_hoisted_new_expr(CodeGen* gen, Node* node, const char* temp_name) {
                 "codegen: emit_hoisted_new_expr: could not resolve type for new expression at "
                 "line %d\n",
                 node->line);
+        return;
+    }
+    if (rtype->kind == TYPE_BOX) {
+        const char* elem_tname = type_mangle_name(rtype->as.box.elem);
+        emit_indent(gen);
+        emit(gen, "__Box_%s* %s = (__Box_%s*)__rc_alloc(sizeof(__Box_%s), NULL);\n", elem_tname,
+             temp_name, elem_tname, elem_tname);
+        emit_indent(gen);
+        if (node->as.new_expr.init != NULL) {
+            Node* field = node->as.new_expr.init->as.struct_init.fields.nodes[0];
+            emit(gen, "%s->value = ", temp_name);
+            emit_expr(gen, field->as.field_init.value);
+            emit(gen, ";\n");
+        } else {
+            emit(gen, "%s->value = ", temp_name);
+            emit_expr(gen, node->as.new_expr.args.nodes[0]);
+            emit(gen, ";\n");
+        }
         return;
     }
     if (rtype->kind == TYPE_STRINGBUILDER) {
@@ -1679,6 +1727,13 @@ static void emit_complex_expr(CodeGen* gen, Node* node) {
 // Dispatch expression code generation based on node type.
 void emit_expr(CodeGen* gen, Node* node) {
     if (!node) {
+        return;
+    }
+    // Auto-deref Box<T>: emit expression then append ->value
+    if (node->is_box_deref) {
+        node->is_box_deref = 0; // Clear so recursive call doesn't loop
+        emit_expr(gen, node);
+        emit(gen, "->value");
         return;
     }
     if (emit_hoisted_expr(gen, node)) {

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -689,11 +689,11 @@ void emit_vec_methods(CodeGen* gen) {
     for (int i = 0; i < gen->checker.vec_count; i++) {
         VecInstance*     inst = &gen->checker.vecs[i];
         VecMethodEmitCtx ctx;
-        ctx.elem_type  = inst->elem_type;
-        ctx.elem_tname = type_mangle_name(ctx.elem_type);
-        ctx.elem_is_ptr =
-            (ctx.elem_type->kind == TYPE_STRUCT || ctx.elem_type->kind == TYPE_VEC ||
-             ctx.elem_type->kind == TYPE_STRING || ctx.elem_type->kind == TYPE_STRINGBUILDER);
+        ctx.elem_type   = inst->elem_type;
+        ctx.elem_tname  = type_mangle_name(ctx.elem_type);
+        ctx.elem_is_ptr = (ctx.elem_type->kind == TYPE_STRUCT || ctx.elem_type->kind == TYPE_VEC ||
+                           ctx.elem_type->kind == TYPE_BOX || ctx.elem_type->kind == TYPE_STRING ||
+                           ctx.elem_type->kind == TYPE_STRINGBUILDER);
         ctx.elem_is_rc_enum =
             (ctx.elem_type->kind == TYPE_ENUM && ctx.elem_type->as.enm.has_rc_fields);
 
@@ -807,7 +807,7 @@ void emit_vec_cleanup(CodeGen* gen) {
         Type*        elem_type   = inst->elem_type;
         const char*  elem_tname  = type_mangle_name(elem_type);
         int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC ||
-                           elem_type->kind == TYPE_STRINGBUILDER);
+                           elem_type->kind == TYPE_BOX || elem_type->kind == TYPE_STRINGBUILDER);
         int elem_is_rc_enum = (elem_type->kind == TYPE_ENUM && elem_type->as.enm.has_rc_fields);
 
         // Vec<string> cleanup is provided by whist_runtime.h
@@ -853,7 +853,7 @@ static void emit_generic_field_cleanup(CodeGen* gen, const char* field_name, Typ
         return;
 
     if (field_type->kind == TYPE_STRUCT || field_type->kind == TYPE_VEC ||
-        field_type->kind == TYPE_STRINGBUILDER) {
+        field_type->kind == TYPE_BOX || field_type->kind == TYPE_STRINGBUILDER) {
         emit(gen, "    __rc_dec(ptr->%s);\n", field_name);
     } else if (field_type->kind == TYPE_STRING) {
         emit(gen, "    __rc_dec((void*)ptr->%s);\n", field_name);

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -203,7 +203,7 @@ static int closure_ident_needs_env_inc(Node* expr) {
 // Emit RC-safe assignment for tracked identifier targets; returns whether it handled the statement.
 static int emit_rc_ident_assign_stmt(CodeGen* gen, Node* expr) {
     if (expr->type != NODE_ASSIGN || expr->as.assign.op != TOK_EQ ||
-        expr->as.assign.target->type != NODE_IDENT ||
+        expr->as.assign.target->type != NODE_IDENT || expr->as.assign.target->is_box_deref ||
         !rc_is_tracked(gen, expr->as.assign.target->as.ident.name)) {
         return 0;
     }
@@ -878,9 +878,34 @@ static int emit_var_decl_destructuring(CodeGen* gen, Node* node) {
 }
 
 // Dispatch RC-managed `new` declaration emission by allocated type.
+static void emit_var_decl_rc_new_box(CodeGen* gen, Node* node) {
+    Type*       rtype      = node->as.var_decl.init->as.new_expr.resolved_type;
+    const char* elem_tname = type_mangle_name(rtype->as.box.elem);
+    emit_indent(gen);
+    emit(gen, "__Box_%s* %s = (__Box_%s*)__rc_alloc(sizeof(__Box_%s), NULL);\n", elem_tname,
+         node->as.var_decl.name, elem_tname, elem_tname);
+    emit_indent(gen);
+    Node* init_node = node->as.var_decl.init;
+    if (init_node->as.new_expr.init != NULL) {
+        // Struct init form: new Box<T>{value: expr}
+        Node* field = init_node->as.new_expr.init->as.struct_init.fields.nodes[0];
+        emit(gen, "%s->value = ", node->as.var_decl.name);
+        emit_expr(gen, field->as.field_init.value);
+        emit(gen, ";\n");
+    } else {
+        // Constructor form: new Box<T>(expr)
+        emit(gen, "%s->value = ", node->as.var_decl.name);
+        emit_expr(gen, init_node->as.new_expr.args.nodes[0]);
+        emit(gen, ";\n");
+    }
+    rc_push_var(gen, node->as.var_decl.name, rtype);
+}
+
 static void emit_var_decl_rc_new(CodeGen* gen, Node* node) {
     Type* rtype = node->as.var_decl.init->as.new_expr.resolved_type;
-    if (rtype && rtype->kind == TYPE_VEC) {
+    if (rtype && rtype->kind == TYPE_BOX) {
+        emit_var_decl_rc_new_box(gen, node);
+    } else if (rtype && rtype->kind == TYPE_VEC) {
         emit_var_decl_rc_new_vec(gen, node);
     } else if (rtype && rtype->kind == TYPE_STRINGBUILDER) {
         emit_var_decl_rc_new_stringbuilder(gen, node);

--- a/w0/codegen_types.c
+++ b/w0/codegen_types.c
@@ -58,12 +58,16 @@ int is_struct_type(CodeGen* gen, Node* type_node) {
     if (!type_node)
         return 0;
     type_node = resolve_alias(gen, type_node);
-    // Generic types (Box<i64>) are always struct types, except Span<T>, Vec<T>, and generic enums
+    // Generic types are always struct types, except Span<T>, Vec<T>, Box<T>, and generic enums
     if (type_node->type == NODE_GENERIC_TYPE) {
         if (strcmp(type_node->as.generic_type.base_name, "Span") == 0) {
             return 0;
         }
         if (strcmp(type_node->as.generic_type.base_name, "Vec") == 0) {
+            return 0;
+        }
+        if (strcmp(type_node->as.generic_type.base_name, "Box") == 0 &&
+            gen->checker.box_count > 0) {
             return 0;
         }
         // Check if the mangled name is a registered enum
@@ -91,6 +95,8 @@ int type_node_has_rc(CodeGen* gen, Node* type_node) {
             return 0;
         if (strcmp(type_node->as.generic_type.base_name, "Vec") == 0)
             return 1; // Vec is always RC-managed
+        if (strcmp(type_node->as.generic_type.base_name, "Box") == 0 && gen->checker.box_count > 0)
+            return 1; // Box is always RC-managed
         // Check if this is a generic enum
         char* mangled = build_mangled_name_from_generic_node(gen, type_node);
         if (is_enum_type_name(gen, mangled)) {

--- a/w0/main.c
+++ b/w0/main.c
@@ -73,6 +73,8 @@ static CodeGenChecker make_codegen_checker(Checker* checker) {
         .span_count          = checker->containers.span_count,
         .vecs                = checker->containers.vecs,
         .vec_count           = checker->containers.vec_count,
+        .boxes               = checker->containers.boxes,
+        .box_count           = checker->containers.box_count,
         .traits              = checker->traits.impls,
         .trait_count         = checker->traits.impl_count,
         .func_defs           = checker->generics.func_defs,

--- a/w0/test/run/types/box.w
+++ b/w0/test/run/types/box.w
@@ -1,0 +1,100 @@
+// Expected: PASS: box_basic
+// Expected: PASS: box_arithmetic
+// Expected: PASS: box_comparison
+// Expected: PASS: box_assign_through
+// Expected: PASS: box_compound_assign
+// Expected: PASS: box_sharing
+// Expected: PASS: box_value_copy
+// Expected: PASS: box_func_call
+// Expected: PASS: box_constructor
+// Expected: PASS: box_multiple_types
+
+func takes_i64(x: i64) -> i64 {
+    return x * 2;
+}
+
+func takes_bool(x: bool) -> bool {
+    return !x;
+}
+
+test "box_basic" {
+    var b = new Box<i64>{value: 42};
+    assert(b == 42);
+}
+
+test "box_arithmetic" {
+    var b = new Box<i64>{value: 10};
+    assert(b + 5 == 15);
+    assert(b * 2 == 20);
+    assert(b - 3 == 7);
+    assert(b / 2 == 5);
+    assert(b % 3 == 1);
+}
+
+test "box_comparison" {
+    var b = new Box<i64>{value: 42};
+    assert(b == 42);
+    assert(b != 0);
+    assert(b > 0);
+    assert(b >= 42);
+    assert(b < 100);
+    assert(b <= 42);
+}
+
+test "box_assign_through" {
+    var b = new Box<i64>{value: 10};
+    b = 20;
+    assert(b == 20);
+}
+
+test "box_compound_assign" {
+    var b = new Box<i64>{value: 10};
+    b += 5;
+    assert(b == 15);
+    b -= 3;
+    assert(b == 12);
+    b *= 2;
+    assert(b == 24);
+}
+
+test "box_sharing" {
+    var b = new Box<i64>{value: 10};
+    var c = b;
+    b = 42;
+    // c shares the same box, so it should see the mutation
+    assert(c == 42);
+}
+
+test "box_value_copy" {
+    var b = new Box<i64>{value: 42};
+    var y: i64 = b;
+    b = 99;
+    // y is a copy, should not see the mutation
+    assert(y == 42);
+    assert(b == 99);
+}
+
+test "box_func_call" {
+    var b = new Box<i64>{value: 21};
+    var result = takes_i64(b);
+    assert(result == 42);
+}
+
+test "box_constructor" {
+    var b = new Box<i64>(100);
+    assert(b == 100);
+    b = 200;
+    assert(b == 200);
+}
+
+test "box_multiple_types" {
+    var bi = new Box<i32>{value: 10};
+    assert(bi + 5 == 15);
+
+    var bf = new Box<f64>{value: 3.14};
+    assert(bf > 3.0);
+    assert(bf < 4.0);
+
+    var bb = new Box<bool>{value: true};
+    assert(takes_bool(bb) == false);
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -161,6 +161,12 @@ Type* type_vec(Type* elem) {
     return type;
 }
 
+Type* type_box(Type* elem) {
+    Type* type        = type_new(TYPE_BOX);
+    type->as.box.elem = elem;
+    return type;
+}
+
 void type_free(Type* type) {
     if (!type)
         return;
@@ -249,6 +255,8 @@ int type_equals(Type* a, Type* b) {
         return type_equals(a->as.span.elem, b->as.span.elem);
     case TYPE_VEC:
         return type_equals(a->as.vec.elem, b->as.vec.elem);
+    case TYPE_BOX:
+        return type_equals(a->as.box.elem, b->as.box.elem);
     case TYPE_STRUCT:
         return strcmp(a->as.struc.name, b->as.struc.name) == 0;
     case TYPE_ENUM:
@@ -405,8 +413,8 @@ int type_supports_equality(Type* type) {
 int type_is_rc_managed(Type* type) {
     if (!type)
         return 0;
-    if (type->kind == TYPE_STRUCT || type->kind == TYPE_VEC || type->kind == TYPE_STRINGBUILDER ||
-        type->kind == TYPE_STRING)
+    if (type->kind == TYPE_STRUCT || type->kind == TYPE_VEC || type->kind == TYPE_BOX ||
+        type->kind == TYPE_STRINGBUILDER || type->kind == TYPE_STRING)
         return 1;
     if (type->kind == TYPE_ENUM && type->as.enm.has_rc_fields)
         return 1;
@@ -451,6 +459,11 @@ int type_assignable(Type* target, Type* value) {
 
     // null can be assigned to vec references
     if (target->kind == TYPE_VEC && value->kind == TYPE_NULL) {
+        return 1;
+    }
+
+    // null can be assigned to Box references
+    if (target->kind == TYPE_BOX && value->kind == TYPE_NULL) {
         return 1;
     }
 
@@ -542,6 +555,11 @@ const char* type_name(Type* type) {
     case TYPE_VEC: {
         char* buf = next_type_name_buf();
         snprintf(buf, 256, "Vec<%s>", type_name(type->as.vec.elem));
+        return buf;
+    }
+    case TYPE_BOX: {
+        char* buf = next_type_name_buf();
+        snprintf(buf, 256, "Box<%s>", type_name(type->as.box.elem));
         return buf;
     }
     case TYPE_STRUCT:
@@ -698,6 +716,11 @@ const char* type_mangle_name(Type* type) {
         snprintf(buf, 256, "Vec_%s", type_mangle_name(type->as.vec.elem));
         return buf;
     }
+    case TYPE_BOX: {
+        char* buf = next_type_mangle_buf();
+        snprintf(buf, 256, "Box_%s", type_mangle_name(type->as.box.elem));
+        return buf;
+    }
     case TYPE_STRUCT:
         return type->as.struc.name;
     case TYPE_ENUM:
@@ -827,6 +850,11 @@ Type* type_from_node(Node* type_node) {
         }
         if (strcmp(base, "Span") == 0 && arg_count == 1) {
             Type* result = type_span(args[0]);
+            free(args);
+            return result;
+        }
+        if (strcmp(base, "Box") == 0 && arg_count == 1) {
+            Type* result = type_box(args[0]);
             free(args);
             return result;
         }

--- a/w0/types.h
+++ b/w0/types.h
@@ -25,6 +25,7 @@ typedef enum {
     TYPE_ARRAY,
     TYPE_SPAN,
     TYPE_VEC,
+    TYPE_BOX,
     TYPE_STRINGBUILDER,
     TYPE_STRUCT,
     TYPE_ENUM,
@@ -66,6 +67,11 @@ struct Type {
         struct {
             Type* elem; // Element type T
         } vec;
+
+        // Box: Box<T>
+        struct {
+            Type* elem; // Wrapped value type T
+        } box;
 
         // Struct
         struct {
@@ -167,6 +173,7 @@ Type* type_tuple(Type** elems, int count);
 Type* type_generic_param(const char* name);
 Type* type_span(Type* elem);
 Type* type_vec(Type* elem);
+Type* type_box(Type* elem);
 
 // Type name mangling for C identifiers (no angle brackets or special chars)
 const char* type_mangle_name(Type* type);


### PR DESCRIPTION
## Summary

- Adds `Box<T>` as a built-in generic type — a heap-allocated, RC-managed value wrapper that auto-dereferences to `T` in all expression contexts
- Supports both `new Box<T>{value: expr}` and `new Box<T>(expr)` construction forms
- Enables shared mutable access: `var c = b` shares the same box, so mutations through either variable are visible to both
- User-defined `Box<T>` structs can shadow the builtin via the prelude pattern (same as Vec/Span)

## Changes across 18 files

**Type system** (`types.h/c`): `TYPE_BOX` kind, `type_box()` constructor, equality/mangling/assignability/RC management

**AST** (`ast.h/c`): `is_box_deref` flag set by checker, read by codegen to emit `->value`

**Checker** (`checker.h/c`, `checker_types.c`, `checker_expr.c`, `checker_internal.h`): `BoxInstance` tracking, `ensure_box_type()`, auto-deref in binary/unary/call/assign/return/var_decl expressions, `new Box<T>` validation

**Codegen** (`codegen.h/c`, `codegen_emit.c/h`, `codegen_expr.c`, `codegen_stmt.c`, `codegen_types.c`, `codegen_rc.c`, `main.c`): `__Box_T` typedef emission, `emit_var_decl_rc_new_box` with RC tracking, auto-deref emission via `->value`, Box exclusion from struct type queries

## Test plan

- [x] All 243 tests pass (`make test`) — 242 existing + 1 new
- [x] 10 box test cases: basic, arithmetic, comparison, assign-through, compound assign, sharing, value copy, func call, constructor, multiple types
- [x] Existing `Box<T>` user-defined struct in `test/run/structs/generics.w` still works (not intercepted by builtin)
- [x] `make format` applied

Closes #285