### PR TITLE
feat: sibling module imports and separate compilation for wc

### DIFF
--- a/w0/ast.h
+++ b/w0/ast.h
@@ -577,13 +577,14 @@ struct Node {
             int    type_param_count;
         } type_alias;
 
-        // Use declaration: use module.symbol or use module.{sym1, sym2}
+        // Use declaration: use module::symbol; or use module::{sym1, sym2}; or use module::*;
         struct {
             char*  module_name;
             int    module_name_length;
             char** symbol_names;
             int*   symbol_name_lengths;
             int    symbol_count;
+            int    is_wildcard; // 1 for use module::*;
         } use_decl;
 
         // Test block: test "name" { body }
@@ -604,6 +605,7 @@ struct Node {
             char*    name;
             int      name_length;
             NodeList decls;
+            int      is_sibling; // 1 if from sibling import (not lib-path)
         } module;
 
         // Program

--- a/w0/checker.c
+++ b/w0/checker.c
@@ -2458,6 +2458,22 @@ static void check_impl_decl(Checker* checker, Node* node) {
     checker->self_type = NULL;
 }
 
+// Insert an unqualified alias for a module symbol into the current scope.
+static void insert_use_alias(Checker* checker, Symbol* sym, const char* sym_name) {
+    Scope*       scope = checker->scope;
+    unsigned int index = hash_string(sym_name) % scope->size;
+
+    Symbol* alias         = xcalloc(1, sizeof(Symbol));
+    alias->kind           = sym->kind;
+    alias->name           = xstrdup(sym_name);
+    alias->type           = sym->type;
+    alias->is_const       = sym->is_const;
+    alias->is_public      = sym->is_public;
+    alias->source_module  = NULL; // NULL = accessible without qualification
+    alias->next           = scope->symbols[index];
+    scope->symbols[index] = alias;
+}
+
 // Check a use declaration: validate module, look up each symbol, and register unqualified alias
 static void check_use_decl(Checker* checker, Node* node) {
     const char* mod_name = node->as.use_decl.module_name;
@@ -2465,6 +2481,28 @@ static void check_use_decl(Checker* checker, Node* node) {
     // Verify module is imported
     if (!is_imported_module(checker, mod_name)) {
         check_error(checker, node->line, node->column, "Module '%s' is not imported", mod_name);
+        return;
+    }
+
+    if (node->as.use_decl.is_wildcard) {
+        // Wildcard: import all public symbols from the module
+        for (Scope* scope = checker->scope; scope; scope = scope->parent) {
+            for (int b = 0; b < scope->size; b++) {
+                for (Symbol* sym = scope->symbols[b]; sym; sym = sym->next) {
+                    if (!sym->source_module || strcmp(sym->source_module, mod_name) != 0) {
+                        continue;
+                    }
+                    if (!sym->is_public) {
+                        continue;
+                    }
+                    // Skip if already defined unqualified (e.g., prelude symbol with same name)
+                    if (checker_lookup(checker, sym->name)) {
+                        continue;
+                    }
+                    insert_use_alias(checker, sym, sym->name);
+                }
+            }
+        }
         return;
     }
 
@@ -2485,21 +2523,7 @@ static void check_use_decl(Checker* checker, Node* node) {
             continue;
         }
 
-        // Insert an unqualified alias directly into the scope.
-        // We can't use checker_define because it would find the existing module-qualified
-        // symbol with the same name and reject it as a redefinition.
-        Scope*       scope = checker->scope;
-        unsigned int index = hash_string(sym_name) % scope->size;
-
-        Symbol* alias         = xcalloc(1, sizeof(Symbol));
-        alias->kind           = sym->kind;
-        alias->name           = xstrdup(sym_name);
-        alias->type           = sym->type;
-        alias->is_const       = sym->is_const;
-        alias->is_public      = sym->is_public;
-        alias->source_module  = NULL; // NULL = accessible without qualification
-        alias->next           = scope->symbols[index];
-        scope->symbols[index] = alias;
+        insert_use_alias(checker, sym, sym_name);
     }
 }
 

--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -1435,13 +1435,23 @@ static void emit_declarations(CodeGen* gen, Node* ast) {
         Node* mod = ast->as.program.modules.nodes[m];
         if (!mod || mod->type != NODE_MODULE)
             continue;
+
+        int is_non_target =
+            (gen->target_module != NULL && strcmp(mod->as.module.name, gen->target_module) != 0);
+
+        // In separate compilation mode, skip sibling module bodies entirely.
+        // Their symbols are resolved at link time via extern prototypes emitted
+        // in the forward declaration pass.
+        if (is_non_target && mod->as.module.is_sibling) {
+            continue;
+        }
+
         // Set current module context (NULL for "main", module name for library imports)
         gen->current_module = strcmp(mod->as.module.name, "main") == 0 ? NULL : mod->as.module.name;
 
         // In separate compilation mode, force non-target module functions to static
         // so each .o has its own private copy (avoids duplicate symbols at link time).
-        gen->force_static =
-            (gen->target_module != NULL && strcmp(mod->as.module.name, gen->target_module) != 0);
+        gen->force_static = is_non_target;
 
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             emit_decl(gen, mod->as.module.decls.nodes[i]);
@@ -1892,6 +1902,71 @@ static void emit_generic_func_impls(CodeGen* gen, Node* ast) {
     }
 }
 
+static void register_use_alias(CodeGen* gen, const char* mod_name, const char* sym_name,
+                               int is_sibling) {
+    char c_name[256];
+    if (is_sibling) {
+        // Sibling modules compile with bare names (no module prefix)
+        snprintf(c_name, sizeof(c_name), "%s", sym_name);
+    } else if (strcmp(mod_name, "std") == 0 && strcmp(sym_name, "format") == 0) {
+        snprintf(c_name, sizeof(c_name), "__std_format");
+    } else {
+        snprintf(c_name, sizeof(c_name), "%s_%s", mod_name, sym_name);
+    }
+
+    VEC_GROW(gen->aliases.uses, gen->aliases.use_count, gen->aliases.use_capacity);
+    gen->aliases.uses[gen->aliases.use_count].whist_name = xstrdup(sym_name);
+    gen->aliases.uses[gen->aliases.use_count].c_name     = xstrdup(c_name);
+    gen->aliases.use_count++;
+}
+
+// Find a module node in the AST by name
+static Node* find_module_in_ast(Node* ast, const char* name) {
+    for (int i = 0; i < ast->as.program.modules.count; i++) {
+        Node* mod = ast->as.program.modules.nodes[i];
+        if (mod && mod->type == NODE_MODULE && strcmp(mod->as.module.name, name) == 0)
+            return mod;
+    }
+    return NULL;
+}
+
+// Pre-collect use aliases for all use declarations, including wildcard (use module::*).
+// This must run before emit_declarations so aliases are available for function call emission.
+static void collect_use_aliases(CodeGen* gen, Node* ast) {
+    for (int m = 0; m < ast->as.program.modules.count; m++) {
+        Node* mod = ast->as.program.modules.nodes[m];
+        if (!mod || mod->type != NODE_MODULE)
+            continue;
+        for (int i = 0; i < mod->as.module.decls.count; i++) {
+            Node* decl = mod->as.module.decls.nodes[i];
+            if (decl->type != NODE_USE_DECL)
+                continue;
+
+            const char* mod_name = decl->as.use_decl.module_name;
+            Node* target_mod = find_module_in_ast(ast, mod_name);
+            int is_sibling = target_mod ? target_mod->as.module.is_sibling : 0;
+
+            if (decl->as.use_decl.is_wildcard) {
+                if (target_mod) {
+                    for (int d = 0; d < target_mod->as.module.decls.count; d++) {
+                        Node* target_decl = target_mod->as.module.decls.nodes[d];
+                        if (target_decl->type == NODE_FUNC_DECL &&
+                            target_decl->as.func_decl.is_public) {
+                            register_use_alias(gen, mod_name,
+                                               target_decl->as.func_decl.name, is_sibling);
+                        }
+                    }
+                }
+            } else {
+                for (int s = 0; s < decl->as.use_decl.symbol_count; s++) {
+                    register_use_alias(gen, mod_name, decl->as.use_decl.symbol_names[s],
+                                       is_sibling);
+                }
+            }
+        }
+    }
+}
+
 // Main codegen entry point: emit all C code for a program AST
 void codegen_emit(CodeGen* gen, Node* ast) {
     if (!ast || ast->type != NODE_PROGRAM)
@@ -1900,6 +1975,7 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     int has_user_main = program_has_user_main(ast);
 
     collect_types_and_aliases(gen, ast);
+    collect_use_aliases(gen, ast);
     collect_string_literals(gen, ast);
     emit_c_headers(gen);
     emit_rc_runtime(gen);

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -812,26 +812,8 @@ void emit_decl(CodeGen* gen, Node* node) {
         break;
 
     case NODE_USE_DECL:
-        // Register use aliases for function calls (types don't need aliases since
-        // struct/enum names in generated C are bare, not module-prefixed)
-        for (int i = 0; i < node->as.use_decl.symbol_count; i++) {
-            char* sym_name = node->as.use_decl.symbol_names[i];
-            char* mod_name = node->as.use_decl.module_name;
-
-            // Build the C function name: module_symbolname
-            // Special case: std.format -> __std_format (compiler builtin)
-            char c_name[256];
-            if (strcmp(mod_name, "std") == 0 && strcmp(sym_name, "format") == 0) {
-                snprintf(c_name, sizeof(c_name), "__std_format");
-            } else {
-                snprintf(c_name, sizeof(c_name), "%s_%s", mod_name, sym_name);
-            }
-
-            VEC_GROW(gen->aliases.uses, gen->aliases.use_count, gen->aliases.use_capacity);
-            gen->aliases.uses[gen->aliases.use_count].whist_name = xstrdup(sym_name);
-            gen->aliases.uses[gen->aliases.use_count].c_name     = xstrdup(c_name);
-            gen->aliases.use_count++;
-        }
+        // Use aliases are pre-collected in collect_use_aliases() before declarations
+        // are emitted, so no work needed here.
         break;
 
     case NODE_IMPL_DECL:
@@ -1456,11 +1438,23 @@ static void emit_non_generic_function_forward_decls(CodeGen* gen, Node* ast) {
         if (!mod || mod->type != NODE_MODULE)
             continue;
 
-        // In separate compilation mode, force non-target module functions to static
-        gen->force_static =
+        int is_non_target =
             (gen->target_module != NULL && strcmp(mod->as.module.name, gen->target_module) != 0);
 
-        const char* module_prefix = module_forward_prefix(mod);
+        // For sibling modules in separate compilation mode, emit extern prototypes
+        // for public functions only (private functions are not needed in this .o).
+        // For library modules, force everything to static (each .o gets its own copy).
+        if (is_non_target && mod->as.module.is_sibling) {
+            gen->force_static = 0; // Public functions get implicit extern linkage
+        } else {
+            gen->force_static = is_non_target;
+        }
+
+        int skip_private = is_non_target && mod->as.module.is_sibling;
+
+        // For sibling modules, use no prefix (their .o defines bare names)
+        const char* module_prefix =
+            (is_non_target && mod->as.module.is_sibling) ? NULL : module_forward_prefix(mod);
         for (int i = 0; i < mod->as.module.decls.count; i++) {
             Node* decl = mod->as.module.decls.nodes[i];
 
@@ -1472,6 +1466,10 @@ static void emit_non_generic_function_forward_decls(CodeGen* gen, Node* ast) {
             for (int fi = 0; fi < func_count; fi++) {
                 func_decl_node* fdn = &funcs[fi]->as.func_decl;
                 if (!should_emit_non_generic_forward_decl(gen, fdn)) {
+                    continue;
+                }
+                // Skip private functions from sibling modules (they're in the other .o)
+                if (skip_private && !fdn->is_public) {
                     continue;
                 }
                 emit_non_generic_forward_decl(gen, fdn, module_prefix);

--- a/w0/module_loader.c
+++ b/w0/module_loader.c
@@ -29,6 +29,10 @@ void module_loader_init(ModuleLoader* loader, const char* lib_path) {
     loader->file_imports_count    = 0;
     loader->file_imports_capacity = 0;
 
+    loader->sibling_modules          = NULL;
+    loader->sibling_modules_count    = 0;
+    loader->sibling_modules_capacity = 0;
+
     loader->import_depth = 0;
 }
 
@@ -52,6 +56,11 @@ void module_loader_free(ModuleLoader* loader) {
         free(loader->file_imports[i]);
     }
     free(loader->file_imports);
+
+    for (int i = 0; i < loader->sibling_modules_count; i++) {
+        free(loader->sibling_modules[i]);
+    }
+    free(loader->sibling_modules);
 }
 
 int module_loader_is_imported(ModuleLoader* loader, const char* name, size_t len) {
@@ -98,6 +107,26 @@ static void add_file_import(ModuleLoader* loader, const char* name, size_t len) 
     loader->file_imports[loader->file_imports_count++] = name_copy;
 }
 
+static void add_sibling_module(ModuleLoader* loader, const char* name, size_t len) {
+    VEC_GROW(loader->sibling_modules, loader->sibling_modules_count,
+             loader->sibling_modules_capacity);
+
+    char* name_copy = xmalloc(len + 1);
+    memcpy(name_copy, name, len);
+    name_copy[len]                                           = '\0';
+    loader->sibling_modules[loader->sibling_modules_count++] = name_copy;
+}
+
+int module_loader_is_sibling(ModuleLoader* loader, const char* name, size_t len) {
+    for (int i = 0; i < loader->sibling_modules_count; i++) {
+        if (strlen(loader->sibling_modules[i]) == len &&
+            strncmp(loader->sibling_modules[i], name, len) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int module_loader_file_exists(const char* path) {
     FILE* f = fopen(path, "r");
     if (f) {
@@ -135,6 +164,17 @@ void module_loader_build_path(ModuleLoader* loader, const char* source_path, cha
     // Standard library import: try lib/ directories
     if (loader->lib_path) {
         snprintf(path, path_size, "%s/%.*s.w", loader->lib_path, (int)module_length, module_name);
+        if (module_loader_file_exists(path)) {
+            return;
+        }
+    }
+
+    // Sibling import: try source directory
+    if (source_path) {
+        char* path_copy = xstrdup(source_path);
+        char* dir       = dirname(path_copy);
+        snprintf(path, path_size, "%s/%.*s.w", dir, (int)module_length, module_name);
+        free(path_copy);
         if (module_loader_file_exists(path)) {
             return;
         }
@@ -259,7 +299,22 @@ int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, No
             }
             import_ast->as.program.modules.count = 0;
         } else {
-            // Library import: rename main module to library name
+            // Named import: rename main module to library name.
+            // Detect sibling imports (not found in lib-path).
+            int is_sibling_import = 0;
+            if (loader->lib_path) {
+                char lib_check[1024];
+                snprintf(lib_check, sizeof(lib_check), "%s/%.*s.w", loader->lib_path,
+                         (int)module_length, module_name);
+                is_sibling_import = !module_loader_file_exists(lib_check);
+            } else {
+                is_sibling_import = 1;
+            }
+
+            if (is_sibling_import) {
+                add_sibling_module(loader, module_name, module_length);
+            }
+
             for (int m = 0; m < import_ast->as.program.modules.count; m++) {
                 Node* imported_module = import_ast->as.program.modules.nodes[m];
                 if (imported_module && imported_module->type == NODE_MODULE) {
@@ -269,6 +324,7 @@ int module_loader_import(ModuleLoader* loader, Parser* parser, Node* program, No
                         memcpy(imported_module->as.module.name, module_name, module_length);
                         imported_module->as.module.name[module_length] = '\0';
                         imported_module->as.module.name_length         = (int)module_length;
+                        imported_module->as.module.is_sibling          = is_sibling_import;
                     }
                     nodelist_push(&program->as.program.modules, imported_module);
                 }

--- a/w0/module_loader.h
+++ b/w0/module_loader.h
@@ -31,6 +31,11 @@ typedef struct {
     int    file_imports_count;
     int    file_imports_capacity;
 
+    // Sibling modules (imported from same directory, not lib-path)
+    char** sibling_modules;
+    int    sibling_modules_count;
+    int    sibling_modules_capacity;
+
     // 0 = root file, >0 = transitive import
     int import_depth;
 } ModuleLoader;
@@ -48,6 +53,7 @@ void module_loader_add_direct_import(ModuleLoader* loader, const char* name, siz
 // Path utilities
 int  module_loader_file_exists(const char* path);
 int  module_loader_is_relative_path(const char* path, size_t len);
+int  module_loader_is_sibling(ModuleLoader* loader, const char* name, size_t len);
 void module_loader_build_path(ModuleLoader* loader, const char* source_path, char* path,
                               size_t path_size, const char* module_name, size_t module_length,
                               int is_relative);

--- a/w0/parser_decl.c
+++ b/w0/parser_decl.c
@@ -712,7 +712,7 @@ static Node* parse_extern_decls(Parser* parser, int is_public) {
 // Import Handling
 // ============================================================================
 
-// Parse a use statement: use module.symbol; or use module.{sym1, sym2};
+// Parse a use statement: use module::symbol; or use module::{sym1, sym2}; or use module::*;
 Node* parse_use_stmt(Parser* parser) {
     Token module_token = parser->current;
     consume_token(parser, TOK_IDENT, "Expected module name after 'use'");
@@ -724,9 +724,13 @@ Node* parse_use_stmt(Parser* parser) {
     char** symbol_names = xmalloc(capacity * sizeof(char*));
     int*   name_lengths = xmalloc(capacity * sizeof(int));
     int    count        = 0;
+    int    is_wildcard  = 0;
 
-    if (match_token(parser, TOK_LBRACE)) {
-        // Grouped: use module.{sym1, sym2}
+    if (match_token(parser, TOK_STAR)) {
+        // Wildcard: use module::*
+        is_wildcard = 1;
+    } else if (match_token(parser, TOK_LBRACE)) {
+        // Grouped: use module::{sym1, sym2}
         while (!check_token(parser, TOK_RBRACE) && !check_token(parser, TOK_EOF)) {
             Token sym = parser->current;
             consume_token(parser, TOK_IDENT, "Expected symbol name in use group");
@@ -744,9 +748,9 @@ Node* parse_use_stmt(Parser* parser) {
         }
         consume_token(parser, TOK_RBRACE, "Expected '}' after use group");
     } else {
-        // Single: use module.symbol
+        // Single: use module::symbol
         Token sym = parser->current;
-        consume_token(parser, TOK_IDENT, "Expected symbol name after '.'");
+        consume_token(parser, TOK_IDENT, "Expected symbol name after '::'");
         symbol_names[0] = copy_token_string(&sym);
         name_lengths[0] = sym.length;
         count           = 1;
@@ -760,6 +764,7 @@ Node* parse_use_stmt(Parser* parser) {
     node->as.use_decl.symbol_names        = symbol_names;
     node->as.use_decl.symbol_name_lengths = name_lengths;
     node->as.use_decl.symbol_count        = count;
+    node->as.use_decl.is_wildcard         = is_wildcard;
     return node;
 }
 

--- a/wc/Makefile
+++ b/wc/Makefile
@@ -1,7 +1,7 @@
 W0 = ../w0/bin/w0
 LIB = ../lib
 BIN = bin
-SRC = main.w
+SRC = main.w lexer.w
 OBJ = $(SRC:.w=.o)
 TARGET = $(BIN)/wc
 

--- a/wc/lexer.w
+++ b/wc/lexer.w
@@ -1,6 +1,6 @@
 // Whist Lexer — Self-hosted port of w0/lexer.c
 
-enum TokenType {
+public enum TokenType {
     // End of file
     EOF,
 
@@ -105,14 +105,14 @@ enum TokenType {
     Error,
 }
 
-struct Token {
+public struct Token {
     kind: TokenType,
     value: string,
     line: i64,
     column: i64,
 }
 
-struct Lexer {
+public struct Lexer {
     source: string,
     pos: i64,
     start: i64,
@@ -146,7 +146,7 @@ func is_octal_digit(ch: char) -> bool {
 
 // --- Lexer core functions ---
 
-func lexer_init(source: string) -> Lexer {
+public func lexer_init(source: string) -> Lexer {
     var lex = new Lexer{
         source: source,
         pos: 0,
@@ -569,7 +569,7 @@ func lex_character(lex: Lexer) -> Token {
 
 // --- Main lexer function ---
 
-func lexer_next(lex: Lexer) -> Token {
+public func lexer_next(lex: Lexer) -> Token {
     lexer_skip_whitespace(lex);
 
     lex.start = lex.pos;
@@ -757,7 +757,7 @@ func lexer_next(lex: Lexer) -> Token {
 
 // --- Token type name ---
 
-func token_type_name(tt: TokenType) -> string {
+public func token_type_name(tt: TokenType) -> string {
     match (tt) {
         EOF => return "EOF";
         Ident => return "IDENT";

--- a/wc/main.w
+++ b/wc/main.w
@@ -3,8 +3,8 @@
 
 import std;
 import fs;
-
-include "./lexer.w";
+import lexer;
+use lexer::*;
 
 struct MainOptions {
     lex_only: bool,


### PR DESCRIPTION
## Summary

- Extends the `import` system to resolve sibling `.w` files in the same directory, enabling true separate compilation
- Adds wildcard `use module::*;` syntax to bring all public symbols into unqualified scope (needed because the parser only handles two-part `::` paths)
- Compiles `wc/main.w` and `wc/lexer.w` into separate `.o` files and links them, replacing the textual `include` mechanism

## Changes

**Module loader** (`w0/module_loader.c`, `w0/module_loader.h`):
- After checking lib-path, check `{source_dir}/{module_name}.w` for sibling modules
- Track sibling modules separately so codegen knows which modules use bare names

**AST** (`w0/ast.h`):
- `is_sibling` flag on module nodes
- `is_wildcard` flag on use_decl nodes

**Parser** (`w0/parser_decl.c`):
- Parse `use module::*;` wildcard syntax

**Checker** (`w0/checker.c`):
- For wildcard use: iterate all scope symbols from the target module, alias each public symbol

**Codegen** (`w0/codegen.c`, `w0/codegen_emit.c`):
- Sibling non-target modules: emit extern prototypes with bare names (no module prefix), skip function bodies entirely
- Non-sibling (library) modules: unchanged behavior (static copies)

**wc** (`wc/lexer.w`, `wc/main.w`, `wc/Makefile`):
- Mark lexer API functions/types as `public`
- Replace `include "./lexer.w"` with `import lexer; use lexer::*;`
- Compile both files separately and link

## Test plan

- [x] All 250 existing tests pass (no regressions)
- [x] `main.o` has undefined references to `lexer_init`, `lexer_next`, `token_type_name`
- [x] `lexer.o` defines those symbols as non-static (external linkage)
- [x] Linked `bin/wc` binary runs correctly
- [x] `--emit-c` output shows bare extern prototypes in main.w, non-static definitions in lexer.w