### PR TITLE
feat: default Option<T> to None when not initialized

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -878,6 +878,16 @@ static void check_normal_var_decl_stmt(Checker* checker, Node* node) {
     record_inferred_var_decl_type(node, init_type);
     maybe_mark_var_decl_rc_from_init(checker, node, sym, var_type);
     maybe_mark_string_var_decl_rc(node, sym, var_type);
+
+    // Option<T> without initializer defaults to None
+    if (!node->as.var_decl.init && type_is_option(var_type)) {
+        // Store resolved type for codegen to emit default None
+        node->as.var_decl.resolved_type = var_type;
+        // Mark RC if type has RC fields (for scope cleanup)
+        if (var_type->as.enm.has_rc_fields) {
+            mark_var_decl_rc(node, sym, var_type);
+        }
+    }
 }
 
 // Type-check a variable declaration: handles destructuring, type inference, and RC tracking

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -2968,6 +2968,10 @@ static Type* check_struct_init(Checker* checker, Node* init, Type* struct_type) 
 
     for (int i = 0; i < field_count; i++) {
         if (!seen[i]) {
+            // Allow Option<T> fields to be omitted (default to None)
+            if (type_is_option(struct_type->as.struc.field_types[i])) {
+                continue;
+            }
             check_error(checker, init->line, init->column, "Missing initializer for field '%s'",
                         struct_type->as.struc.field_names[i]);
             had_error = 1;

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -865,7 +865,7 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
                  tname, tmp, tname, tname, tmp, tname);
         }
         free(cleanup);
-        emit_struct_init(gen, node->as.new_expr.init);
+        emit_struct_init(gen, node->as.new_expr.init, rtype);
         emit(gen, ";");
         // Increment refcount for any RC-tracked idents stored in struct fields
         Node* rc_init = node->as.new_expr.init;
@@ -1000,7 +1000,7 @@ static void emit_hoisted_new_struct_init_expr(CodeGen* gen, Node* node, Type* rt
     free(cleanup);
     emit_indent(gen);
     emit(gen, "*%s = (%s)", temp_name, tname);
-    emit_struct_init(gen, node->as.new_expr.init);
+    emit_struct_init(gen, node->as.new_expr.init, rtype);
     emit(gen, ";\n");
     emit_hoisted_new_field_rc_incs(gen, node->as.new_expr.init);
 }
@@ -1745,7 +1745,7 @@ static void emit_complex_expr(CodeGen* gen, Node* node) {
         emit_assign_expr(gen, node);
         break;
     case NODE_STRUCT_INIT:
-        emit_struct_init(gen, node);
+        emit_struct_init(gen, node, NULL);
         break;
     case NODE_TUPLE_LIT:
         emit_tuple_lit_expr(gen, node);
@@ -1798,19 +1798,50 @@ void emit_expr(CodeGen* gen, Node* node) {
     emit_complex_expr(gen, node);
 }
 
+// Check if a struct field name is present in the struct init AST node.
+static int struct_init_has_field(Node* init_node, const char* field_name) {
+    for (int i = 0; i < init_node->as.struct_init.fields.count; i++) {
+        Node* field = init_node->as.struct_init.fields.nodes[i];
+        if (field && field->type == NODE_FIELD_INIT &&
+            strcmp(field->as.field_init.name, field_name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Emit a struct initializer as a C designated initializer: {.field = value, ...}
-void emit_struct_init(CodeGen* gen, Node* node) {
+// If struct_type is provided, missing Option<T> fields are defaulted to None.
+void emit_struct_init(CodeGen* gen, Node* node, Type* struct_type) {
     emit(gen, "{");
+    int emitted = 0;
     for (int i = 0; i < node->as.struct_init.fields.count; i++) {
         Node* field = node->as.struct_init.fields.nodes[i];
         if (!field || field->type != NODE_FIELD_INIT) {
             continue;
         }
-        if (i > 0) {
+        if (emitted > 0) {
             emit(gen, ", ");
         }
         emit(gen, ".%s = ", field->as.field_init.name);
         emit_expr(gen, field->as.field_init.value);
+        emitted++;
+    }
+    // Emit default None for missing Option<T> fields
+    if (struct_type && struct_type->kind == TYPE_STRUCT) {
+        for (int i = 0; i < struct_type->as.struc.field_count; i++) {
+            Type* ft = struct_type->as.struc.field_types[i];
+            if (type_is_option(ft) &&
+                !struct_init_has_field(node, struct_type->as.struc.field_names[i])) {
+                if (emitted > 0) {
+                    emit(gen, ", ");
+                }
+                int none_idx = type_enum_variant_index(ft, "None");
+                emit(gen, ".%s = (%s){.tag = %s_%s}", struct_type->as.struc.field_names[i],
+                     ft->as.enm.name, ft->as.enm.name, ft->as.enm.value_names[none_idx]);
+                emitted++;
+            }
+        }
     }
     emit(gen, "}");
 }

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -36,7 +36,7 @@ int         rc_is_tracked(CodeGen* gen, const char* name);
 
 // --- From codegen_expr.c: expression emission ---
 void  emit_expr(CodeGen* gen, Node* node);
-void  emit_struct_init(CodeGen* gen, Node* node);
+void  emit_struct_init(CodeGen* gen, Node* node, Type* struct_type);
 void  emit_hoisted_new_expr(CodeGen* gen, Node* node, const char* temp_name);
 void  emit_hoisted_owned_temp(CodeGen* gen, Node* node, const char* temp_name);
 void  emit_destruct_pattern(CodeGen* gen, DestructPattern* pattern, const char* temp_prefix,

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -600,7 +600,7 @@ static void emit_var_decl_rc_new_struct(CodeGen* gen, Node* node) {
     free(cleanup);
     emit_indent(gen);
     emit(gen, "*%s = (%s)", node->as.var_decl.name, tname);
-    emit_struct_init(gen, node->as.var_decl.init->as.new_expr.init);
+    emit_struct_init(gen, node->as.var_decl.init->as.new_expr.init, rtype);
     emit(gen, ";\n");
     // Increment refcount for any RC values stored in struct fields
     Node* rc_init = node->as.var_decl.init->as.new_expr.init;
@@ -960,7 +960,21 @@ static void emit_var_decl_rc_copy_with_temps(CodeGen* gen, Node* node) {
 
 // Emit RC-managed variable declaration fast path; returns whether it handled the declaration.
 static int emit_var_decl_rc_managed(CodeGen* gen, Node* node) {
-    if (!node->as.var_decl.is_rc || !node->as.var_decl.init) {
+    if (!node->as.var_decl.is_rc) {
+        return 0;
+    }
+
+    // Option<T> with RC fields but no initializer: default to None and track for cleanup
+    if (!node->as.var_decl.init) {
+        Type* rt = node->as.var_decl.resolved_type;
+        if (rt && type_is_option(rt)) {
+            int none_idx = type_enum_variant_index(rt, "None");
+            emit_indent(gen);
+            emit(gen, "%s %s = (%s){.tag = %s_%s};\n", rt->as.enm.name, node->as.var_decl.name,
+                 rt->as.enm.name, rt->as.enm.name, rt->as.enm.value_names[none_idx]);
+            rc_push_var(gen, node->as.var_decl.name, rt);
+            return 1;
+        }
         return 0;
     }
 
@@ -1042,6 +1056,14 @@ static void emit_var_decl_initializer(CodeGen* gen, Node* node, int struct_type,
     } else if (is_func_var) {
         // Ensure env cleanup sees a deterministic pointer value.
         emit(gen, " = (__Closure){NULL, NULL}");
+    } else if (!node->as.var_decl.init) {
+        // Option<T> without initializer defaults to None
+        Type* rt = node->as.var_decl.resolved_type;
+        if (rt && type_is_option(rt)) {
+            int none_idx = type_enum_variant_index(rt, "None");
+            emit(gen, " = (%s){.tag = %s_%s}", rt->as.enm.name, rt->as.enm.name,
+                 rt->as.enm.value_names[none_idx]);
+        }
     }
 }
 

--- a/w0/test/run/option_default_none.w
+++ b/w0/test/run/option_default_none.w
@@ -1,0 +1,58 @@
+// Expected: PASS: option_default_none
+// Test that Option<T> defaults to None when not initialized
+
+import std;
+
+struct Config {
+    name: Option<string>,
+    count: i64,
+}
+
+struct Point {
+    x: i64,
+    y: i64,
+    label: Option<string>,
+    tag: Option<i64>,
+}
+
+test "option_default_none" {
+    // 1. Struct field: omit Option<string> field
+    var cfg = new Config{ count: 42 };
+    assert(!cfg.name.has_value());
+    assert(cfg.name.value_or("default") == "default");
+
+    // 2. Struct field: omit multiple Option fields
+    var pt = new Point{ x: 1, y: 2 };
+    assert(!pt.label.has_value());
+    assert(!pt.tag.has_value());
+    assert(pt.tag.value_or(-1) == -1);
+
+    // 3. Struct field: mix explicit and defaulted
+    var pt2 = new Point{ x: 10, y: 20, label: Option::Some("origin") };
+    assert(pt2.label.has_value());
+    assert(pt2.label.value() == "origin");
+    assert(!pt2.tag.has_value());
+
+    // 4. Variable: Option<i64> without initializer
+    var opt_int: Option<i64>;
+    assert(!opt_int.has_value());
+    assert(opt_int.value_or(99) == 99);
+
+    // 5. Variable: Option<string> without initializer
+    var opt_str: Option<string>;
+    assert(!opt_str.has_value());
+    assert(opt_str.value_or("none") == "none");
+
+    // 6. Pattern matching on defaulted values
+    match (cfg.name) {
+        Some(_) => assert(false);
+        None => {}
+    }
+
+    match (opt_int) {
+        Some(_) => assert(false);
+        None => {}
+    }
+
+    std::println("PASS: option_default_none");
+}

--- a/w0/types.c
+++ b/w0/types.c
@@ -385,6 +385,14 @@ int type_enum_variant_index(Type* enum_type, const char* variant_name) {
     return -1;
 }
 
+// Return whether this type is an Option type (has Some and None variants).
+int type_is_option(Type* type) {
+    if (!type || type->kind != TYPE_ENUM) {
+        return 0;
+    }
+    return type_enum_variant_index(type, "Some") >= 0 && type_enum_variant_index(type, "None") >= 0;
+}
+
 // Return whether this element type supports Vec.contains (requires ==).
 int type_supports_vec_contains(Type* type) {
     if (!type)

--- a/w0/types.h
+++ b/w0/types.h
@@ -187,6 +187,7 @@ int         type_is_rc_managed(Type* type);             // Is this an RC-managed
 int         type_is_signed_integer(Type* type);         // Is this a signed integer type?
 int         type_is_unsigned_integer(Type* type);       // Is this an unsigned integer type?
 int         type_enum_variant_index(Type* enum_type, const char* variant_name);
+int         type_is_option(Type* type);              // Is this an Option type (has Some+None)?
 int         type_find_field_index(Type* type, const char* field_name);
 int         type_supports_vec_contains(Type* type); // Can Vec<T>.contains compare this type?
 int         type_supports_vec_sort(Type* type);     // Is this type sortable by Vec<T>.sort?


### PR DESCRIPTION
## Summary
- Allow `Option<T>` struct fields to be omitted from `new Foo{...}` initializers — they default to `Option::None`
- Allow `var x: Option<T>;` declarations without an initializer — defaults to `Option::None`
- Handles RC tracking for `Option<T>` types with RC-managed payloads (e.g., `Option<string>`)

## Test plan
- [x] New test `option_default_none.w` covers: omitted struct fields, uninitialized variables (`Option<i64>`, `Option<string>`), mixed explicit/defaulted fields, pattern matching on defaults
- [x] Existing `option_struct_field.w` test passes
- [x] Full test suite passes (249/249)