### PR TITLE
fix: emit __rc_inc for untracked RC fields in inline new expressions

### DIFF
--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -868,18 +868,38 @@ static void emit_new_expr(CodeGen* gen, Node* node) {
         free(cleanup);
         emit_struct_init(gen, node->as.new_expr.init, rtype);
         emit(gen, ";");
-        // Increment refcount for any RC-tracked idents stored in struct fields
+        // Increment refcount for any RC values stored in struct fields
         Node* rc_init = node->as.new_expr.init;
         for (int i = 0; i < rc_init->as.struct_init.fields.count; i++) {
             Node* field = rc_init->as.struct_init.fields.nodes[i];
-            if (field && field->type == NODE_FIELD_INIT &&
-                field->as.field_init.value->type == NODE_IDENT &&
-                rc_is_tracked(gen, field->as.field_init.value->as.ident.name)) {
-                const char* vname  = field->as.field_init.value->as.ident.name;
-                Type*       vtype  = rc_get_var_type(gen, vname);
-                const char* inc_fn = get_inc_func_for_type(vtype);
-                emit(gen, " %s(%s);", inc_fn, vname);
-                free((char*)inc_fn);
+            if (field && field->type == NODE_FIELD_INIT) {
+                Node* val = field->as.field_init.value;
+                if (val->type == NODE_IDENT && rc_is_tracked(gen, val->as.ident.name)) {
+                    const char* vname  = val->as.ident.name;
+                    Type*       vtype  = rc_get_var_type(gen, vname);
+                    const char* inc_fn = get_inc_func_for_type(vtype);
+                    emit(gen, " %s(%s);", inc_fn, vname);
+                    free((char*)inc_fn);
+                } else if (val->type == NODE_INDEX && val->as.index.is_rc_elem) {
+                    emit(gen, " __rc_inc(__rc_tmp%d->%s);", tmp, field->as.field_init.name);
+                } else if (val->type == NODE_IDENT && !rc_is_tracked(gen, val->as.ident.name)) {
+                    const char* fname = field->as.field_init.name;
+                    for (int j = 0; j < rtype->as.struc.field_count; j++) {
+                        if (strcmp(rtype->as.struc.field_names[j], fname) == 0) {
+                            Type* ftype = rtype->as.struc.field_types[j];
+                            if (type_is_rc_managed(ftype)) {
+                                const char* inc_fn = get_inc_func_for_type(ftype);
+                                if (ftype->kind == TYPE_STRING) {
+                                    emit(gen, " %s((void*)__rc_tmp%d->%s);", inc_fn, tmp, fname);
+                                } else {
+                                    emit(gen, " %s(__rc_tmp%d->%s);", inc_fn, tmp, fname);
+                                }
+                                free((char*)inc_fn);
+                            }
+                            break;
+                        }
+                    }
+                }
             }
         }
         emit(gen, " __rc_tmp%d; })", tmp);
@@ -900,19 +920,42 @@ static void emit_hoisted_new_arg_rc_incs(CodeGen* gen, Node* node) {
     }
 }
 
-// Emit refcount increments for tracked identifier values used in struct field init.
-static void emit_hoisted_new_field_rc_incs(CodeGen* gen, Node* init) {
+// Emit refcount increments for RC values used in struct field init.
+static void emit_hoisted_new_field_rc_incs(CodeGen* gen, Node* init, Type* rtype,
+                                           const char* temp_name) {
     for (int i = 0; i < init->as.struct_init.fields.count; i++) {
         Node* field = init->as.struct_init.fields.nodes[i];
-        if (field && field->type == NODE_FIELD_INIT &&
-            field->as.field_init.value->type == NODE_IDENT &&
-            rc_is_tracked(gen, field->as.field_init.value->as.ident.name)) {
-            const char* vname  = field->as.field_init.value->as.ident.name;
-            Type*       vtype  = rc_get_var_type(gen, vname);
-            const char* inc_fn = get_inc_func_for_type(vtype);
-            emit_indent(gen);
-            emit(gen, "%s(%s);\n", inc_fn, vname);
-            free((char*)inc_fn);
+        if (field && field->type == NODE_FIELD_INIT) {
+            Node* val = field->as.field_init.value;
+            if (val->type == NODE_IDENT && rc_is_tracked(gen, val->as.ident.name)) {
+                const char* vname  = val->as.ident.name;
+                Type*       vtype  = rc_get_var_type(gen, vname);
+                const char* inc_fn = get_inc_func_for_type(vtype);
+                emit_indent(gen);
+                emit(gen, "%s(%s);\n", inc_fn, vname);
+                free((char*)inc_fn);
+            } else if (val->type == NODE_INDEX && val->as.index.is_rc_elem) {
+                emit_indent(gen);
+                emit(gen, "__rc_inc(%s->%s);\n", temp_name, field->as.field_init.name);
+            } else if (val->type == NODE_IDENT && !rc_is_tracked(gen, val->as.ident.name)) {
+                const char* fname = field->as.field_init.name;
+                for (int j = 0; j < rtype->as.struc.field_count; j++) {
+                    if (strcmp(rtype->as.struc.field_names[j], fname) == 0) {
+                        Type* ftype = rtype->as.struc.field_types[j];
+                        if (type_is_rc_managed(ftype)) {
+                            const char* inc_fn = get_inc_func_for_type(ftype);
+                            emit_indent(gen);
+                            if (ftype->kind == TYPE_STRING) {
+                                emit(gen, "%s((void*)%s->%s);\n", inc_fn, temp_name, fname);
+                            } else {
+                                emit(gen, "%s(%s->%s);\n", inc_fn, temp_name, fname);
+                            }
+                            free((char*)inc_fn);
+                        }
+                        break;
+                    }
+                }
+            }
         }
     }
 }
@@ -1003,7 +1046,7 @@ static void emit_hoisted_new_struct_init_expr(CodeGen* gen, Node* node, Type* rt
     emit(gen, "*%s = (%s)", temp_name, tname);
     emit_struct_init(gen, node->as.new_expr.init, rtype);
     emit(gen, ";\n");
-    emit_hoisted_new_field_rc_incs(gen, node->as.new_expr.init);
+    emit_hoisted_new_field_rc_incs(gen, node->as.new_expr.init, rtype, temp_name);
 }
 
 // Emit a `new` expression as standalone statements with a given temp name.

--- a/w0/test/run/memory/rc_new_expr_field_inc.w
+++ b/w0/test/run/memory/rc_new_expr_field_inc.w
@@ -1,0 +1,54 @@
+// Expected: PASS: return_new_struct_with_rc_param
+// Expected: PASS: return_new_struct_with_string_param
+// Expected: PASS: return_new_struct_with_struct_param
+// Test that `return new Struct{field: param}` correctly increments RC fields (#313)
+
+import std;
+
+struct Token {
+    value: string,
+}
+
+func make_token(s: string) -> Token {
+    return new Token{ value: s };
+}
+
+struct Wrapper {
+    inner: Token,
+}
+
+func wrap_token(t: Token) -> Wrapper {
+    return new Wrapper{ inner: t };
+}
+
+struct Pair {
+    a: string,
+    b: string,
+}
+
+func make_pair(x: string, y: string) -> Pair {
+    return new Pair{ a: x, b: y };
+}
+
+test "return_new_struct_with_string_param" {
+    // String field from parameter — was use-after-free before fix
+    var s = "hel" + "lo";
+    var tok = make_token(s);
+    assert(tok.value == "hello");
+}
+
+test "return_new_struct_with_struct_param" {
+    // Struct field from parameter
+    var tok = new Token{ value: "inner" };
+    var w = wrap_token(tok);
+    assert(w.inner.value == "inner");
+}
+
+test "return_new_struct_with_rc_param" {
+    // Multiple RC fields from parameters
+    var a = "foo" + "bar";
+    var b = "baz" + "qux";
+    var p = make_pair(a, b);
+    assert(p.a == "foobar");
+    assert(p.b == "bazqux");
+}


### PR DESCRIPTION
## Summary
- Fixes use-after-free when `return new Struct{field: param}` stores an untracked RC value (function parameter) without incrementing its refcount (#313)
- Extends `emit_new_expr()` and `emit_hoisted_new_field_rc_incs()` to handle untracked identifiers and Vec index reads, matching the complete RC logic already in `emit_var_decl_rc_new_struct()`
- Adds test `rc_new_expr_field_inc.w` covering string params, struct params, and multiple RC params

## Test plan
- [x] `make` builds cleanly
- [x] `make test` — 254/254 tests pass (including new test)
- [x] ASAN confirms no heap-use-after-free on reproduction case

Closes #313