### PR TITLE
feat: support forward references for recursive types

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1967,25 +1967,35 @@ static int is_prelude_symbol(Symbol* sym) {
 static void check_struct_decl(Checker* checker, Node* node) {
     const char* name = node->as.struct_decl.name;
 
-    // Check for redefinition (allow shadowing prelude symbols)
-    Symbol* existing = checker_lookup(checker, name);
-    if (existing && !is_prelude_symbol(existing)) {
-        check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+    // Phase 1a: register type name only (no field resolution)
+    if (checker->registering_type_names) {
+        Symbol* existing = checker_lookup(checker, name);
+        if (existing && !is_prelude_symbol(existing)) {
+            check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+            return;
+        }
+
+        if (node->as.struct_decl.type_param_count > 0) {
+            register_generic_def(checker, name, node->as.struct_decl.type_params,
+                                 node->as.struct_decl.type_param_bounds,
+                                 node->as.struct_decl.type_param_count, node);
+            return;
+        }
+
+        Type* struct_type = type_struct(name);
+        checker_define(checker, name, SYM_TYPE, struct_type, 0, node->as.struct_decl.is_public,
+                       checker->modules.current_module);
         return;
     }
 
-    // Check if this is a generic struct definition
+    // Phase 1b: resolve field types (all type names are now registered)
     if (node->as.struct_decl.type_param_count > 0) {
-        // Register as generic template - don't create concrete type yet
-        register_generic_def(checker, name, node->as.struct_decl.type_params,
-                             node->as.struct_decl.type_param_bounds,
-                             node->as.struct_decl.type_param_count, node);
-        return;
+        return; // Generic templates resolve fields during instantiation
     }
 
-    // Non-generic struct: create concrete type as before
-    Type* struct_type = type_struct(name);
-    int   field_count = node->as.struct_decl.fields.count;
+    Symbol* sym         = checker_lookup(checker, name);
+    Type*   struct_type = sym->type;
+    int     field_count = node->as.struct_decl.fields.count;
 
     struct_type->as.struc.field_count      = field_count;
     struct_type->as.struc.field_names      = xmalloc(field_count * sizeof(char*));
@@ -2000,18 +2010,7 @@ static void check_struct_decl(Checker* checker, Node* node) {
         struct_type->as.struc.field_is_const[i]   = field->as.field.is_const;
         struct_type->as.struc.field_is_private[i] = field->as.field.is_private;
     }
-
-    // Check if any field is an RC-managed type (struct, Vec, or enum with RC fields)
-    for (int i = 0; i < field_count; i++) {
-        Type* ftype = struct_type->as.struc.field_types[i];
-        if (type_is_rc_managed(ftype)) {
-            struct_type->as.struc.has_rc_fields = 1;
-            break;
-        }
-    }
-
-    checker_define(checker, name, SYM_TYPE, struct_type, 0, node->as.struct_decl.is_public,
-                   checker->modules.current_module);
+    // has_rc_fields is computed in a separate pass after all types are resolved
 }
 
 // Type-check an enum declaration: resolve variant types or register generic template
@@ -2019,11 +2018,30 @@ static void check_enum_decl(Checker* checker, Node* node) {
     const char* name        = node->as.enum_decl.name;
     int         value_count = node->as.enum_decl.values.count;
 
-    // Check for redefinition (allow shadowing prelude symbols)
-    Symbol* existing = checker_lookup(checker, name);
-    if (existing && !is_prelude_symbol(existing)) {
-        check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+    // Phase 1a: register type name only (no variant type resolution)
+    if (checker->registering_type_names) {
+        Symbol* existing = checker_lookup(checker, name);
+        if (existing && !is_prelude_symbol(existing)) {
+            check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+            return;
+        }
+
+        if (node->as.enum_decl.type_param_count > 0) {
+            register_generic_def(checker, name, node->as.enum_decl.type_params,
+                                 node->as.enum_decl.type_param_bounds,
+                                 node->as.enum_decl.type_param_count, node);
+            return;
+        }
+
+        Type* enum_type = type_enum(name);
+        checker_define(checker, name, SYM_TYPE, enum_type, 0, node->as.enum_decl.is_public,
+                       checker->modules.current_module);
         return;
+    }
+
+    // Phase 1b: resolve variant types (all type names are now registered)
+    if (node->as.enum_decl.type_param_count > 0) {
+        return; // Generic templates resolve variants during instantiation
     }
 
     // Data enums (any payload variant) do not support explicit integer assignments.
@@ -2042,23 +2060,13 @@ static void check_enum_decl(Checker* checker, Node* node) {
         return;
     }
 
-    // Check if this is a generic enum definition
-    if (node->as.enum_decl.type_param_count > 0) {
-        register_generic_def(checker, name, node->as.enum_decl.type_params,
-                             node->as.enum_decl.type_param_bounds,
-                             node->as.enum_decl.type_param_count, node);
-        return;
-    }
-
-    Type* enum_type = type_enum(name);
+    Symbol* sym       = checker_lookup(checker, name);
+    Type*   enum_type = sym->type;
 
     enum_type->as.enm.value_count         = value_count;
     enum_type->as.enm.value_names         = xmalloc(value_count * sizeof(char*));
     enum_type->as.enm.variant_types       = xmalloc(value_count * sizeof(Type**));
     enum_type->as.enm.variant_type_counts = xmalloc(value_count * sizeof(int));
-
-    checker_define(checker, name, SYM_TYPE, enum_type, 0, node->as.enum_decl.is_public,
-                   checker->modules.current_module);
 
     // Process enum variants
     for (int i = 0; i < value_count; i++) {
@@ -2072,12 +2080,10 @@ static void check_enum_decl(Checker* checker, Node* node) {
             enum_type->as.enm.has_data         = 1;
             enum_type->as.enm.variant_types[i] = xmalloc(type_count * sizeof(Type*));
             for (int j = 0; j < type_count; j++) {
-                Type* resolved = resolve_type(checker, val->as.enum_variant.types.nodes[j]);
-                enum_type->as.enm.variant_types[i][j] = resolved;
-                if (type_is_rc_managed(resolved)) {
-                    enum_type->as.enm.has_rc_fields = 1;
-                }
+                enum_type->as.enm.variant_types[i][j] =
+                    resolve_type(checker, val->as.enum_variant.types.nodes[j]);
             }
+            // has_rc_fields is computed in a separate pass after all types are resolved
         } else {
             enum_type->as.enm.variant_types[i] = NULL;
         }
@@ -2088,16 +2094,24 @@ static void check_enum_decl(Checker* checker, Node* node) {
 static void check_trait_decl(Checker* checker, Node* node) {
     const char* name = node->as.trait_decl.name;
 
-    // Check for redefinition (allow shadowing prelude symbols)
-    Symbol* existing = checker_lookup(checker, name);
-    if (existing && !is_prelude_symbol(existing)) {
-        check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+    // Phase 1a: register trait name only (no method signature resolution)
+    if (checker->registering_type_names) {
+        Symbol* existing = checker_lookup(checker, name);
+        if (existing && !is_prelude_symbol(existing)) {
+            check_error(checker, node->line, node->column, "Redefinition of type '%s'", name);
+            return;
+        }
+
+        Type* trait_type = type_trait(name);
+        checker_define(checker, name, SYM_TYPE, trait_type, 0, node->as.trait_decl.is_public,
+                       checker->modules.current_module);
         return;
     }
 
-    // Create TYPE_TRAIT with method signatures
-    Type* trait_type   = type_trait(name);
-    int   method_count = node->as.trait_decl.methods.count;
+    // Phase 1b: resolve method signatures (all type names are now registered)
+    Symbol* sym          = checker_lookup(checker, name);
+    Type*   trait_type   = sym->type;
+    int     method_count = node->as.trait_decl.methods.count;
 
     trait_type->as.trait.method_count    = method_count;
     trait_type->as.trait.method_names    = xmalloc(method_count * sizeof(char*));
@@ -2116,9 +2130,6 @@ static void check_trait_decl(Checker* checker, Node* node) {
     }
 
     checker->self_type = NULL;
-
-    checker_define(checker, name, SYM_TYPE, trait_type, 0, node->as.trait_decl.is_public,
-                   checker->modules.current_module);
 }
 
 // Type-check a type alias: resolve target type or register generic alias template
@@ -2869,14 +2880,75 @@ static void verify_deferred_trait_checks(Checker* checker) {
     }
 }
 
-// Type-check an entire program AST using four sequential passes.
+// Compute has_rc_fields for all struct/enum types after all fields and variant
+// types have been resolved. Uses a fixed-point loop because the flag depends
+// on other types' flags (e.g., enum A contains enum B which contains a struct —
+// B must be flagged before A can detect it as RC-managed).
+static void compute_has_rc_fields(Checker* checker, Node* ast) {
+    int changed;
+    do {
+        changed = 0;
+        for (int m = 0; m < ast->as.program.modules.count; m++) {
+            Node* mod = ast->as.program.modules.nodes[m];
+            if (!mod || mod->type != NODE_MODULE)
+                continue;
+
+            checker->modules.current_module =
+                (mod->as.module.name && strcmp(mod->as.module.name, "main") == 0)
+                    ? NULL
+                    : mod->as.module.name;
+
+            for (int i = 0; i < mod->as.module.decls.count; i++) {
+                Node* decl = mod->as.module.decls.nodes[i];
+                if (!decl)
+                    continue;
+
+                if (decl->type == NODE_STRUCT_DECL && decl->as.struct_decl.type_param_count == 0) {
+                    Symbol* sym = checker_lookup(checker, decl->as.struct_decl.name);
+                    if (!sym || sym->kind != SYM_TYPE || sym->type->as.struc.has_rc_fields)
+                        continue;
+                    Type* st = sym->type;
+                    for (int f = 0; f < st->as.struc.field_count; f++) {
+                        if (type_is_rc_managed(st->as.struc.field_types[f])) {
+                            st->as.struc.has_rc_fields = 1;
+                            changed                    = 1;
+                            break;
+                        }
+                    }
+                } else if (decl->type == NODE_ENUM_DECL &&
+                           decl->as.enum_decl.type_param_count == 0) {
+                    Symbol* sym = checker_lookup(checker, decl->as.enum_decl.name);
+                    if (!sym || sym->kind != SYM_TYPE || sym->type->as.enm.has_rc_fields)
+                        continue;
+                    Type* et = sym->type;
+                    for (int v = 0; v < et->as.enm.value_count; v++) {
+                        for (int t = 0; t < et->as.enm.variant_type_counts[v]; t++) {
+                            if (type_is_rc_managed(et->as.enm.variant_types[v][t])) {
+                                et->as.enm.has_rc_fields = 1;
+                                changed                  = 1;
+                                goto next_decl;
+                            }
+                        }
+                    }
+                next_decl:;
+                }
+            }
+        }
+    } while (changed);
+}
+
+// Type-check an entire program AST using sequential passes.
 //
 // The multi-pass design is required because declarations can reference each
 // other out of order (forward references). The passes are:
 //
-//   Pass 1: Forward-declare all types (structs, enums, traits) so that
-//           fields, function signatures, and type aliases can reference
-//           any type regardless of declaration order.
+//   Pre-pass: Register all type names (structs, enums, traits) as known
+//             symbols without resolving field types. This enables forward
+//             references and recursive/mutually-recursive types.
+//
+//   Pass 1: Resolve field types, variant types, and trait method signatures
+//           for all type declarations. All type names are now registered,
+//           so forward references and self-references work.
 //
 //   Pass 2: Register generic methods and trait impls on their GenericDef
 //           entries. This must happen before passes 3-4 because type aliases
@@ -2921,8 +2993,20 @@ int checker_check(Checker* checker, Node* ast) {
         checker->modules.current_module = saved_module;
     }
 
+    // Pre-pass: register all type names before resolving fields.
+    // This enables forward references and recursive/mutually-recursive types.
+    checker->registering_type_names = 1;
+    run_checker_pass(checker, ast, &k_checker_pass_specs[0]);
+    checker->registering_type_names = 0;
+
     for (size_t i = 0; i < sizeof(k_checker_pass_specs) / sizeof(k_checker_pass_specs[0]); i++) {
         run_checker_pass(checker, ast, &k_checker_pass_specs[i]);
+        // After pass 1 (field resolution), compute has_rc_fields for all types.
+        // This must happen after ALL fields/variants are resolved because the flag
+        // depends on other types' flags being set correctly.
+        if (i == 0) {
+            compute_has_rc_fields(checker, ast);
+        }
     }
 
     verify_deferred_trait_checks(checker);

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -219,6 +219,10 @@ struct Checker {
     // Type alias cycle detection
     int alias_depth;
 
+    // Forward reference support: when set, type decl functions only register
+    // the type name (no field/variant resolution). Cleared before the full pass.
+    int registering_type_names;
+
     // Hint for generic enum type inference (set by var_decl when declared type is known)
     Type* enum_target_hint;
 

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -223,11 +223,11 @@ static int emit_rc_ident_assign_stmt(CodeGen* gen, Node* expr) {
 
     // Hoist owned temps in the value expression (e.g. nested string concats).
     // Exclude the value node itself — its ownership transfers to the variable.
-    Node* val             = expr->as.assign.value;
-    int   val_orig_owned  = val->is_owned_temp;
-    val->is_owned_temp    = 0;
-    int   owned_saved     = 0;
-    int   has_owned       = has_owned_temps(val);
+    Node* val            = expr->as.assign.value;
+    int   val_orig_owned = val->is_owned_temp;
+    val->is_owned_temp   = 0;
+    int owned_saved      = 0;
+    int has_owned        = has_owned_temps(val);
     if (has_owned) {
         owned_saved = hoist_owned_temps(gen, val);
     }
@@ -252,7 +252,8 @@ static int emit_rc_ident_assign_stmt(CodeGen* gen, Node* expr) {
         emit(gen, "__rc_dec_%s(%s);\n", var_type->as.enm.name, var_name);
         emit_indent(gen);
         emit(gen, "%s = __rc_tmp%d;\n", var_name, temp_id);
-        if (has_owned) cleanup_owned_temps(gen, owned_saved);
+        if (has_owned)
+            cleanup_owned_temps(gen, owned_saved);
         return 1;
     }
 
@@ -280,7 +281,8 @@ static int emit_rc_ident_assign_stmt(CodeGen* gen, Node* expr) {
     }
     emit_indent(gen);
     emit(gen, "%s = __rc_tmp%d;\n", var_name, temp_id);
-    if (has_owned) cleanup_owned_temps(gen, owned_saved);
+    if (has_owned)
+        cleanup_owned_temps(gen, owned_saved);
     return 1;
 }
 
@@ -1555,8 +1557,8 @@ static void emit_match_stmt(CodeGen* gen, Node* node) {
 
 // Return whether a condition expression already emits outer parentheses.
 static int stmt_cond_has_outer_parens(Node* cond) {
-    return cond && (cond->type == NODE_BINARY || cond->type == NODE_UNARY ||
-                    cond->type == NODE_IS_EXPR);
+    return cond &&
+           (cond->type == NODE_BINARY || cond->type == NODE_UNARY || cond->type == NODE_IS_EXPR);
 }
 
 // Emit a statement body, handling block and single-statement forms.
@@ -1702,7 +1704,7 @@ static void emit_while_stmt(CodeGen* gen, Node* node) {
         emit(gen, "if (!__while_cond%d) break;\n", cond_id);
 
         // Emit loop body
-        int saved_ld = gen->rc.loop_depth;
+        int saved_ld       = gen->rc.loop_depth;
         gen->rc.loop_depth = gen->rc.depth + 1;
         emit_stmt_body(gen, node->as.while_stmt.body);
         gen->rc.loop_depth = saved_ld;
@@ -1724,7 +1726,7 @@ static void emit_while_stmt(CodeGen* gen, Node* node) {
     }
 
     gen->out.indent++;
-    int saved_ld = gen->rc.loop_depth;
+    int saved_ld       = gen->rc.loop_depth;
     gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.while_stmt.body);
     gen->rc.loop_depth = saved_ld;
@@ -1766,7 +1768,7 @@ static void emit_for_stmt(CodeGen* gen, Node* node) {
     emit(gen, ") {\n");
 
     gen->out.indent++;
-    int saved_ld = gen->rc.loop_depth;
+    int saved_ld       = gen->rc.loop_depth;
     gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.for_stmt.body);
     gen->rc.loop_depth = saved_ld;
@@ -1810,7 +1812,7 @@ static void emit_foreach_collection_stmt(CodeGen* gen, Node* node) {
         emit(gen, "%sdata[__foreach_%d];\n", access, idx_id);
     }
 
-    int saved_ld = gen->rc.loop_depth;
+    int saved_ld       = gen->rc.loop_depth;
     gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.foreach_stmt.body);
     gen->rc.loop_depth = saved_ld;
@@ -1839,7 +1841,7 @@ static void emit_foreach_range_stmt(CodeGen* gen, Node* node) {
     emit_expr(gen, node->as.foreach_stmt.step);
     emit(gen, ") {\n");
     gen->out.indent++;
-    int saved_ld = gen->rc.loop_depth;
+    int saved_ld       = gen->rc.loop_depth;
     gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.foreach_stmt.body);
     gen->rc.loop_depth = saved_ld;
@@ -2012,9 +2014,9 @@ static void emit_if_stmt_with_is_bindings(CodeGen* gen, Node* node) {
     int               cleanup_cap = 0;
 
     // Pre-declare all is_expr temps at outer scope so they're visible for cleanup
-    int* pre_let_ids  = NULL;
-    int  pre_count    = 0;
-    int  pre_cap      = 0;
+    int* pre_let_ids = NULL;
+    int  pre_count   = 0;
+    int  pre_cap     = 0;
     for (int i = 0; i < chain_len; i++) {
         Node* part = chain[i];
         if (part->type == NODE_IS_EXPR && part->as.is_expr.has_bindings) {
@@ -2104,7 +2106,7 @@ static void emit_while_stmt_with_is_bindings(CodeGen* gen, Node* node) {
     gen->out.indent++;
 
     // Collect cleanup info for all is_expr parts
-    IsBindingCleanup* cleanups   = NULL;
+    IsBindingCleanup* cleanups    = NULL;
     int               cleanup_len = 0;
     int               cleanup_cap = 0;
 
@@ -2187,7 +2189,7 @@ static void emit_while_stmt_with_is_bindings(CodeGen* gen, Node* node) {
     }
 
     // Emit loop body
-    int saved_ld = gen->rc.loop_depth;
+    int saved_ld       = gen->rc.loop_depth;
     gen->rc.loop_depth = gen->rc.depth + 1;
     emit_stmt_body(gen, node->as.while_stmt.body);
     gen->rc.loop_depth = saved_ld;

--- a/w0/main.c
+++ b/w0/main.c
@@ -89,7 +89,8 @@ static CodeGenChecker make_codegen_checker(Checker* checker) {
 
 // Check if lib_path contains a pre-compiled libwhist.a archive.
 static int lib_archive_exists(const char* lib_path) {
-    if (!lib_path) return 0;
+    if (!lib_path)
+        return 0;
     char path[1024];
     snprintf(path, sizeof(path), "%s/libwhist.a", lib_path);
     return access(path, F_OK) == 0;
@@ -146,8 +147,8 @@ static int compile_to_c_targeted(const char* source, const char* source_path, co
     CodeGen gen;
     codegen_init(&gen, out, make_codegen_checker(&checker), rc_debug, test_mode, source_path,
                  line_directives);
-    gen.target_module    = effective_target;
-    gen.use_lib_archive  = use_lib_archive;
+    gen.target_module   = effective_target;
+    gen.use_lib_archive = use_lib_archive;
     codegen_emit(&gen, ast);
     codegen_free(&gen);
 
@@ -174,9 +175,9 @@ static int compile_and_run(const char* source_path, int argc, char** argv, const
 
     // --emit-c: just dump generated C to stdout and exit
     if (emit_c) {
-        int result = compile_to_c_targeted(source, source_path, lib_path, rc_debug, 0,
-                                           line_directives, stdout, NULL, NULL,
-                                           lib_archive_exists(lib_path));
+        int result =
+            compile_to_c_targeted(source, source_path, lib_path, rc_debug, 0, line_directives,
+                                  stdout, NULL, NULL, lib_archive_exists(lib_path));
         free(source);
         return result;
     }
@@ -288,9 +289,9 @@ static int compile_and_test(const char* source_path, const char* lib_path, int r
 
     // --emit-c: just dump generated C to stdout and exit
     if (emit_c) {
-        int result = compile_to_c_targeted(source, source_path, lib_path, rc_debug, 1,
-                                           line_directives, stdout, NULL, NULL,
-                                           lib_archive_exists(lib_path));
+        int result =
+            compile_to_c_targeted(source, source_path, lib_path, rc_debug, 1, line_directives,
+                                  stdout, NULL, NULL, lib_archive_exists(lib_path));
         free(source);
         return result;
     }
@@ -890,9 +891,9 @@ int main(int argc, char** argv) {
             free(input_files);
             return 1;
         }
-        int result = compile_to_object(input_files[0], opts.output_file, opts.lib_path,
-                                       opts.rc_debug, opts.emit_c, opts.line_directives,
-                                       opts.module_name);
+        int result =
+            compile_to_object(input_files[0], opts.output_file, opts.lib_path, opts.rc_debug,
+                              opts.emit_c, opts.line_directives, opts.module_name);
         free(input_files);
         return result;
     }

--- a/w0/test/run/types/forward_ref.w
+++ b/w0/test/run/types/forward_ref.w
@@ -1,0 +1,112 @@
+// Test forward references and recursive types
+// Expected: PASS: forward_ref_struct
+// Expected: PASS: self_referential_struct
+// Expected: PASS: mutual_recursion
+// Expected: PASS: forward_ref_enum_variant
+// Expected: PASS: linked_list
+
+// Forward reference: A references B which is declared after A
+struct Wrapper {
+    inner: Payload,
+}
+
+struct Payload {
+    value: i64,
+}
+
+test "forward_ref_struct" {
+    var p = new Payload { value: 99 };
+    var w = new Wrapper { inner: p };
+    assert(w.inner.value == 99);
+}
+
+// Self-referential struct via Option
+struct ListNode {
+    value: i64,
+    next: Option<ListNode>,
+}
+
+test "self_referential_struct" {
+    var tail = new ListNode { value: 2, next: Option::None };
+    var head = new ListNode { value: 1, next: Option::Some(tail) };
+    assert(head.value == 1);
+    assert(head.next.has_value());
+    match (head.next) {
+        Some(n) => assert(n.value == 2);
+        None => assert(false);
+    }
+}
+
+// Mutually recursive struct + enum
+struct AstNode {
+    kind: AstKind,
+    line: i32,
+}
+
+enum AstKind {
+    IntLit(i64),
+    Binary(string, AstNode, AstNode),
+}
+
+test "mutual_recursion" {
+    var left = new AstNode { kind: AstKind::IntLit(1), line: 1 };
+    var right = new AstNode { kind: AstKind::IntLit(2), line: 1 };
+    var add = new AstNode { kind: AstKind::Binary("+", left, right), line: 1 };
+    assert(add.line == 1);
+    match (add.kind) {
+        Binary(op, l, r) => {
+            assert(op == "+");
+            match (l.kind) {
+                IntLit(v) => assert(v == 1);
+                _ => assert(false);
+            }
+            match (r.kind) {
+                IntLit(v) => assert(v == 2);
+                _ => assert(false);
+            }
+        }
+        _ => assert(false);
+    }
+}
+
+// Enum variant referencing a later-declared struct
+enum Container {
+    Empty,
+    HasItem(Item),
+}
+
+struct Item {
+    name: string,
+}
+
+test "forward_ref_enum_variant" {
+    var item = new Item { name: "test" };
+    var c: Container = Container::HasItem(item);
+    match (c) {
+        HasItem(i) => assert(i.name == "test");
+        Empty => assert(false);
+    }
+}
+
+// Linked list with traversal
+test "linked_list" {
+    var c = new ListNode { value: 3, next: Option::None };
+    var b = new ListNode { value: 2, next: Option::Some(c) };
+    var a = new ListNode { value: 1, next: Option::Some(b) };
+
+    // Walk the list and sum values
+    var sum: i64 = a.value;
+    match (a.next) {
+        Some(n1) => {
+            sum = sum + n1.value;
+            match (n1.next) {
+                Some(n2) => {
+                    sum = sum + n2.value;
+                }
+                None => {}
+            }
+        }
+        None => {}
+    }
+    assert(sum == 6);
+}

--- a/w0/test/valid/types/forward_ref.w
+++ b/w0/test/valid/types/forward_ref.w
@@ -1,0 +1,42 @@
+// Valid: forward references and recursive types should type-check
+
+// Forward reference: Wrapper uses Payload before it's declared
+struct Wrapper {
+    inner: Payload,
+}
+
+struct Payload {
+    value: i64,
+}
+
+// Self-referential struct
+struct TreeNode {
+    value: i64,
+    left: Option<TreeNode>,
+    right: Option<TreeNode>,
+}
+
+// Mutually recursive struct + enum
+struct Node {
+    kind: NodeKind,
+    line: i32,
+}
+
+enum NodeKind {
+    IntLit(i64),
+    Binary(string, Node, Node),
+}
+
+// Forward reference in enum variant
+enum Shape {
+    Circle(f64),
+    Labeled(Label),
+}
+
+struct Label {
+    text: string,
+}
+
+func main() -> i32 {
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Split checker pass 1 into two sub-passes: a name-registration pre-pass and the existing field-resolution pass, enabling forward references and recursive/mutually-recursive types
- Extract `has_rc_fields` computation into a separate fixed-point pass to correctly propagate RC flags across type dependencies regardless of declaration order
- Add run and valid tests for self-referential structs, mutually recursive struct+enum, forward references, and linked list patterns

## Test plan
- [x] All 255 tests pass (134 run + 121 error), including 5 new forward reference tests
- [x] `make format` passes
- [x] Valid test (`--check` only) passes for forward references

Closes #325