### PR TITLE
fix: emit RC cleanup before break/continue in loops

### DIFF
--- a/tools/compare_output.sh
+++ b/tools/compare_output.sh
@@ -85,7 +85,15 @@ done < <(find "$TEST_DIR" -name '*.w' -type f -print0 | sort -z)
 
 PASS=0
 FAIL=0
+LEAK=0
 FAIL_LIST=()
+LEAK_LIST=()
+
+# Known RC baseline: net alloc−free count.  This is −3 because whist_runtime.c
+# (compiled without WHIST_RC_DEBUG) allocates 3 argv strings via __rc_strdup
+# whose RC_ALLOC traces are invisible, but whose RC_FREE traces are visible.
+# Real RC balance is 0; visible balance = 0 − 3 = −3.
+KNOWN_LEAKS=-3
 
 echo -e "${BOLD}Comparing w0 vs wc output (stage: $STAGE)${RESET}"
 echo "---"
@@ -105,19 +113,18 @@ for FILE in "${TEST_FILES[@]}"; do
     W0_EXIT=0
     "$W0" $W0_FLAGS "$FILE" > "$W0_OUT" 2>/dev/null || W0_EXIT=$?
 
+    WC_RC=$(mktemp)
     WC_EXIT=0
-    "$WC" $WC_FLAGS "$FILE" > "$WC_OUT" 2>/dev/null || WC_EXIT=$?
+    "$WC" $WC_FLAGS "$FILE" > "$WC_OUT" 2>"$WC_RC" || WC_EXIT=$?
 
     # Normalize: strip trailing whitespace from each line
     sed -i '' 's/[[:space:]]*$//' "$W0_OUT" 2>/dev/null || sed -i 's/[[:space:]]*$//' "$W0_OUT"
     sed -i '' 's/[[:space:]]*$//' "$WC_OUT" 2>/dev/null || sed -i 's/[[:space:]]*$//' "$WC_OUT"
 
-    if diff -q "$W0_OUT" "$WC_OUT" > /dev/null 2>&1; then
-        PASS=$((PASS + 1))
-        if [[ $VERBOSE -eq 1 ]]; then
-            echo -e "  ${GREEN}PASS${RESET}  $REL_PATH"
-        fi
-    else
+    # Check output match
+    MATCH=1
+    if ! diff -q "$W0_OUT" "$WC_OUT" > /dev/null 2>&1; then
+        MATCH=0
         FAIL=$((FAIL + 1))
         FAIL_LIST+=("$REL_PATH")
         echo -e "  ${RED}FAIL${RESET}  $REL_PATH"
@@ -127,7 +134,35 @@ for FILE in "${TEST_FILES[@]}"; do
         fi
     fi
 
-    rm -f "$W0_OUT" "$WC_OUT"
+    # Check for RC leaks beyond the known baseline.
+    # Use net alloc-free count (address-based tracking is unreliable due to
+    # malloc address reuse).
+    LEAK_COUNT=$(awk '/^RC_ALLOC:/{a++} /^RC_FREE:/{f++} END{print (a+0)-(f+0)}' "$WC_RC")
+    if [[ "$LEAK_COUNT" -ne "$KNOWN_LEAKS" ]]; then
+        DELTA=$((LEAK_COUNT - KNOWN_LEAKS))
+        LEAK=$((LEAK + 1))
+        LEAK_LIST+=("$REL_PATH (delta=$DELTA)")
+        echo -e "  ${YELLOW}LEAK${RESET}  $REL_PATH  (net=$LEAK_COUNT, expected=$KNOWN_LEAKS, delta=$DELTA)"
+        if [[ $VERBOSE -eq 1 ]]; then
+            # Show per-address details for debugging
+            awk '/^RC_ALLOC:/{alloc[$2]++} /^RC_FREE:/{free[$2]++} END{
+                for(a in alloc) {
+                    f = (a in free ? free[a] : 0);
+                    if(alloc[a] > f) print a ": alloc=" alloc[a] " free=" f " net=+" (alloc[a]-f)
+                }
+            }' "$WC_RC"
+            echo ""
+        fi
+    fi
+
+    if [[ $MATCH -eq 1 && "$LEAK_COUNT" -eq "$KNOWN_LEAKS" ]]; then
+        PASS=$((PASS + 1))
+        if [[ $VERBOSE -eq 1 ]]; then
+            echo -e "  ${GREEN}PASS${RESET}  $REL_PATH"
+        fi
+    fi
+
+    rm -f "$W0_OUT" "$WC_OUT" "$WC_RC"
 done
 
 TOTAL=$((PASS + FAIL))
@@ -135,16 +170,37 @@ echo "---"
 echo -e "${BOLD}Results:${RESET} $TOTAL files compared"
 echo -e "  ${GREEN}PASS: $PASS${RESET}"
 
+EXIT_CODE=0
+
 if [[ $FAIL -gt 0 ]]; then
     echo -e "  ${RED}FAIL: $FAIL${RESET}"
+    EXIT_CODE=1
+fi
+
+if [[ $LEAK -gt 0 ]]; then
+    echo -e "  ${YELLOW}LEAK: $LEAK${RESET}"
+    EXIT_CODE=1
+fi
+
+if [[ $FAIL -gt 0 ]]; then
     echo ""
     echo -e "${RED}Failed files:${RESET}"
     for F in "${FAIL_LIST[@]}"; do
         echo "  $F"
     done
-    exit 1
-else
-    echo ""
-    echo -e "${GREEN}All outputs match!${RESET}"
-    exit 0
 fi
+
+if [[ $LEAK -gt 0 ]]; then
+    echo ""
+    echo -e "${YELLOW}Files with RC imbalance (expected net=$KNOWN_LEAKS):${RESET}"
+    for F in "${LEAK_LIST[@]}"; do
+        echo "  $F"
+    done
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo ""
+    echo -e "${GREEN}All outputs match, no extra leaks!${RESET}"
+fi
+
+exit $EXIT_CODE

--- a/w0/codegen.h
+++ b/w0/codegen.h
@@ -47,6 +47,7 @@ typedef struct {
     int    count;
     int    capacity;
     int    depth;
+    int    loop_depth; // scope depth of innermost loop body (for break/continue cleanup)
     int    debug;
 } CodeGenRc;
 

--- a/w0/codegen_internal.h
+++ b/w0/codegen_internal.h
@@ -31,6 +31,7 @@ const char* get_inc_func_for_type(Type* t);
 void        rc_push_var(CodeGen* gen, const char* name, Type* type);
 void        rc_cleanup_scope(CodeGen* gen, int depth);
 void        rc_cleanup_all(CodeGen* gen, const char* skip_name);
+void        rc_cleanup_to_depth(CodeGen* gen, int target_depth);
 Type*       rc_get_var_type(CodeGen* gen, const char* name);
 int         rc_is_tracked(CodeGen* gen, const char* name);
 

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -97,6 +97,19 @@ void rc_cleanup_scope(CodeGen* gen, int depth) {
     gen->rc.count = dst;
 }
 
+// Emit dec for vars at scope_depth >= target_depth. Does NOT modify list.
+// Used by break/continue to clean up all loop-body scopes without removing
+// vars from tracking (the normal scope-exit cleanup handles removal).
+void rc_cleanup_to_depth(CodeGen* gen, int target_depth) {
+    for (int i = 0; i < gen->rc.count; i++) {
+        if (gen->rc.vars[i].scope_depth >= target_depth) {
+            emit_indent(gen);
+            emit_rc_dec_var(gen, &gen->rc.vars[i]);
+            emit(gen, ";\n");
+        }
+    }
+}
+
 // Emit dec for ALL remaining vars (skip one by name). Does NOT modify list.
 void rc_cleanup_all(CodeGen* gen, const char* skip_name) {
     for (int i = 0; i < gen->rc.count; i++) {

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -1701,7 +1701,10 @@ static void emit_while_stmt(CodeGen* gen, Node* node) {
         emit(gen, "if (!__while_cond%d) break;\n", cond_id);
 
         // Emit loop body
+        int saved_ld = gen->rc.loop_depth;
+        gen->rc.loop_depth = gen->rc.depth + 1;
         emit_stmt_body(gen, node->as.while_stmt.body);
+        gen->rc.loop_depth = saved_ld;
         gen->out.indent--;
         emit_indent(gen);
         emit(gen, "}\n");
@@ -1720,7 +1723,10 @@ static void emit_while_stmt(CodeGen* gen, Node* node) {
     }
 
     gen->out.indent++;
+    int saved_ld = gen->rc.loop_depth;
+    gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.while_stmt.body);
+    gen->rc.loop_depth = saved_ld;
     gen->out.indent--;
     emit_indent(gen);
     emit(gen, "}\n");
@@ -1759,7 +1765,10 @@ static void emit_for_stmt(CodeGen* gen, Node* node) {
     emit(gen, ") {\n");
 
     gen->out.indent++;
+    int saved_ld = gen->rc.loop_depth;
+    gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.for_stmt.body);
+    gen->rc.loop_depth = saved_ld;
     gen->out.indent--;
     emit_indent(gen);
     emit(gen, "}\n");
@@ -1800,7 +1809,10 @@ static void emit_foreach_collection_stmt(CodeGen* gen, Node* node) {
         emit(gen, "%sdata[__foreach_%d];\n", access, idx_id);
     }
 
+    int saved_ld = gen->rc.loop_depth;
+    gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.foreach_stmt.body);
+    gen->rc.loop_depth = saved_ld;
     gen->out.indent--;
     emit_indent(gen);
     emit(gen, "}\n");
@@ -1826,7 +1838,10 @@ static void emit_foreach_range_stmt(CodeGen* gen, Node* node) {
     emit_expr(gen, node->as.foreach_stmt.step);
     emit(gen, ") {\n");
     gen->out.indent++;
+    int saved_ld = gen->rc.loop_depth;
+    gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.foreach_stmt.body);
+    gen->rc.loop_depth = saved_ld;
     gen->out.indent--;
     emit_indent(gen);
     emit(gen, "}\n");
@@ -1846,18 +1861,20 @@ static void emit_defer_stmt(CodeGen* gen, Node* node) {
     defer_push(gen, node->as.defer_stmt.stmt);
 }
 
-// Emit a break statement with RC cleanup for the current scope depth.
+// Emit a break statement with RC cleanup for all loop-body scopes.
+// Uses rc_cleanup_to_depth (emit-only) since break may be in a conditional
+// branch — the normal scope-exit cleanup handles var list removal.
 static void emit_break_stmt(CodeGen* gen, Node* node) {
     (void)node;
-    rc_cleanup_scope(gen, gen->rc.depth);
+    rc_cleanup_to_depth(gen, gen->rc.loop_depth);
     emit_indent(gen);
     emit(gen, "break;\n");
 }
 
-// Emit a continue statement with RC cleanup for the current scope depth.
+// Emit a continue statement with RC cleanup for all loop-body scopes.
 static void emit_continue_stmt(CodeGen* gen, Node* node) {
     (void)node;
-    rc_cleanup_scope(gen, gen->rc.depth);
+    rc_cleanup_to_depth(gen, gen->rc.loop_depth);
     emit_indent(gen);
     emit(gen, "continue;\n");
 }
@@ -2157,7 +2174,10 @@ static void emit_while_stmt_with_is_bindings(CodeGen* gen, Node* node) {
     }
 
     // Emit loop body
+    int saved_ld = gen->rc.loop_depth;
+    gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.while_stmt.body);
+    gen->rc.loop_depth = saved_ld;
 
     // End-of-iteration cleanup for all is_expr temps
     for (int i = 0; i < cleanup_len; i++) {


### PR DESCRIPTION
## Summary
- **Break/continue RC leak fix**: `break` and `continue` inside loops were skipping end-of-iteration RC cleanup, leaking all loop-body-scoped RC variables. Added `loop_depth` tracking to `CodeGenRc` and `rc_cleanup_to_depth()` which emits `__rc_dec` for all vars at `scope_depth >= loop_depth` without removing them from the tracking list (emit-only, like `rc_cleanup_all`).
- **All 5 loop emitters** (`while`, `for`, `foreach` collection, `foreach` range, `while-is`) save/restore `loop_depth` and set it to `gen->rc.depth + 1` before emitting the body.
- **RC leak checking in `make compare`**: `compare_output.sh` now captures wc's stderr RC debug traces and verifies exact net alloc−free balance (expected −3 from 3 invisible argv `__rc_strdup` allocations in `whist_runtime.c`). Any deviation in either direction is flagged.

## Test plan
- [x] `make test` — 253/253 pass
- [x] `make compare` — 270/270 pass with net=−3 (real balance = 0)