### PR TITLE
feat: add --verbose per-test output and test name filter to test_runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ wc: w0
 	$(MAKE) -C wc
 
 test:
-	$(MAKE) -C w0 test
+	$(MAKE) -C w0 test FILTER=$(FILTER)
 
 test-verbose:
-	$(MAKE) -C w0 test-verbose
+	$(MAKE) -C w0 test-verbose FILTER=$(FILTER)
 
 test-run:
-	$(MAKE) -C w0 test-run
+	$(MAKE) -C w0 test-run FILTER=$(FILTER)
 
 test-errors:
-	$(MAKE) -C w0 test-errors
+	$(MAKE) -C w0 test-errors FILTER=$(FILTER)
 
 clean:
 	$(MAKE) -C w0 clean

--- a/w0/Makefile
+++ b/w0/Makefile
@@ -29,19 +29,19 @@ $(BIN)/test_runner: $(TARGET) tools/test_runner.w
 	@$(TARGET) --lib-path ../lib tools/test_runner.w | cc -x c -I../lib/include -o $@ - ../lib/whist_runtime.c
 
 test: $(BIN)/test_runner
-	@$(BIN)/test_runner
+	@$(BIN)/test_runner $(FILTER)
 
 test-verbose: $(BIN)/test_runner
-	@$(BIN)/test_runner --verbose
+	@$(BIN)/test_runner --verbose $(FILTER)
 
 test-run: $(BIN)/test_runner
-	@$(BIN)/test_runner --run
+	@$(BIN)/test_runner --run $(FILTER)
 
 test-valid: $(BIN)/test_runner
-	@$(BIN)/test_runner --run
+	@$(BIN)/test_runner --run $(FILTER)
 
 test-errors: $(BIN)/test_runner
-	@$(BIN)/test_runner --errors
+	@$(BIN)/test_runner --errors $(FILTER)
 
 format:
 	clang-format -i *.c *.h

--- a/w0/tools/test_runner.w
+++ b/w0/tools/test_runner.w
@@ -394,15 +394,27 @@ func main() -> i32 {
     var run_errors = args.any(|x| x == "--errors");
     var verbose = args.any(|x| x == "--verbose");
 
+    // Collect non-flag arguments as test name filter
+    var filter = "";
+    foreach (const arg in args) {
+        if (!arg.starts_with("--") && !arg.starts_with("-") && !arg.ends_with("test_runner")) {
+            filter = arg;
+        }
+    }
+
     if (args.any(|x| x == "--help")) {
         std::println("""
-        Usage: test_runner [OPTIONS]
+        Usage: test_runner [OPTIONS] [FILTER]
 
         Options:
           --run       Run only executable program tests (test/run/**)
           --errors    Run only error case tests (test/errors/**)
-          --verbose   Show detailed output on failure
+          --verbose   Show per-test pass/fail and detailed output on failure
           --help      Show this help
+
+        Filter:
+          Optional substring to match against test file paths.
+          Example: test_runner option_struct_field
 
         With no options, runs all tests.
         """);
@@ -441,6 +453,10 @@ func main() -> i32 {
         files.sort();
 
         foreach (const file in files) {
+            if (filter != "" && !file.contains(filter)) {
+                continue;
+            }
+
             var disp = display_path(file);
 
             var has_test_blocks = file_contains(file, "test \"");
@@ -450,6 +466,9 @@ func main() -> i32 {
                 var result = run_test_block_file(file, w0, lib_path, verbose);
                 if (result.is_ok()) {
                     run_passed += 1;
+                    if (verbose) {
+                        std::println($"{disp}:".pad_right(45, ' ') + $" {green("PASS")}");
+                    }
                 } else {
                     std::println($"{disp}:".pad_right(45, ' ') + $" {red("FAIL")} ({result.error()})");
                     run_failed += 1;
@@ -458,6 +477,9 @@ func main() -> i32 {
                 var result = run_program_test(file, w0, lib_path, verbose);
                 if (result.is_ok()) {
                     run_passed += 1;
+                    if (verbose) {
+                        std::println($"{disp}:".pad_right(45, ' ') + $" {green("PASS")}");
+                    }
                 } else {
                     std::println($"{disp}:".pad_right(45, ' ') + $" {red("FAIL")} ({result.error()})");
                     run_failed += 1;
@@ -476,11 +498,18 @@ func main() -> i32 {
         files.sort();
 
         foreach (const file in files) {
+            if (filter != "" && !file.contains(filter)) {
+                continue;
+            }
+
             var disp = display_path(file);
 
             var result = run_error_test(file, w0, lib_path, verbose);
             if (result.is_ok()) {
                 error_passed += 1;
+                if (verbose) {
+                    std::println($"{disp}:".pad_right(45, ' ') + $" {green("PASS")}");
+                }
             } else {
                 std::println($"{disp}:".pad_right(45, ' ') + $" {red("FAIL")} ({result.error()})");
                 error_failed += 1;


### PR DESCRIPTION
## Summary
- **`--verbose` per-test output**: Each test now prints `PASS` or `FAIL` as it runs, instead of only showing failures
- **Test name filter**: Accept an optional positional argument as a substring filter (e.g., `make test-verbose FILTER=option_struct_field`)
- **Makefile integration**: All test targets pass `FILTER=` through to the test runner

Closes #307

## Test plan
- [x] `make test` — all 248 tests pass
- [x] `make test-verbose` — prints per-test PASS/FAIL lines
- [x] `make test-verbose FILTER=option_struct_field` — runs only matching test
- [x] `make test-verbose FILTER=type_mismatch` — filters error tests correctly