### PR TITLE
fix: preserve short-circuit evaluation for RC-managed temps

### DIFF
--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -1532,6 +1532,19 @@ static void emit_string_binary_expr(CodeGen* gen, Node* node) {
     emit(gen, ")%s)", suffix);
 }
 
+// Emit the right side of a short-circuit operator (&&/||) with inline RC temp management.
+// Wraps the right operand in a GCC statement expression that hoists owned temps,
+// evaluates the expression, cleans up temps, and returns the boolean result.
+static void emit_short_circuit_rhs(CodeGen* gen, Node* rhs) {
+    emit(gen, "({ ");
+    int saved = hoist_owned_temps(gen, rhs);
+    emit(gen, "bool __sc = ");
+    emit_expr(gen, rhs);
+    emit(gen, "; ");
+    cleanup_owned_temps(gen, saved);
+    emit(gen, " __sc; })");
+}
+
 // Emit a binary expression, dispatching to specialized string/equality handlers.
 static void emit_binary_expr(CodeGen* gen, Node* node) {
     if (node->as.binary.is_eq_op) {
@@ -1547,7 +1560,14 @@ static void emit_binary_expr(CodeGen* gen, Node* node) {
     emit(gen, "(");
     emit_expr(gen, node->as.binary.left);
     emit(gen, " %s ", binary_op_str(node->as.binary.op));
-    emit_expr(gen, node->as.binary.right);
+    // For short-circuit operators, if the right side has owned temps, wrap it in
+    // a statement expression so temps are only allocated when the right side executes.
+    if ((node->as.binary.op == TOK_AMP_AMP || node->as.binary.op == TOK_PIPE_PIPE) &&
+        has_owned_temps(node->as.binary.right)) {
+        emit_short_circuit_rhs(gen, node->as.binary.right);
+    } else {
+        emit_expr(gen, node->as.binary.right);
+    }
     emit(gen, ")");
 }
 

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -86,7 +86,11 @@ static void collect_owned_temps_children(Node* node, Node*** temps, int* count, 
         break;
     case NODE_BINARY:
         collect_owned_temps(node->as.binary.left, temps, count, cap);
-        collect_owned_temps(node->as.binary.right, temps, count, cap);
+        // Don't hoist temps from the right side of short-circuit operators (&&, ||).
+        // The right side may not execute, so its temps must be handled inline.
+        if (node->as.binary.op != TOK_AMP_AMP && node->as.binary.op != TOK_PIPE_PIPE) {
+            collect_owned_temps(node->as.binary.right, temps, count, cap);
+        }
         break;
     case NODE_UNARY:
         collect_owned_temps(node->as.unary.operand, temps, count, cap);

--- a/w0/test/run/control/if_expr_order.w
+++ b/w0/test/run/control/if_expr_order.w
@@ -1,0 +1,7 @@
+// Expected: PASS: if expr order
+
+test "if expr order" {
+    var v: Option<string> = Option::None;
+    assert(v.has_value() == false);
+    assert( !(v.has_value() && v.value() == "hello"));
+}


### PR DESCRIPTION
## Summary
- RC-managed temporaries (e.g. `v.value()` returning a string) in the right operand of `&&`/`||` were eagerly hoisted before the expression, defeating short-circuit semantics and causing panics (e.g. calling `.value()` on `Option::None`)
- `collect_owned_temps` now skips the right side of `&&`/`||` so temps aren't hoisted out of the short-circuit
- `emit_binary_expr` wraps the right operand in a GCC statement expression that hoists, evaluates, and cleans up RC temps only when the right side actually executes

Closes #311

## Test plan
- [x] New test `test/run/control/if_expr_order.w` verifies `!(v.has_value() && v.value() == "hello")` doesn't panic when `v` is `None`
- [x] Full test suite passes (250/250)