### PR TITLE
feat: add autoboxing syntax `var ^name = value`

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -174,7 +174,7 @@ Aliases are fully interchangeable with the underlying type: `var id: UserId = 42
 ### Variable Declaration
 
 ```bnf
-<var-decl> ::= ( 'var' | 'const' ) <identifier> [ ':' <type> ] [ '=' <expression> ] ';'
+<var-decl> ::= ( 'var' | 'const' ) '^'? <identifier> [ ':' <type> ] [ '=' <expression> ] ';'
             | ( 'var' | 'const' ) <destruct-pattern> [ ':' <type> ] '=' <expression> ';'
             | ( 'var' | 'const' ) <struct-destruct> '=' <expression> ';'
 

--- a/test/run/types/autobox.w
+++ b/test/run/types/autobox.w
@@ -1,0 +1,67 @@
+// Test: autoboxing syntax var ^name = value
+
+import std;
+
+// Expected: PASS: basic autobox
+// Expected: PASS: typed autobox
+// Expected: PASS: arithmetic
+// Expected: PASS: assign through
+// Expected: PASS: sharing
+// Expected: PASS: bool autobox
+// Expected: PASS: float autobox
+// Expected: PASS: const autobox
+// Expected: 8 passed, 0 failed, 8 total
+
+func increment(b: Box<i64>) -> void {
+    b = b + 1;
+}
+
+test "basic autobox" {
+    var ^x = 42;
+    assert(x == 42);
+}
+
+test "typed autobox" {
+    var ^y: i64 = 10;
+    assert(y == 10);
+}
+
+test "arithmetic" {
+    var ^a = 5;
+    var ^b = 3;
+    assert(a + b == 8);
+}
+
+test "assign through" {
+    var ^a = 5;
+    a = 100;
+    assert(a == 100);
+}
+
+test "sharing" {
+    var ^total = 0;
+    increment(total);
+    increment(total);
+    assert(total == 2);
+}
+
+test "bool autobox" {
+    var ^flag = true;
+    assert(flag == true);
+    flag = false;
+    assert(flag == false);
+}
+
+test "float autobox" {
+    var ^pi = 3.14;
+    assert(pi > 3.0);
+}
+
+test "const autobox" {
+    const ^c = 99;
+    assert(c == 99);
+}
+
+func main() -> i32 {
+    return 0;
+}

--- a/w0/ast.c
+++ b/w0/ast.c
@@ -726,6 +726,7 @@ Node* node_clone(Node* node) {
         c->as.var_decl.type             = node_clone(node->as.var_decl.type);
         c->as.var_decl.init             = node_clone(node->as.var_decl.init);
         c->as.var_decl.is_const         = node->as.var_decl.is_const;
+        c->as.var_decl.is_boxed         = node->as.var_decl.is_boxed;
         c->as.var_decl.destruct_pattern = pattern_clone(node->as.var_decl.destruct_pattern);
         break;
     case NODE_BLOCK:

--- a/w0/ast.h
+++ b/w0/ast.h
@@ -171,6 +171,7 @@ typedef struct {
     Node* type;
     Node* init;
     int   is_const;
+    int   is_boxed;      // Parser flag: var ^name = expr (autoboxing)
     char* source_module; // NULL = same module, else external module name
 
     // Destructuring support: var (a, b) = tuple; or var (a, (b, c)) = nested;

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -845,7 +845,32 @@ static void check_normal_var_decl_stmt(Checker* checker, Node* node) {
     }
 
     Type* init_type = check_var_decl_initializer(checker, decl_type, node->as.var_decl.init);
-    Type* var_type  = resolve_var_decl_type(checker, node, name, decl_type, init_type);
+
+    // Autoboxing: var ^x = expr desugars to Box<T> allocation
+    if (node->as.var_decl.is_boxed) {
+        if (!node->as.var_decl.init) {
+            check_error(checker, node->line, node->column,
+                        "Boxed variable declaration requires an initializer");
+            return;
+        }
+        Type* inner = decl_type ? decl_type : init_type;
+        if (!inner || inner->kind == TYPE_ERROR) {
+            check_error(checker, node->line, node->column,
+                        "Cannot determine type for boxed variable '%s'", name);
+            return;
+        }
+        if (decl_type && init_type && !type_assignable(decl_type, init_type)) {
+            check_error_type(checker, node->line, node->column, name, decl_type, init_type);
+            return;
+        }
+        Type*   box_type = ensure_box_type(checker, inner);
+        Symbol* sym = checker_define(checker, name, SYM_VAR, box_type, node->as.var_decl.is_const,
+                                     node->as.var_decl.is_public, checker->modules.current_module);
+        mark_var_decl_rc(node, sym, box_type);
+        return;
+    }
+
+    Type* var_type = resolve_var_decl_type(checker, node, name, decl_type, init_type);
 
     Symbol* sym = checker_define(checker, name, SYM_VAR, var_type, node->as.var_decl.is_const,
                                  node->as.var_decl.is_public, checker->modules.current_module);

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -877,6 +877,32 @@ static int emit_var_decl_destructuring(CodeGen* gen, Node* node) {
     return 1;
 }
 
+// Emit autoboxed variable declaration: var ^x = expr → Box<T> allocation with value assignment.
+static void emit_var_decl_autobox(CodeGen* gen, Node* node) {
+    Type*       box_type   = node->as.var_decl.resolved_type;
+    const char* elem_tname = type_mangle_name(box_type->as.box.elem);
+
+    // Hoist owned temps in the init expression
+    int has_temps = has_owned_temps(node->as.var_decl.init);
+    int saved     = 0;
+    if (has_temps) {
+        saved = hoist_owned_temps(gen, node->as.var_decl.init);
+    }
+
+    emit_indent(gen);
+    emit(gen, "__Box_%s* %s = (__Box_%s*)__rc_alloc(sizeof(__Box_%s), NULL);\n", elem_tname,
+         node->as.var_decl.name, elem_tname, elem_tname);
+    emit_indent(gen);
+    emit(gen, "%s->value = ", node->as.var_decl.name);
+    emit_expr(gen, node->as.var_decl.init);
+    emit(gen, ";\n");
+    rc_push_var(gen, node->as.var_decl.name, box_type);
+
+    if (has_temps) {
+        cleanup_owned_temps(gen, saved);
+    }
+}
+
 // Dispatch RC-managed `new` declaration emission by allocated type.
 static void emit_var_decl_rc_new_box(CodeGen* gen, Node* node) {
     Type*       rtype      = node->as.var_decl.init->as.new_expr.resolved_type;
@@ -936,6 +962,12 @@ static void emit_var_decl_rc_copy_with_temps(CodeGen* gen, Node* node) {
 static int emit_var_decl_rc_managed(CodeGen* gen, Node* node) {
     if (!node->as.var_decl.is_rc || !node->as.var_decl.init) {
         return 0;
+    }
+
+    // Autoboxing: var ^x = expr → allocate Box<T> and store value
+    if (node->as.var_decl.is_boxed) {
+        emit_var_decl_autobox(gen, node);
+        return 1;
     }
 
     // Direct RC assignment: ownership transfers to the variable, don't hoist the init itself

--- a/w0/parser_stmt.c
+++ b/w0/parser_stmt.c
@@ -666,6 +666,8 @@ Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
     }
 
     // Normal variable declaration
+    int is_boxed = match_token(parser, TOK_CARET);
+
     Token name = parser->current;
     consume_token(parser, TOK_IDENT, "Expected variable name");
 
@@ -676,6 +678,7 @@ Node* parse_var_decl(Parser* parser, int is_const, int is_public) {
     vdn->is_public        = is_public;
     vdn->name_length      = name.length;
     vdn->is_const         = is_const;
+    vdn->is_boxed         = is_boxed;
     vdn->type             = NULL;
     vdn->init             = NULL;
     vdn->destruct_pattern = NULL;

--- a/w0/print_ast.c
+++ b/w0/print_ast.c
@@ -151,7 +151,8 @@ static void print_var_decl(Node* node, int depth) {
         print_destruct_pattern(node->as.var_decl.destruct_pattern);
         printf("%s\n", node->as.var_decl.is_const ? " (const)" : "");
     } else {
-        printf("VarDecl: %.*s%s\n", node->as.var_decl.name_length, node->as.var_decl.name,
+        printf("VarDecl: %s%.*s%s\n", node->as.var_decl.is_boxed ? "^" : "",
+               node->as.var_decl.name_length, node->as.var_decl.name,
                node->as.var_decl.is_const ? " (const)" : "");
     }
     if (node->as.var_decl.type) {

--- a/w0/test/errors/error_autobox_no_init.w
+++ b/w0/test/errors/error_autobox_no_init.w
@@ -1,0 +1,7 @@
+// ERROR TEST: autoboxing requires an initializer
+// Expected error: Boxed variable declaration requires an initializer
+
+func main() -> i32 {
+    var ^x: i64;
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add `var ^name = value` syntax that desugars to `Box<T>` allocation, providing a concise way to opt into heap-allocated boxed values with full auto-deref support
- Parser recognizes `^` after `var`/`const`, checker resolves the inner type and creates `Box<T>` via `ensure_box_type`, codegen emits `__rc_alloc` + value assignment
- Supports type inference (`var ^x = 42` → `Box<i64>`), explicit annotation (`var ^y: i64 = 10`), and `const` (`const ^c = 99`)

Closes #286

## Test plan

- [x] 8 new test cases covering basic, typed, arithmetic, assign-through, sharing, bool, float, and const autoboxing
- [x] Error test for missing initializer (`var ^x: i64;`)
- [x] All 244 tests pass (126 run + 118 error)
- [x] RC debug shows no leaks in autobox tests