### PR TITLE
fix: infer generic enum type params from struct field type

### DIFF
--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -2949,8 +2949,15 @@ static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type) 
 
         seen[field_index] = 1;
 
-        Type* value_type = check_expression(checker, field->as.field_init.value);
         Type* field_type = struct_type->as.struc.field_types[field_index];
+
+        // Set enum_target_hint for generic enum inference (e.g., new Config{ name: Option::None })
+        Type* old_hint = checker->enum_target_hint;
+        if (field_type->kind == TYPE_ENUM) {
+            checker->enum_target_hint = field_type;
+        }
+        Type* value_type = check_expression(checker, field->as.field_init.value);
+        checker->enum_target_hint = old_hint;
 
         if (!type_assignable(field_type, value_type)) {
             check_error_type(checker, field->line, field->column, field_name, field_type,

--- a/w0/test/run/memory/option_struct_field.w
+++ b/w0/test/run/memory/option_struct_field.w
@@ -23,9 +23,8 @@ test "option_struct_field" {
         None => assert(false);
     }
 
-    // Test with None variant
-    var none: Option<string> = Option::None;
-    var cfg2 = new Config{ name: none, count: 0 };
+    // Test with None variant (direct inference from field type)
+    var cfg2 = new Config{ name: Option::None, count: 0 };
     assert(!cfg2.name.has_value());
     assert(cfg2.name.value_or("default") == "default");
 


### PR DESCRIPTION
## Summary
- Propagate `enum_target_hint` during struct field initialization so generic enum variants like `Option::None` can be used directly without explicit type annotations
- Updates test to use `Option::None` directly in struct initializer instead of a workaround variable

Fixes #304

## Test plan
- [x] `make -C w0` compiles cleanly (no warnings)
- [x] `./w0/bin/w0 --lib-path lib test w0/test/run/memory/option_struct_field.w` passes with direct `Option::None` in struct init
- [x] `make -C w0 test` — 248/248 tests pass (no regressions)