### PR TITLE
fix: emit __rc_inc for RC-managed values in enum variant construction

### DIFF
--- a/w0/ast.h
+++ b/w0/ast.h
@@ -304,6 +304,7 @@ struct Node {
             int      has_parens;     // set by parser: 1 if () was present (even if empty)
             int      is_data_enum;   // set by checker: 1 if parent enum has data variants
             int      is_module_call; // set by checker: 1 if this is module::func access
+            Type*    resolved_type; // set by checker: resolved enum Type* (for RC codegen)
         } enum_value;
 
         // New expression: new Type { fields } or new Type(args)

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1493,8 +1493,9 @@ static Type* check_enum_value_expr(Checker* checker, Node* node) {
         return type_error;
     }
 
-    // Set is_data_enum flag for codegen.
+    // Set is_data_enum flag and resolved type for codegen.
     sem_info_set_enum_value_is_data_enum(checker->sem, node, enum_type->as.enm.has_data);
+    node->as.enum_value.resolved_type = enum_type;
 
     // Validate constructor args for data enums.
     int expected_args = enum_type->as.enm.variant_type_counts[variant_idx];

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -207,29 +207,42 @@ static void emit_enum_value(CodeGen* gen, Node* node) {
              node->as.enum_value.value_name_length, node->as.enum_value.value_name);
     } else {
         // Data enum with args: (EnumName){.tag = EnumName_ValueName, .ValueName = {.f0 = ..}}
+        // Use resolved type info to determine which args need __rc_inc.
+        Type* enum_type   = node->as.enum_value.resolved_type;
+        int   variant_idx = -1;
+        if (enum_type) {
+            variant_idx = type_enum_variant_index(enum_type, node->as.enum_value.value_name);
+        }
+
         int needs_rc_inc = 0;
-        for (int i = 0; i < node->as.enum_value.args.count; i++) {
-            Node* arg = node->as.enum_value.args.nodes[i];
-            if (arg->type == NODE_IDENT && rc_is_tracked(gen, arg->as.ident.name)) {
-                needs_rc_inc = 1;
-                break;
+        if (variant_idx >= 0) {
+            for (int i = 0; i < node->as.enum_value.args.count; i++) {
+                if (i < enum_type->as.enm.variant_type_counts[variant_idx] &&
+                    type_is_rc_managed(enum_type->as.enm.variant_types[variant_idx][i])) {
+                    needs_rc_inc = 1;
+                    break;
+                }
             }
         }
 
         if (needs_rc_inc) {
             emit(gen, "({ ");
+            // Emit temp variables and __rc_inc for each RC-managed arg.
             for (int i = 0; i < node->as.enum_value.args.count; i++) {
-                Node* arg = node->as.enum_value.args.nodes[i];
-                if (arg->type == NODE_IDENT && rc_is_tracked(gen, arg->as.ident.name)) {
-                    Type*       arg_type = rc_get_var_type(gen, arg->as.ident.name);
-                    const char* inc_fn   = get_inc_func_for_type(arg_type);
-                    if (arg_type && arg_type->kind == TYPE_STRING) {
-                        emit(gen, "%s((void*)%s); ", inc_fn, arg->as.ident.name);
-                    } else {
-                        emit(gen, "%s(%s); ", inc_fn, arg->as.ident.name);
-                    }
-                    free((char*)inc_fn);
+                Type* ftype = enum_type->as.enm.variant_types[variant_idx][i];
+                if (!type_is_rc_managed(ftype))
+                    continue;
+                emit_resolved_type(gen, ftype);
+                emit(gen, " __ev_f%d = ", i);
+                emit_expr(gen, node->as.enum_value.args.nodes[i]);
+                emit(gen, "; ");
+                const char* inc_fn = get_inc_func_for_type(ftype);
+                if (ftype->kind == TYPE_STRING) {
+                    emit(gen, "%s((void*)__ev_f%d); ", inc_fn, i);
+                } else {
+                    emit(gen, "%s(__ev_f%d); ", inc_fn, i);
                 }
+                free((char*)inc_fn);
             }
         }
 
@@ -240,7 +253,14 @@ static void emit_enum_value(CodeGen* gen, Node* node) {
             if (i > 0)
                 emit(gen, ", ");
             emit(gen, ".f%d = ", i);
-            emit_expr(gen, node->as.enum_value.args.nodes[i]);
+            Type* ftype = (variant_idx >= 0 && i < enum_type->as.enm.variant_type_counts[variant_idx])
+                              ? enum_type->as.enm.variant_types[variant_idx][i]
+                              : NULL;
+            if (needs_rc_inc && ftype && type_is_rc_managed(ftype)) {
+                emit(gen, "__ev_f%d", i);
+            } else {
+                emit_expr(gen, node->as.enum_value.args.nodes[i]);
+            }
         }
         emit(gen, "}}");
 

--- a/w0/test/run/memory/rc_option_some_inc.w
+++ b/w0/test/run/memory/rc_option_some_inc.w
@@ -1,0 +1,28 @@
+// Expected: PASS: rc_option_some_inc
+// Test that Option::Some(rc_value) correctly increments refcount.
+// Regression test for issue #305: wrapping an RC-managed value from a Vec
+// in Option::Some must emit __rc_inc to prevent double-free.
+
+import std;
+
+struct Opts {
+    output_file: Option<string>,
+}
+
+test "rc_option_some_inc" {
+    // Create a Vec that owns strings
+    var args = new Vec<string>{"hello", "world"};
+
+    // Wrap a string from the Vec in Option::Some — this must __rc_inc the string
+    var no_string: Option<string> = Option::None;
+    var opts = new Opts{ output_file: no_string };
+    opts.output_file = Option::Some(args[0]);
+
+    // The string should still be valid through both owners
+    assert(opts.output_file.has_value());
+    assert(opts.output_file.value() == "hello");
+
+    // Both args Vec and opts go out of scope — without the fix, this double-frees
+
+    std::println("PASS: rc_option_some_inc");
+}


### PR DESCRIPTION
## Summary
- Fixes #305: `Option::Some(rc_value)` now correctly emits `__rc_inc` for RC-managed values, preventing double-free/use-after-free
- Replaces identifier-tracking-based RC detection with type-based detection using resolved variant field types, so non-identifier expressions (e.g. `args[0]`) are handled correctly
- Uses temp variables in codegen to avoid double-evaluating argument expressions

## Test plan
- [x] Compiler builds cleanly with no warnings
- [x] All 248 existing tests pass (128 run + 120 error cases)
- [x] New regression test `rc_option_some_inc.w` covers the exact pattern from the issue (wrapping a Vec string in `Option::Some`)
- [x] Verified generated C output contains `__rc_inc` via `__ev_f0` temp variable
- [x] Compiled and ran standalone program confirming no use-after-free