### PR TITLE
fix: string literal RC collection for if-let/while-let and lexer escape handling

### DIFF
--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -590,6 +590,12 @@ static int collect_string_literals_stmt_node(CodeGen* gen, Node* node) {
         collect_string_literals_node(gen, node->as.if_stmt.then_block);
         collect_string_literals_node(gen, node->as.if_stmt.else_block);
         return 1;
+    case NODE_IF_LET:
+        collect_string_literals_node(gen, node->as.if_let_stmt.expr);
+        collect_string_literals_node(gen, node->as.if_let_stmt.extra_cond);
+        collect_string_literals_node(gen, node->as.if_let_stmt.then_block);
+        collect_string_literals_node(gen, node->as.if_let_stmt.else_block);
+        return 1;
     case NODE_FOR:
         collect_string_literals_node(gen, node->as.for_stmt.init);
         collect_string_literals_node(gen, node->as.for_stmt.cond);
@@ -605,6 +611,11 @@ static int collect_string_literals_stmt_node(CodeGen* gen, Node* node) {
     case NODE_WHILE:
         collect_string_literals_node(gen, node->as.while_stmt.cond);
         collect_string_literals_node(gen, node->as.while_stmt.body);
+        return 1;
+    case NODE_WHILE_LET:
+        collect_string_literals_node(gen, node->as.while_let_stmt.expr);
+        collect_string_literals_node(gen, node->as.while_let_stmt.extra_cond);
+        collect_string_literals_node(gen, node->as.while_let_stmt.body);
         return 1;
     case NODE_EXPR_STMT:
         collect_string_literals_node(gen, node->as.expr_stmt.expr);

--- a/wc/lexer.w
+++ b/wc/lexer.w
@@ -428,28 +428,25 @@ func (Lexer) number(start_char: char) -> Token {
 
 // --- Escape sequence handling ---
 
-func (Lexer) advance_octal_value() -> Result<string, string> {
-    foreach(const i in 0..3) {
-        match(self.peek()) {
-            LexerCharacter::EOF => return Result::Err("Unterminated octal escape sequence");
-            LexerCharacter::Char(ch) => {
-                if (!ch.is_octal_digit()) {
-                    return Result::Err("Invalid octal escape sequence");
-                }
-                self.advance();
-            }
+func (Lexer) advance_octal_value() {
+    // Consume 1-3 octal digits greedily (like C's \NNN)
+    for (var i: i64 = 0; i < 3; i += 1) {
+        if (self.peek() is LexerCharacter::Char(ch) && ch.is_octal_digit()) {
+            self.advance();
+        } else {
+            return;
         }
     }
-    return Result::Ok("");
 }
 
-func (Lexer) advance_hex_value() -> Result<string, string> {
-    foreach(const i in 0..3) {
+func (Lexer) advance_hex_value(error_msg: string) -> Result<string, string> {
+    // Exactly 2 hex digits required for \xNN
+    foreach(const i in 0..2) {
         match(self.peek()) {
-            LexerCharacter::EOF => return Result::Err("Unterminated hex escape sequence");
+            LexerCharacter::EOF => return Result::Err(error_msg);
             LexerCharacter::Char(ch) => {
                 if (!ch.is_hex_digit()) {
-                    return Result::Err("Invalid hex escape sequence");
+                    return Result::Err(error_msg);
                 }
                 self.advance();
             }
@@ -468,10 +465,12 @@ func (Lexer) skip_escape() -> Result<string, string> {
     if (escaped == LexerCharacter::Char('x')) {
         // Hex escape: \xNN
         self.advance();
-        return self.advance_hex_value();
+        return self.advance_hex_value("Invalid hex escape in string literal");
     }
     if (escaped is LexerCharacter::Char(ch) && ch.is_octal_digit()) {
-        return self.advance_octal_value();
+        // Octal escape: 1-3 digits
+        self.advance_octal_value();
+        return Result::Ok("");
     }
     // Simple escape: \n, \t, \r, \\, \', \", \e, \0, etc.
     self.advance();
@@ -600,18 +599,13 @@ func (Lexer) scan_char() -> Token {
         if (escaped == LexerCharacter::Char('x')) {
             // Hex escape: \xNN
             self.advance();
-            match(self.advance_hex_value()) {
+            match(self.advance_hex_value("Invalid hex escape in character literal")) {
                 Result::Ok(x) => { /* continue */ }
                 Result::Err(msg) => return self.error_token(msg);
             }
-
-            // return self.advance_hex_value().unwrap_or_else(|msg: string| self.error_token(msg));
         } else if (escaped is LexerCharacter::Char(ch) && ch.is_octal_digit()) {
-            match(self.advance_octal_value()) {
-                Result::Ok(x) => { /* continue */ }
-                Result::Err(msg) => return self.error_token(msg);
-            }
-            // return self.advance_octal_value().unwrap_or_else(|msg: string| self.error_token(msg));
+            // Octal escape: 1-3 digits
+            self.advance_octal_value();
         } else {
             // Simple escape
             self.advance();


### PR DESCRIPTION
## Summary
- **Compiler fix**: `collect_string_literals_stmt_node` was missing `NODE_IF_LET` and `NODE_WHILE_LET`, so string literals inside `if ... is` / `while ... is` blocks were emitted as raw C strings instead of `__rc_str` constants. Calling `__rc_inc` on those caused bus errors (SIGBUS) in the wc lexer.
- **Lexer fix**: Hex escapes (`\xNN`) now read exactly 2 digits instead of 3; octal escapes greedily consume 1-3 digits instead of requiring exactly 3 (so `\0` works); error messages are context-specific per w0 behavior.

## Test plan
- [x] `make test` — 250/250 w0 tests pass
- [x] `make compare` — 266/266 wc lexer outputs match w0