### PR TITLE
feat: checker error for assigning to captured value types in lambdas

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -7,8 +7,9 @@
 #include "sem_info.h"
 #include "vec.h"
 
-// Forward declaration for check_struct_init (called by check_new_expr)
+// Forward declarations
 static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type);
+static int   count_captured_boundaries(Checker* checker, const char* name);
 
 // Auto-deref Box<T> to T: if type is TYPE_BOX, set is_box_deref flag and return elem type.
 static Type* auto_deref_box(Node* node, Type* type) {
@@ -1154,6 +1155,32 @@ static int check_assignment_enum_tag_writable(Checker* checker, Node* assign_nod
     return 1;
 }
 
+// Disallow assignment to captured value types inside lambdas.
+// Value types are copied into the closure environment, so assignment modifies the copy, not the
+// original. Returns 0 (and emits an error) if this is a forbidden captured value-type assignment.
+static int check_captured_value_assignment(Checker* checker, Node* assign_node, Type* target) {
+    if (checker->lambda_depth <= 0)
+        return 1;
+
+    Node* lhs = assign_node->as.assign.target;
+    if (lhs->type != NODE_IDENT)
+        return 1;
+
+    int boundaries = count_captured_boundaries(checker, lhs->as.ident.name);
+    if (boundaries <= 0)
+        return 1;
+
+    // RC-managed types and func types are heap-allocated pointers — assignment is fine
+    if (type_is_rc_managed(target) || (target && target->kind == TYPE_FUNC))
+        return 1;
+
+    check_error(checker, assign_node->line, assign_node->column,
+                "Cannot assign to captured value type '%s' in lambda; value types are copied into "
+                "the closure — use 'var ^%s' to create a shared mutable Box",
+                lhs->as.ident.name, lhs->as.ident.name);
+    return 0;
+}
+
 // Validate that compound assignment uses numeric operands on both sides.
 static int check_compound_assignment_operands(Checker* checker, Node* assign_node, Type* target,
                                               Type* value) {
@@ -1188,6 +1215,10 @@ static Type* check_assign_expr(Checker* checker, Node* node) {
     }
 
     if (!check_assignment_enum_tag_writable(checker, node)) {
+        return type_error;
+    }
+
+    if (!check_captured_value_assignment(checker, node, target)) {
         return type_error;
     }
 

--- a/w0/test/errors/error_lambda_captured_value_assign.w
+++ b/w0/test/errors/error_lambda_captured_value_assign.w
@@ -1,0 +1,8 @@
+// ERROR TEST: assigning to captured value types in lambdas
+// Expected error: Cannot assign to captured value type 'total' in lambda
+
+func main() -> i32 {
+    var total = 0;
+    var adder = |x: i64| -> void { total += x; };
+    return 0;
+}

--- a/w0/test/errors/error_lambda_captured_value_compound.w
+++ b/w0/test/errors/error_lambda_captured_value_compound.w
@@ -1,0 +1,8 @@
+// ERROR TEST: compound assignment to captured value type
+// Expected error: Cannot assign to captured value type 'count' in lambda
+
+func main() -> i32 {
+    var count: i32 = 0;
+    var inc = || -> void { count = count + 1; };
+    return 0;
+}

--- a/w0/test/valid/types/lambda_capture_box.w
+++ b/w0/test/valid/types/lambda_capture_box.w
@@ -1,0 +1,7 @@
+// Valid: assigning to a captured Box is allowed (shared mutable reference)
+
+func main() -> i32 {
+    var ^total = 0;
+    var adder = |x: i64| -> void { total += x; };
+    return 0;
+}

--- a/w0/test/valid/types/lambda_capture_read.w
+++ b/w0/test/valid/types/lambda_capture_read.w
@@ -1,0 +1,7 @@
+// Valid: reading captured value types is allowed (copy is correct at capture time)
+
+func main() -> i32 {
+    var x = 42;
+    var reader = || -> i64 { return x; };
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes #287

- Emit a checker error when a lambda body assigns to a captured variable that is a value type (integer, float, bool, char, etc.)
- Value types are copied into the closure environment, so assignment modifies the copy — not the original
- Error message suggests using `var ^name` to create a shared mutable Box for shared mutation

## What is NOT an error

- Assigning to a captured `Box` variable (shared heap cell — the intended pattern)
- Assigning to fields of a captured RC struct (shared via RC)
- Assigning to captured strings, vecs, etc. (RC pointers)
- Reading a captured value type (copy is correct at capture time)

## Test plan

- [x] Error test: compound assignment (`+=`) to captured i64
- [x] Error test: plain assignment (`=`) to captured i32
- [x] Valid test: Box capture assignment passes type-check
- [x] Valid test: reading captured value types passes type-check
- [x] Full test suite passes (248 tests)