### PR TITLE
docs: update README and PROGRESS.md to reflect current state

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,16 +4,116 @@ A weekly changelog of the Whist compiler, tracking development from initial comm
 
 ---
 
+## Week of Feb 23 – Mar 1, 2026
+
+Self-hosting accelerates: the `wc` self-hosted compiler gains a working lexer, sibling module imports, and separate compilation. The bootstrap compiler adds `is` expressions as a cleaner replacement for if-let/while-let, and the standard library modules are compiled to `libwhist.a` for proper separate linking. Default initialization for `Option<T>` rounds out the ergonomics story.
+
+- **feat: compile stdlib modules to libwhist.a for separate linking** — stdlib modules now compile into a static library, enabling clean multi-unit builds
+- **feat: replace if-let/while-let with `is` expression** ([#319](https://github.com/shanehyde/whist/pull/319)) — unified `is` syntax for pattern matching in conditionals: `if (opt is Some(v)) { ... }`
+- **fix: string literal RC collection for if-let/while-let and lexer escape handling** ([#318](https://github.com/shanehyde/whist/pull/318)) — correct RC tracking for string literals in pattern-matching contexts
+- **fix: allow generic base name in qualified match arms** ([#317](https://github.com/shanehyde/whist/pull/317)) — `Option::Some(v)` now resolves correctly for generic enum types
+- **refactor(wc): idiomatic method syntax for lexer** ([#316](https://github.com/shanehyde/whist/pull/316)) — self-hosted lexer rewritten to use Whist receiver method syntax
+- **feat: sibling module imports and separate compilation for wc** ([#315](https://github.com/shanehyde/whist/pull/315)) — wc modules can import siblings; separate `.w` → `.c` → `.o` compilation pipeline
+- **feat(wc): implement self-hosted lexer and run_lex_mode** ([#314](https://github.com/shanehyde/whist/pull/314)) — first working component of the self-hosted compiler: a complete lexer written in Whist
+- **fix: preserve short-circuit evaluation for RC-managed temps** ([#311](https://github.com/shanehyde/whist/pull/311)) — `&&`/`||` expressions correctly short-circuit without leaking RC temporaries
+- **feat: default Option\<T\> to None when not initialized** ([#310](https://github.com/shanehyde/whist/pull/310)) — `var opt: Option<i64>;` defaults to `None` instead of requiring explicit initialization
+- **feat: add --verbose per-test output and test name filter to test_runner** ([#309](https://github.com/shanehyde/whist/pull/309)) — `make test VERBOSE=1` shows per-test results; filter by name substring
+- **fix: infer generic enum type params from struct field type** ([#308](https://github.com/shanehyde/whist/pull/308)) — generic enum constructors in struct init now infer type parameters from the field declaration
+- **fix: emit \_\_rc\_inc for RC-managed values in enum variant construction** ([#306](https://github.com/shanehyde/whist/pull/306)) — wrapping an RC value in an enum variant (`Some(my_struct)`) now correctly increments the refcount
+- **feat: port w0 CLI option processing to wc/main.w** ([#302](https://github.com/shanehyde/whist/pull/302)) — self-hosted compiler entry point processes command-line flags
+- **fix: Option\<string\> struct field methods and RC cleanup** ([#303](https://github.com/shanehyde/whist/pull/303)) — methods on `Option<string>` fields in structs now resolve and clean up correctly
+- **feat: separate compilation and linking for multi-file projects** ([#299](https://github.com/shanehyde/whist/pull/299)) — `w0` can compile individual `.w` files to `.c` and link them together
+- **feat: add top-level Makefile and wc scaffolding** ([#298](https://github.com/shanehyde/whist/pull/298)) — project-wide `make` with targets for w0, wc, lib, and tests
+- **refactor: simplify main() and codegen/types helpers** ([#300](https://github.com/shanehyde/whist/pull/300), [#291](https://github.com/shanehyde/whist/pull/291)) — extracted helpers from main and simplified type query functions
+- **feat: checker error for assigning to captured value types in lambdas** ([#290](https://github.com/shanehyde/whist/pull/290)) — assigning to a by-value capture now produces a clear error message
+- **feat: add autoboxing syntax `var ^name = value`** ([#289](https://github.com/shanehyde/whist/pull/289)) — explicit autoboxing hint for wrapping primitives in `Box<T>`
+- **feat: add Box\<T\> built-in type with auto-deref** ([#288](https://github.com/shanehyde/whist/pull/288)) — `Box<T>` wraps a primitive with transparent arithmetic, comparison, and compound assignment
+- **refactor: move misplaced functions to correct domains** ([#284](https://github.com/shanehyde/whist/pull/284)) — code organization cleanup across checker and codegen
+- **feat: replace shell test runner with Whist-based runner** ([#283](https://github.com/shanehyde/whist/pull/283)) — `make test` now uses a test runner written entirely in Whist
+- **refactor: simplify expression emission and var declaration checking** ([#282](https://github.com/shanehyde/whist/pull/282)) — reduced complexity in expression codegen and variable declaration checking
+- **fix: generic mangling collisions and deduplicate codegen lookup** ([#281](https://github.com/shanehyde/whist/pull/281)) — generic types with similar names no longer collide in generated C
+- **fix: RC leaks in struct destructuring and foreach return** ([#280](https://github.com/shanehyde/whist/pull/280)) — struct destructuring and early return from foreach now clean up correctly
+- **feat: replace import with include for relative paths** ([#279](https://github.com/shanehyde/whist/pull/279)) — `include "./file.w"` for relative paths; `import` reserved for library modules
+- **feat: add Vec/Set/fs convenience methods and simplify test_runner** ([#278](https://github.com/shanehyde/whist/pull/278)) — `Vec.is_empty()`, `Vec.find()`, `Set.insert_all()`, `fs.is_file()`, and other convenience methods
+
+## Week of Feb 16 – Feb 22, 2026
+
+The language reaches a turning point. Lambdas and closures land in quick succession, giving Whist first-class functions with variable capture. Method-level generic type parameters enable `Vec.map<K>` and `Vec.filter`. Pattern matching expands from enums to integers, strings, and general expressions via `is`-based conditionals. A series of syntax refinements — `::` module separator, `->` return type, `include` for relative paths, private struct fields — bring the language closer to its final surface form. The standard library gains a `Set` type, string trimming/padding, escape sequences, and the test runner starts dogfooding itself. Underneath, an owned-temporaries system plugs a category of RC leaks in expressions.
+
+- **feat: change if-let syntax to `is`-based pattern matching** ([#277](https://github.com/shanehyde/whist/pull/277)) — `if (opt is Some(v))` replaces `if let Some(v) = opt`
+- **feat: add private struct fields** ([#276](https://github.com/shanehyde/whist/pull/276)) — `private` modifier on struct fields restricts access to the defining module
+- **feat: change function return type syntax from `:` to `->`** ([#275](https://github.com/shanehyde/whist/pull/275)) — `func foo() -> i32` replaces `func foo() : i32`
+- **feat: improve test_runner dogfooding** ([#271](https://github.com/shanehyde/whist/pull/271)) — test runner uses more Whist idioms
+- **feat: add string trim/strip/pad methods** ([#270](https://github.com/shanehyde/whist/pull/270)) — `trim()`, `trim_start()`, `trim_end()`, `strip_prefix()`, `strip_suffix()`, `pad_left()`, `pad_right()`
+- **feat: add Set collection type** ([#269](https://github.com/shanehyde/whist/pull/269)) — `Set<T>` hash set with `insert`, `contains`, `remove`, `values`
+- **feat: if-let pattern matching + Result/Option methods** ([#268](https://github.com/shanehyde/whist/pull/268)) — `if let` syntax for enum destructuring; `map`, `and_then`, `unwrap_or_else`, `map_err` methods on Option and Result
+- **feat: use compound assignment operators and add missing tests** ([#267](https://github.com/shanehyde/whist/pull/267)) — expanded test coverage for `+=`, `-=`, etc.
+- **feat: implement hex, octal, and \\e escape sequences** ([#266](https://github.com/shanehyde/whist/pull/266)) — `\xNN`, `\NNN` octal, and `\e` (ESC) in strings and chars
+- **feat: improve test runner + fix RC return param bug** ([#260](https://github.com/shanehyde/whist/pull/260)) — returning a borrowed RC parameter now correctly increments; test runner improvements
+- **feat: change module separator from `.` to `::`** ([#259](https://github.com/shanehyde/whist/pull/259)) — `std::println(...)` replaces `std.println(...)`
+- **fix: Vec method lookup, tuple codegen, RC leak in tuple destructuring** ([#256](https://github.com/shanehyde/whist/pull/256)) — several fixes for Vec methods on aliased types, tuple codegen edge cases, and tuple destructuring RC
+- **feat: update VS Code syntax highlighter to match current grammar** ([#255](https://github.com/shanehyde/whist/pull/255)) — TextMate grammar updated for `::`, `->`, new keywords
+- **feat: closures (capturing lambdas)** ([#254](https://github.com/shanehyde/whist/pull/254)) — lambdas can now capture variables from enclosing scopes; RC-managed captures are reference-counted; fat pointer representation with environment
+- **feat: renaming on struct destructuring** ([#253](https://github.com/shanehyde/whist/pull/253)) — `var {code, value: val} = info;` renames fields during destructuring
+- **feat: lambda parameter type inference** ([#251](https://github.com/shanehyde/whist/pull/251)) — lambda parameters infer types from the expected function signature
+- **fix: RC leak in chained method calls** ([#250](https://github.com/shanehyde/whist/pull/250)) — intermediate RC values in method chains are now properly cleaned up
+- **fix(generics): handle method-level generic receiver patterns** ([#249](https://github.com/shanehyde/whist/pull/249)) — edge cases in generic method dispatch on receivers
+- **feat: method-level generic type parameters** ([#247](https://github.com/shanehyde/whist/pull/247)) — `func (Vec<T>) map<K>(f: func(T) -> K) -> Vec<K>` — methods can introduce their own type parameters beyond the receiver's
+- **feat: lambda expressions (non-capturing)** ([#245](https://github.com/shanehyde/whist/pull/245)) — `|x: i64| x * 2` syntax, block bodies, empty params, direct calls; compiled as function pointers with null environment
+- **feat: owned temporaries cleanup in control flow** ([#244](https://github.com/shanehyde/whist/pull/244)) — RC temporaries in if/while/for conditions cleaned up at end of enclosing scope
+- **feat: match on general expression types** ([#243](https://github.com/shanehyde/whist/pull/243)) — match statements now work on integers, floats, strings, chars, and bools — not just enums
+- **feat: owned temporaries system for RC leak prevention** ([#242](https://github.com/shanehyde/whist/pull/242)) — new system tracks RC values returned from function calls and ensures cleanup at statement boundaries
+- **fix: RC handling for enum/Vec/StringBuilder types** ([#240](https://github.com/shanehyde/whist/pull/240)) — correct inc/dec for enum payloads, Vec elements, and StringBuilder in various contexts
+- **refactor(parser,codegen): split parser files and simplify codegen traversal** ([#239](https://github.com/shanehyde/whist/pull/239)) — parser split into multiple files; codegen traversal simplified
+
 ## Week of Feb 9 – Feb 15, 2026
 
-Self-hosting checklist items land rapidly: string operations, pattern matching with payloads, match exhaustiveness checking, and collection iteration. A refactoring pass continues to reduce function complexity across the compiler.
+An enormous week that transforms Whist from a basic compiled language into a practical one. The standard library expands with Vec operations (insert, remove, sort, contains, first/last), Option/Result methods, StringBuilder, string splitting/ordering, struct destructuring, and a filesystem module. The type system gains function pointer types, Self in traits, generic free functions with trait bounds, Eq for value equality, and struct constructors via `init`. Reference counting matures with cleanup function pointers in the RC header, RC-tracked strings with immortal literals, and fixes for implicit void returns, Vec index writes, and anonymous `new` in call args. A test framework is built directly in Whist, and the test runner is rewritten in the language itself.
 
-- **refactor: extract helpers from print_ast and check_binary_expr** ([#101](https://github.com/shanehyde/whist/pull/101)) — further complexity reduction in AST printing and binary expression checking
+- **fix: hoist anonymous `new` in call args to prevent RC leak** ([#236](https://github.com/shanehyde/whist/pull/236)) — `items.push(new Item{value: 10})` no longer leaks; args hoisted to temps and dec'd after the call
+- **feat: user-defined methods on Vec\<T\>** ([#234](https://github.com/shanehyde/whist/pull/234)) — user code can define methods on `Vec<T>` via `impl` blocks (map, filter, etc.)
+- **fix: emit RC cleanup for implicit void returns and Vec index writes** ([#232](https://github.com/shanehyde/whist/pull/232)) — functions without explicit return now clean up RC vars; Vec index assignment properly dec's old values
+- **fix: track Vec/StringBuilder from function calls as RC-managed** ([#231](https://github.com/shanehyde/whist/pull/231)) — Vec and StringBuilder returned from function calls are now tracked for scope cleanup
+- **feat: reference-counted strings with immortal literals** ([#230](https://github.com/shanehyde/whist/pull/230)) — strings are RC-managed; string literals use a high refcount to prevent collection
+- **feat: struct destructuring `var {field1, field2} = expr;`** ([#229](https://github.com/shanehyde/whist/pull/229)) — pull individual fields from a struct into local variables
+- **fix: replace system() with fork/exec for proper signal handling** ([#228](https://github.com/shanehyde/whist/pull/228)) — `std.exec` uses fork/exec for correct exit code propagation
+- **feat: Vec\<string\>.sort() support** ([#227](https://github.com/shanehyde/whist/pull/227)) — sorting vectors of strings
+- **feat: string.index_of() method** ([#226](https://github.com/shanehyde/whist/pull/226)) — `s.index_of("sub")` returns position or -1
+- **feat: string.split() method** ([#225](https://github.com/shanehyde/whist/pull/225)) — `s.split(",")` returns `Vec<string>`
+- **feat: string ordering operators** ([#224](https://github.com/shanehyde/whist/pull/224)) — `<`, `>`, `<=`, `>=` for string comparison via strcmp
+- **feat: write test runner in Whist** ([#217](https://github.com/shanehyde/whist/pull/217)) — the test runner is now a Whist program that compiles and runs test files
+- **feat: add std.exec for capturing command output** ([#216](https://github.com/shanehyde/whist/pull/216)) — `std::exec(cmd)` returns `ExecResult` with exit code, stdout, and stderr
+- **feat: multi-line triple-quoted strings** ([#214](https://github.com/shanehyde/whist/pull/214)) — `"""..."""` with automatic indentation stripping
+- **feat: add directory, path, and metadata operations to fs module** ([#213](https://github.com/shanehyde/whist/pull/213)) — `mkdir`, `rmdir`, `is_dir`, `open_dir`, `read_dir`, `join_path`, `dirname`, `basename`, `extension`, `abs_path`, `modified_time`, `temp_dir`
+- **feat: Vec == and != operators** ([#212](https://github.com/shanehyde/whist/pull/212)) — element-wise equality comparison for vectors
+- **feat: struct initializers via `init` in impl blocks** ([#211](https://github.com/shanehyde/whist/pull/211)) — `new Point(1, 2)` constructor syntax backed by `impl Point { func init(...) { ... } }`
+- **feat: duck-type trait conformance with signature-only impl methods** ([#208](https://github.com/shanehyde/whist/pull/208)) — impl blocks can declare method signatures without bodies; conformance checked against standalone methods
+- **feat: generic free functions with trait bounds and type inference** ([#205](https://github.com/shanehyde/whist/pull/205)) — `func get_label<T: Printable>(x: T)` with type argument inference at call sites
+- **feat: embed cleanup function pointer in RC header** ([#204](https://github.com/shanehyde/whist/pull/204)) — each RC allocation stores its type-specific cleanup function, enabling universal `__rc_dec`
+- **feat: Vec.pop() returns Option\<T\> instead of panicking** ([#197](https://github.com/shanehyde/whist/pull/197)) — pop on empty vec returns `None` instead of aborting
+- **feat: add built-in unit testing with test blocks and assert** ([#196](https://github.com/shanehyde/whist/pull/196)) — `test "name" { assert(expr); }` with `w0 test file.w`
+- **feat: add value equality via Eq trait and sameref builtin** ([#191](https://github.com/shanehyde/whist/pull/191)) — structs implementing `Eq` can use `==`/`!=`; `sameref(a, b)` for pointer identity
+- **feat: add function pointer types** ([#190](https://github.com/shanehyde/whist/pull/190)) — `func(i64) -> bool` as a first-class type; nullable; storable in struct fields
+- **feat(checker): support Self type in traits and impl blocks** ([#188](https://github.com/shanehyde/whist/pull/188)) — `func clone() -> Self;` in trait signatures resolves to the implementing type
+- **feat(builtin): add StringBuilder type** ([#187](https://github.com/shanehyde/whist/pull/187)) — mutable string builder with `append`, `append_char`, `append_line`, `to_string`, `clear`
+- **feat(std): add eprint and eprintln for stderr output** ([#184](https://github.com/shanehyde/whist/pull/184)) — stderr printing via `std::eprint` and `std::eprintln`
+- **feat(checker): enforce top-level const, reject top-level var** ([#183](https://github.com/shanehyde/whist/pull/183)) — top-level variables must be `const`; mutable `var` restricted to function bodies
+- **feat(vec): add contains and sort methods** ([#181](https://github.com/shanehyde/whist/pull/181)) — `vec.contains(x)` and `vec.sort()` for orderable types
+- **feat(prelude): add value(), expect(), value\_or(), error() on Option and Result** ([#180](https://github.com/shanehyde/whist/pull/180)) — unwrapping methods for Option and Result
+- **feat(enums): support generic enum methods and add Option/Result queries** ([#179](https://github.com/shanehyde/whist/pull/179)) — methods on generic enums; `has_value()`, `is_ok()`, `is_err()` queries
+- **feat(vec): add first() and last() methods returning Option\<T\>** ([#178](https://github.com/shanehyde/whist/pull/178)) — safe access to vec endpoints
+- **feat(vec): add insert, remove, and swap\_remove for Vec** ([#177](https://github.com/shanehyde/whist/pull/177)) — index-based insertion, removal, and O(1) swap removal
+- **refactor: reduce emit\_stmt complexity** ([#189](https://github.com/shanehyde/whist/pull/189)) — statement emission broken into smaller helper functions
+- **refactor: simplify codegen forward decls and checker call handling** ([#206](https://github.com/shanehyde/whist/pull/206)) — forward declaration generation simplified
+- **refactor: convert run tests to test blocks** ([#210](https://github.com/shanehyde/whist/pull/210)) — test suite migrated from `main()`-based tests to `test` blocks
+- **chore(tests): reorganize suite and runner into run/errors structure** ([#203](https://github.com/shanehyde/whist/pull/203)) — tests organized into run/ (should succeed) and errors/ (should fail) directories
+- **docs(grammar): sync grammar with bootstrap compiler** ([#198](https://github.com/shanehyde/whist/pull/198)) — BNF grammar updated to match all implemented features
+- **refactor: extract helpers from print\_ast and check\_binary\_expr** ([#101](https://github.com/shanehyde/whist/pull/101)) — further complexity reduction in AST printing and binary expression checking
 - **feat: implement foreach over Span\<T\> collections** ([#100](https://github.com/shanehyde/whist/pull/100), [#80](https://github.com/shanehyde/whist/issues/80)) — `foreach item in span { ... }` iterates over Span\<T\> elements
 - **feat: implement foreach over Vec\<T\> collections** ([#99](https://github.com/shanehyde/whist/pull/99), [#79](https://github.com/shanehyde/whist/issues/79)) — `foreach item in vec { ... }` iterates over Vec\<T\> elements
 - **feat: add match exhaustiveness checking** ([#98](https://github.com/shanehyde/whist/pull/98), [#76](https://github.com/shanehyde/whist/issues/76)) — compiler errors on non-exhaustive match statements, ensuring all enum variants are handled
 - **feat: implement match statements with payload binding** ([#97](https://github.com/shanehyde/whist/pull/97), [#75](https://github.com/shanehyde/whist/issues/75)) — match arms can bind enum payloads (`case Some(val) => ...`)
-- **feat: implement string operations** ([#96](https://github.com/shanehyde/whist/pull/96), [#67](https://github.com/shanehyde/whist/issues/67)–[#73](https://github.com/shanehyde/whist/issues/73)) — string comparison, concatenation, slicing, and methods (contains, starts_with, ends_with, std.format)
+- **feat: implement string operations** ([#96](https://github.com/shanehyde/whist/pull/96), [#67](https://github.com/shanehyde/whist/issues/67)–[#73](https://github.com/shanehyde/whist/issues/73)) — string comparison, concatenation, slicing, and methods (contains, starts\_with, ends\_with, std.format)
 - **feat: implement string.length() method** ([#95](https://github.com/shanehyde/whist/pull/95), [#66](https://github.com/shanehyde/whist/issues/66)) — `str.length()` returns the string length
 - **docs: add self-hosting checklist with phased roadmap** ([#65](https://github.com/shanehyde/whist/pull/65)) — comprehensive self-hosting checklist on the GitHub Wiki
 - **refactor: extract 36 helper functions from large switch dispatchers** ([#64](https://github.com/shanehyde/whist/pull/64)) — major complexity reduction across checker and codegen; checker split into three files

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Whist
 
-A statically-typed systems programming language that compiles to C.
+A statically-typed application programming language that compiles to C.
 
-Whist aims to be a practical language with modern features — generics, a module system, tuples, defer — while staying close to the metal through C code generation. The compiler is currently bootstrapped in C, with a self-hosted compiler planned.
+Whist aims to be a practical language with modern features — generics, traits, closures, pattern matching, reference counting — while staying close to the metal through C code generation. The compiler is currently bootstrapped in C, with a self-hosted compiler in progress.
 
 ```whist
 import std;
 
 func main() -> i32 {
-    std.print("Hello, world!\n");
+    std::println("Hello, world!");
     return 0;
 }
 ```
@@ -17,7 +17,7 @@ func main() -> i32 {
 
 ```bash
 cd w0 && make                    # Build the bootstrap compiler
-bin/w0 --lib-path ../lib hello.w | cc -x c -I../lib/include -o hello - && ./hello
+bin/w0 --lib-path ../lib hello.w | cc -x c -I../lib/include -o hello - ../lib/whist_runtime.c && ./hello
 ```
 
 See [w0/README.md](w0/README.md) for full compiler usage.
@@ -26,37 +26,109 @@ See [w0/README.md](w0/README.md) for full compiler usage.
 
 ### Type System
 - **Primitive types** — `void`, `bool`, `i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `char`, `string`, `voidptr`
-- **Pointers** — `*T`, address-of (`&`), dereference (`*`), member access (`->`)
 - **Fixed-size arrays** — `[n]T` with array literals
 - **Spans** — `Span<T>` immutable views into arrays with bounds-checked access and slicing (`arr[1:3]`)
 - **Tuples** — `(T1, T2, ...)` with indexed access and destructuring
-- **Structs** — with methods (mutable and const receivers)
-- **Enums** — `enum Color { Red, Green, Blue }` with `::` access
-- **Generics** — generic structs (`Box<T>`, `Pair<K, V>`) with monomorphization
+- **Structs** — heap-allocated, reference-counted, with methods and `const` fields
+- **Enums** — simple (`enum Color { Red, Green, Blue }`), with explicit values, and data enums (tagged unions with payloads)
+- **Generics** — generic structs, enums, and functions with monomorphization
+- **Type aliases** — `type UserId = i64;`, generic instantiation aliases, partial application
+- **Type casting** — `as` for integer/char/enum/pointer conversions
+- **Autoboxing** — `Box<T>` wraps primitives with transparent arithmetic and comparison
 
 ### Functions & Methods
 - Top-level functions with explicit return types
-- Methods on structs via `func (Type) method()` syntax
+- Methods on structs via `func (Type) method()` syntax via Go like receiver syntax
 - Const receiver methods via `func (const Type) method()`
-- Generic methods on generic structs
+- Generic functions — `func identity<T>(x: T) -> T`
+- Generic methods on generic structs — `func (Box<T>) get() -> T`
+- Method-level generic type parameters — `func (Vec<T>) map<K>(f: func(T) -> K) -> Vec<K>`
+- `const` parameters and return types
 - `public` / `private` visibility (private by default)
+
+### Closures & Function Pointers
+- **Lambda expressions** — `|x: i64| x * 2`, block body: `|x: i64| -> i64 { return x * 2; }`
+- **Closures** capture variables by value from enclosing scope; RC-managed captures are reference-counted
+- **Function pointer types** — `func(T1, T2) -> R`, nullable, stored in struct fields
+- **Method references** — `var f = Counter.increment;`
+- Non-capturing lambdas have zero overhead (null environment)
 
 ### Control Flow
 - `if` / `else if` / `else`
 - `while` loops with `break` / `continue`
 - C-style `for` loops
 - `foreach` range loops — `foreach (const i in 0..100 by 2)`
+- `foreach` over collections — `Vec<T>`, `Span<T>`, `string` (yields `char`)
 - `defer` statements (LIFO cleanup on function exit)
 
+### Pattern Matching
+- **`match` statement** — on enums, integers, floats, strings, chars, bools
+- **`match` expression** — `var area = match (shape) { Circle(r) => r * r, _ => 0.0 };`
+- **Data enum destructuring** — `Circle(r) =>`, `Rect(w, h) =>`
+- **`is` expression** — `if (opt is Some(v)) { ... }` with payload binding
+- **Chained `is`** — `if (opt is Some(v) && v > 0) { ... }`
+- **`while` with `is`** — `while (opt is Some(v)) { ... }`
+- Wildcard `_` arm, negative literal patterns, qualified variant names
+
+### Traits
+- **Trait declarations** — `trait Name { func method(params) -> ReturnType; }`
+- **Trait implementations** — `impl TraitName for TypeName { ... }`
+- **Generic trait impls** — `impl Drop for Box<T> { ... }`
+- **Trait bounds** — `func get_label<T: Printable>(x: T) -> string`
+- **`Self` type** in trait signatures — `func clone() -> Self;`
+- **Built-in traits** — `Drop` (custom cleanup), `Eq` (enables `==`/`!=`), `Hashable` (for map/set keys)
+- **Inherent impl** (no trait) — `impl TypeName { func init(...) }` for constructors
+
+### Error Handling
+- **`Option<T>`** — `Some(T)` / `None` with `map`, `and_then`, `value_or`, `expect`, etc.
+- **`Result<T, E>`** — `Ok(T)` / `Err(E)` with `map`, `map_err`, `and_then`, `value_or`, etc.
+- **Try operator `?`** — unwraps `Ok`/`Some` or propagates `Err`/`None` as early return
+- Both auto-imported from the prelude (no `import` needed)
+
+### Memory Management
+- **Automatic reference counting** — objects allocated with `new` have inline RC headers
+- **Scope-based cleanup** — RC variables automatically decremented at scope exit and before `return`
+- **Drop trait** — custom cleanup called when refcount reaches 0
+- **Cleanup function pointers** — type-specific cleanup embedded in each allocation
+- **RC field tracking** — struct fields of RC types inc/dec'd automatically
+- `sameref(a, b)` — reference identity comparison
+
+### Destructuring
+- **Tuple destructuring** — `var (a, b) = tuple;`, nested: `var (x, (y, z)) = (1, (2, 3));`
+- **Struct destructuring** — `var {x, y} = point;`, partial, with field rename: `var {code, value: val} = info;`
+- Wildcard discard — `var (name, _) = pair;`
+
 ### Module System
-- Library imports — `import std;` with qualified access (`std.print(...)`)
-- Relative includes — `include "./helper.w";`
-- Standard library with `std` (print, abs, max, min) and `fs` (file I/O)
+- `import mod;` with qualified access (`mod::func(...)`)
+- `include "./helper.w";` — relative include, merges into current namespace
+- `use mod::func;` — bring single symbol into scope
+- `use mod::{a, b};` — grouped use
+- `use mod::*;` — wildcard use
+
+### Strings
+- String concatenation with `+`, comparison with `==`/`!=`/`<`/`>`
+- **Methods** — `length`, `contains`, `starts_with`, `ends_with`, `index_of`, `split`, `trim`, `trim_start`, `trim_end`, `strip_prefix`, `strip_suffix`, `pad_left`, `pad_right`
+- **Indexing** — `s[i]` returns `char`, `s[start:end]` returns substring
+- **Interpolated strings** — `$"Hello {name}, age {age + 1}"`
+- **Triple-quoted strings** — `"""multi-line with indentation stripping"""`
+- **StringBuilder** — `new StringBuilder{}` with `append`, `append_char`, `append_line`, `to_string`, `clear`
+
+### Collections
+- **`Vec<T>`** — growable array with `push`, `pop`, `insert`, `remove`, `swap_remove`, `sort`, `contains`, `first`, `last`, `find`, `extend`, `map`, `filter`, `any`, `all`, `each`, `reserve`, `clear`
+- **`HashMap<K, V>`** — hash map with `set`, `get`, `has`, `delete`, `keys`
+- **`Set<T>`** — hash set with `insert`, `insert_all`, `contains`, `remove`, `values`
+- **`Span<T>`** — immutable view with bounds-checked access and `.count`
 
 ### C Interop
 - `extern` blocks for FFI with C libraries
 - Varargs support for extern C functions
+- Function aliasing — `func c_name(...) as whist_name;`
 - Direct C header inclusion for library implementations
+
+### Testing
+- **Inline tests** — `test "name" { ... }` at top level
+- **`assert(expr)`** — prints expression and location on failure
+- `w0 test file.w` — compiles and runs tests; zero overhead in normal compilation
 
 ### Operators
 - Arithmetic: `+` `-` `*` `/` `%`
@@ -65,18 +137,22 @@ See [w0/README.md](w0/README.md) for full compiler usage.
 - Bitwise: `&` `|` `^` `~` `<<` `>>`
 - Compound assignment: `+=` `-=` `*=` `/=` `%=` `&=` `|=` `^=` `<<=` `>>=`
 
+### Literals
+- Decimal, hexadecimal (`0xFF`), binary (`0b1010`), octal (`0o755`)
+- Float with scientific notation (`1.5e10`)
+- Character literals with escape sequences (`\n`, `\t`, `\xNN`, `\NNN`, `\e`)
+
+### Standard Library
+- **`std`** — `print`, `println`, `eprint`, `eprintln`, `format`, `args`, `exit`, `system`, `exec`, `parse_i64`, `to_string`, `abs_i64`, `max_i64`, `min_i64`
+- **`fs`** — file I/O (`read_file`, `write_file`, `open`, `read_line`), directories (`mkdir`, `rmdir`, `is_dir`, `open_dir`, `read_dir`), paths (`join_path`, `dirname`, `basename`, `extension`, `abs_path`)
+- **`collections`** — `HashMap<K, V>`, `Set<T>`
+- **`time`** — `time_ms`
+
 ## Planned Features
 
 ### Language
-- [ ] **Closures / lambdas** — anonymous functions with variable capture ([design](features/closures.md))
-- [ ] **Pattern matching** — `match` expressions with exhaustiveness checking ([design](features/pattern-matching.md))
-- [ ] **Result / Option types** — structured error handling with `?` propagation ([design](features/result-option.md))
-- [ ] **Traits / interfaces** — shared behavior across types, static and dynamic dispatch ([design](features/traits.md))
-- [ ] **String interpolation** — `"Hello {name}!"` ([design](features/string-interpolation.md))
-- [ ] **Union types** — `type JsonValue = null | bool | i64 | string` ([design](features/union-types.md))
-- [ ] **Type aliases** — `type UserId = i64;` ([design](features/type-aliases.md))
 - [ ] **Nullable types** — `?string` with optional chaining ([design](features/nullable-types.md))
-- [ ] **Memory management** — reference counting with owner/borrower semantics ([design](features/memory-management.md))
+- [ ] **Union types** — `type JsonValue = null | bool | i64 | string` ([design](features/union-types.md))
 - [ ] **Reflection & comptime** — derive macros, type metadata, compile-time execution ([design](features/reflection.md))
 
 ### Compiler
@@ -93,15 +169,13 @@ See [w0/README.md](w0/README.md) for full compiler usage.
 - [ ] **Debugger support** — source maps, breakpoints, stack traces ([design](features/debugger.md))
 
 ### Standard Library
-- [ ] **Collections** — `Vec<T>`, `HashMap<K, V>`, `HashSet<T>`, `Queue<T>`, `Stack<T>` ([design](features/stdlib-collections.md))
-- [ ] **Strings** — split, join, trim, search, Unicode support ([design](features/stdlib-strings.md))
 - [ ] **Networking** — TCP/UDP sockets, HTTP client ([design](features/stdlib-networking.md))
 - [ ] **Math** — trigonometry, random numbers, big integers ([design](features/stdlib-math.md))
-- [ ] **Extended I/O** — directory operations, path manipulation, streaming ([design](features/stdlib-io.md))
+- [ ] **Extended I/O** — streaming, advanced path manipulation ([design](features/stdlib-io.md))
 
 ## Progress
 
-Whist is under active development — the compiler went from initial bootstrap to a language with generics, traits, reference-counted memory management, and a standard library in under two weeks. See the [weekly changelog](PROGRESS.md) for a detailed history of every change.
+Whist is under active development — the compiler went from initial bootstrap to a language with generics, traits, closures, pattern matching, reference-counted memory management, and a standard library in under two weeks. See the [weekly changelog](PROGRESS.md) for a detailed history of every change.
 
 ## Project Structure
 
@@ -109,8 +183,8 @@ Whist is under active development — the compiler went from initial bootstrap t
 whist/
 ├── w0/          Bootstrap compiler (C)
 ├── wc/          Self-hosted compiler (planned)
-├── lib/         Standard library
-├── features/       Design documents for future features
+├── lib/         Standard library and runtime
+├── features/    Design documents for future features
 └── grammar.md   BNF grammar specification
 ```
 


### PR DESCRIPTION
## Summary
- **README.md**: Moved many features from "Planned" to "Implemented" (traits, closures, pattern matching, Result/Option, type aliases, RC memory management, collections, string ops, testing, destructuring, etc.). Added new sections for closures, pattern matching, traits, error handling, memory management, destructuring, strings, collections, testing, standard library, and literals. Trimmed the planned list to genuinely unimplemented items. Updated intro and compile command.
- **PROGRESS.md**: Added two entirely missing weeks (Feb 16–22, Feb 23+) and filled in ~45 missing entries from the Feb 9–15 week (PRs #177–#236 were undocumented). The changelog now covers all 319+ PRs.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify PROGRESS.md links resolve to correct PRs/issues