### PR TITLE
fix: allow generic base name in qualified match arms

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1144,8 +1144,14 @@ static Type* check_match_enum(Checker* checker, Node* node, Type* expr_type, int
         }
 
         // If qualified name given, verify it matches the enum type
+        // Accept both the mangled name (e.g. "Result_string_string") and the base
+        // generic name (e.g. "Result") for generic enum instances.
         if (arm->as.match_arm.enum_name) {
-            if (strcmp(arm->as.match_arm.enum_name, expr_type->as.enm.name) != 0) {
+            const char* arm_name = arm->as.match_arm.enum_name;
+            int match = strcmp(arm_name, expr_type->as.enm.name) == 0 ||
+                        (expr_type->as.enm.base_name &&
+                         strcmp(arm_name, expr_type->as.enm.base_name) == 0);
+            if (!match) {
                 check_error(checker, arm->line, arm->column,
                             "Enum name '%s' does not match match expression type '%s'",
                             arm->as.match_arm.enum_name, expr_type->as.enm.name);

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -796,6 +796,7 @@ static void register_enum_method_symbol(Checker* checker, func_decl_node* mfdn,
 Type* instantiate_generic_enum(Checker* checker, GenericDef* def, char* mangled,
                                Type** resolved_args, int arg_count) {
     Type* enum_type = type_enum(mangled);
+    enum_type->as.enm.base_name = xstrdup(def->name);
 
     // Register early to handle recursive types
     register_generic_instance(checker, mangled, def->name, enum_type, resolved_args, arg_count);

--- a/w0/test/run/errors/std_result.w
+++ b/w0/test/run/errors/std_result.w
@@ -1,4 +1,5 @@
 // Expected: PASS: std_result
+// Expected: PASS: mismatched_result
 // Test Result<T, E> from prelude — return Ok and Err, match on both
 
 func parse_number(s: string) -> Result<i64, string> {
@@ -28,6 +29,20 @@ test "std_result" {
         },
         Err(msg) => {
             assert(msg == "not a number");
+        },
+    }
+}
+
+test "mismatched_result" {
+
+    var res: Result<string, string> = Result::Ok("hello");
+
+    match (res) {
+        Result::Ok(val) => {
+            assert(val == "hello");
+        },
+        Result::Err(msg) => {
+            assert(false);
         },
     }
 }

--- a/w0/types.c
+++ b/w0/types.c
@@ -111,6 +111,7 @@ Type* type_struct(const char* name) {
 Type* type_enum(const char* name) {
     Type* type                       = type_new(TYPE_ENUM);
     type->as.enm.name                = xstrdup(name);
+    type->as.enm.base_name           = NULL;
     type->as.enm.value_names         = NULL;
     type->as.enm.value_count         = 0;
     type->as.enm.has_data            = 0;
@@ -210,6 +211,7 @@ static void type_free_struct_members(Type* type) {
 // Free heap-owned members of an enum type definition.
 static void type_free_enum_members(Type* type) {
     free(type->as.enm.name);
+    free(type->as.enm.base_name);
     for (int i = 0; i < type->as.enm.value_count; i++) {
         free(type->as.enm.value_names[i]);
     }

--- a/w0/types.h
+++ b/w0/types.h
@@ -96,6 +96,7 @@ struct Type {
         // Enum
         struct {
             char*   name;
+            char*   base_name; // For generic instances: base type name (e.g. "Result" for "Result_i64_string")
             char**  value_names;
             int     value_count;
             int     has_data;            // 1 if any variant carries payload


### PR DESCRIPTION
## Summary
- Qualified match arms like `Result::Ok(val)` on generic enum instances (e.g. `Result<string, string>`) failed because the checker compared the user-written name `"Result"` against the mangled internal name `"Result_string_string"`
- Adds a `base_name` field to the enum type (mirroring how structs already work) and accepts either the mangled or base name in match arm validation
- Adds a `mismatched_result` test exercising qualified match arms on `Result<string, string>`

## Test plan
- [x] `make test-verbose FILTER=std_result` — new test passes
- [x] `make test` — all 250 tests pass