### PR TITLE
Fix Option<string> struct field methods and RC cleanup

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -585,6 +585,9 @@ static Type* check_member_span(Checker* checker, Node* node) {
 static Type* check_member_enum(Checker* checker, Node* node, Type* object) {
     const char* member_name = node->as.member.name;
     sem_info_set_member_is_ref(checker->sem, node, 0); // Enums are value types, use . not ->
+    // Ensure generic enum methods are instantiated (needed when enum was resolved
+    // during Pass 1 before generic methods were registered in Pass 2)
+    ensure_generic_enum_methods(checker, object);
     if (object->as.enm.has_data && strcmp(member_name, "tag") == 0) {
         return type_int32;
     }

--- a/w0/checker_internal.h
+++ b/w0/checker_internal.h
@@ -20,6 +20,7 @@ Type*        instantiate_generic_enum(Checker* checker, GenericDef* def, char* m
                                       Type** resolved_args, int arg_count);
 VecInstance* lookup_vec_instance_pub(Checker* checker, const char* mangled_name);
 void         ensure_vec_user_methods(Checker* checker, VecInstance* inst);
+void         ensure_generic_enum_methods(Checker* checker, Type* enum_type);
 
 // --- From checker_types.c: generic definition management ---
 void             register_generic_def(Checker* checker, const char* name, char** type_params,

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -877,6 +877,95 @@ Type* instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
     return enum_type;
 }
 
+// Lazily ensure generic enum instance methods are fully instantiated.
+// Needed because enum types can be instantiated during Pass 1 (type declarations)
+// before Pass 2 (generic method registration), leaving the enum with no methods.
+void ensure_generic_enum_methods(Checker* checker, Type* enum_type) {
+    if (enum_type->kind != TYPE_ENUM)
+        return;
+
+    GenericInstance* inst = lookup_generic_instance(checker, enum_type->as.enm.name);
+    if (!inst)
+        return;
+
+    GenericDef* def = lookup_generic_def(checker, inst->base_name);
+    if (!def || def->method_count == 0)
+        return;
+
+    // All methods from the GenericDef have been processed?
+    int already_processed = inst->method_body_count;
+    if (already_processed >= def->method_count)
+        return;
+
+    // Reallocate method body storage for the new methods
+    inst->method_bodies =
+        xrealloc(inst->method_bodies, def->method_count * sizeof(Node*));
+    for (int i = already_processed; i < def->method_count; i++) {
+        inst->method_bodies[i] = NULL;
+    }
+    inst->method_body_count = def->method_count;
+
+    // Set up substitution context
+    char** old_params = checker->generics.current_type_params;
+    Type** old_args   = checker->generics.current_type_args;
+    int    old_count  = checker->generics.current_type_param_count;
+
+    checker->generics.current_type_params      = def->type_params;
+    checker->generics.current_type_args        = inst->type_args;
+    checker->generics.current_type_param_count = def->type_param_count;
+
+    for (int m = already_processed; m < def->method_count; m++) {
+        Node*           method_decl = def->methods[m];
+        func_decl_node* mfdn        = &method_decl->as.func_decl;
+
+        char** method_params = NULL;
+        Type** method_args   = NULL;
+        int    method_count  = 0;
+
+        if (!unify_method_pattern(checker, &mfdn->receiver_type_args, inst->type_args,
+                                  inst->type_arg_count, &method_params, &method_args,
+                                  &method_count)) {
+            continue;
+        }
+
+        char** combined_params = NULL;
+        Type** combined_args   = NULL;
+        int    combined_count  = 0;
+        build_combined_method_substitution(def, inst->type_args, method_params, method_args,
+                                           method_count, &combined_params, &combined_args,
+                                           &combined_count);
+
+        checker->generics.current_type_params      = combined_params;
+        checker->generics.current_type_args        = combined_args;
+        checker->generics.current_type_param_count = combined_count;
+
+        Type** param_types = NULL;
+        int    param_count = 0;
+        Type*  return_type = NULL;
+        resolve_method_signature(checker, mfdn, &param_types, &param_count, &return_type);
+
+        check_instantiated_enum_method_body(checker, inst, m, mfdn, enum_type, param_types,
+                                            param_count, return_type);
+
+        checker->generics.current_type_params      = def->type_params;
+        checker->generics.current_type_args        = inst->type_args;
+        checker->generics.current_type_param_count = def->type_param_count;
+
+        free(combined_params);
+        free(combined_args);
+        free_method_pattern_bindings(method_params, method_args, method_count);
+
+        Type* method_type =
+            register_enum_method_type(enum_type, mfdn, param_types, param_count, return_type);
+        register_enum_method_symbol(checker, mfdn, inst->type_args, inst->type_arg_count,
+                                    method_type);
+    }
+
+    checker->generics.current_type_params      = old_params;
+    checker->generics.current_type_args        = old_args;
+    checker->generics.current_type_param_count = old_count;
+}
+
 // Instantiate user-defined methods on a Vec<T> instance from the Vec GenericDef.
 // Called lazily on first member access to ensure all methods have been registered.
 void ensure_vec_user_methods(Checker* checker, VecInstance* inst) {

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -344,7 +344,7 @@ static int collect_rc_field_info(CodeGen* gen, Node* struct_decl, RcFieldInfo** 
             info->type_name =
                 type_mangle_generic(gtype->as.generic_type.base_name, args, arg_count);
             free(args);
-            info->is_enum = 0;
+            info->is_enum = is_enum_type_name(gen, info->type_name);
         } else {
             info->type_name = NULL;
             info->is_enum   = 0;

--- a/w0/test/run/memory/option_struct_field.w
+++ b/w0/test/run/memory/option_struct_field.w
@@ -1,0 +1,41 @@
+// Expected: PASS: option_struct_field
+// Test Option<string> as a struct field: method resolution and RC cleanup
+
+import std;
+
+struct Config {
+    name: Option<string>,
+    count: i64,
+}
+
+test "option_struct_field" {
+    // Create struct with Some variant
+    var cfg = new Config{ name: Option::Some("hello"), count: 42 };
+
+    // Bug 1: method calls through struct field
+    assert(cfg.name.has_value());
+    assert(cfg.name.value() == "hello");
+    assert(cfg.name.value_or("default") == "hello");
+
+    // Pattern matching (already worked before this fix)
+    match (cfg.name) {
+        Some(v) => assert(v == "hello");
+        None => assert(false);
+    }
+
+    // Test with None variant
+    var none: Option<string> = Option::None;
+    var cfg2 = new Config{ name: none, count: 0 };
+    assert(!cfg2.name.has_value());
+    assert(cfg2.name.value_or("default") == "default");
+
+    match (cfg2.name) {
+        Some(_) => assert(false);
+        None => {}
+    }
+
+    // Bug 2: RC cleanup — struct with Option<string> must clean up correctly
+    // (if cleanup emits wrong code, C compilation fails)
+
+    std::println("PASS: option_struct_field");
+}


### PR DESCRIPTION
## Changes

- **checker_expr.c**: Add `ensure_generic_enum_methods()` call when resolving enum member access to handle enums instantiated during Pass 1 before generic methods were registered in Pass 2
- **checker_types.c**: Implement `ensure_generic_enum_methods()` to lazily instantiate generic enum instance methods with proper type substitution
- **codegen_rc.c**: Fix RC field info to correctly detect enum types in generic instances using `is_enum_type_name()`
- **test**: Add `option_struct_field.w` test verifying Option<string> struct fields work correctly with method resolution and RC cleanup

## Fixes

Resolves method resolution failures and RC cleanup issues when using `Option<string>` (and other generic enums) as struct fields.