### PR TITLE
fix: split Box typedef emission to support recursive enum types

### DIFF
--- a/w0/codegen.c
+++ b/w0/codegen.c
@@ -2002,12 +2002,13 @@ void codegen_emit(CodeGen* gen, Node* ast) {
     compute_enum_eq_flags(gen, ast);
     emit_struct_forward_decls(gen, ast);
     emit_vec_typedefs(gen);
-    emit_box_typedefs(gen);
+    emit_box_forward_decls(gen);
     emit_span_typedefs(gen);
     emit_enum_typedefs(gen, ast);
     emit_generic_enum_typedefs(gen, ast);
     emit_enum_rc_helpers(gen, ast);
     emit_struct_body_typedefs(gen, ast);
+    emit_box_typedefs(gen);
     emit_function_forward_decls(gen, ast);
     collect_lambdas(gen, ast);
     emit_lambda_env_typedefs(gen);

--- a/w0/codegen_emit.c
+++ b/w0/codegen_emit.c
@@ -960,18 +960,32 @@ void emit_vec_typedefs(CodeGen* gen) {
     }
 }
 
-// Emit struct typedefs for each instantiated Box type (__Box_T)
+// Emit forward declarations for each instantiated Box type (__Box_T)
+// These must come early so that pointer types (__Box_T*) can be used
+// in enum/struct definitions before the full Box typedef is emitted.
+void emit_box_forward_decls(CodeGen* gen) {
+    for (int i = 0; i < gen->checker.box_count; i++) {
+        BoxInstance* inst       = &gen->checker.boxes[i];
+        const char*  elem_tname = type_mangle_name(inst->elem_type);
+        emit(gen, "typedef struct __Box_%s __Box_%s;\n", elem_tname, elem_tname);
+    }
+    if (gen->checker.box_count > 0)
+        emit(gen, "\n");
+}
+
+// Emit full struct definitions for each instantiated Box type (__Box_T)
+// Must come after enum and struct typedefs since Box embeds its element by value.
 void emit_box_typedefs(CodeGen* gen) {
     for (int i = 0; i < gen->checker.box_count; i++) {
         BoxInstance* inst       = &gen->checker.boxes[i];
         Type*        elem_type  = inst->elem_type;
         const char*  elem_tname = type_mangle_name(elem_type);
 
-        emit(gen, "typedef struct {\n");
+        emit(gen, "struct __Box_%s {\n", elem_tname);
         emit(gen, "    ");
         emit_resolved_type(gen, elem_type);
         emit(gen, " value;\n");
-        emit(gen, "} __Box_%s;\n\n", elem_tname);
+        emit(gen, "};\n\n");
     }
 }
 

--- a/w0/codegen_emit.h
+++ b/w0/codegen_emit.h
@@ -31,6 +31,7 @@ void emit_tuple_typedefs(CodeGen* gen);
 void emit_struct_forward_decls(CodeGen* gen, Node* ast);
 void emit_span_typedefs(CodeGen* gen);
 void emit_vec_typedefs(CodeGen* gen);
+void emit_box_forward_decls(CodeGen* gen);
 void emit_box_typedefs(CodeGen* gen);
 void emit_enum_typedefs(CodeGen* gen, Node* ast);
 void emit_generic_enum_typedefs(CodeGen* gen, Node* ast);

--- a/w0/test/run/types/box_recursive_enum.w
+++ b/w0/test/run/types/box_recursive_enum.w
@@ -1,0 +1,45 @@
+// Expected: PASS: recursive_enum_eval
+// Expected: PASS: recursive_enum_nested
+// Expected: PASS: recursive_enum_match_leaf
+
+enum Expr {
+    IntLit(i64),
+    Binary(string, Box<Expr>, Box<Expr>),
+}
+
+func eval(e: Expr) -> i64 {
+    match (e) {
+        IntLit(n) => {
+            return n;
+        },
+        Binary(op, left, right) => {
+            var l = eval(left);
+            var r = eval(right);
+            if (op == "+") {
+                return l + r;
+            }
+            if (op == "*") {
+                return l * r;
+            }
+            return 0;
+        },
+    }
+}
+
+test "recursive_enum_eval" {
+    // 2 + 3
+    var expr = Expr::Binary("+", new Box<Expr>(Expr::IntLit(2)), new Box<Expr>(Expr::IntLit(3)));
+    assert(eval(expr) == 5);
+}
+
+test "recursive_enum_nested" {
+    // (2 + 3) * 4
+    var inner = Expr::Binary("+", new Box<Expr>(Expr::IntLit(2)), new Box<Expr>(Expr::IntLit(3)));
+    var expr = Expr::Binary("*", new Box<Expr>(inner), new Box<Expr>(Expr::IntLit(4)));
+    assert(eval(expr) == 20);
+}
+
+test "recursive_enum_match_leaf" {
+    var leaf = Expr::IntLit(42);
+    assert(eval(leaf) == 42);
+}


### PR DESCRIPTION
## Summary
- Split `emit_box_typedefs` into two phases: `emit_box_forward_decls` (early) and `emit_box_typedefs` (after enums/structs)
- Forward declarations (`typedef struct __Box_T __Box_T;`) enable pointer usage in enum/struct definitions
- Full struct definitions come after enum and struct typedefs, since Box embeds its element by value
- Enables recursive enums via `Box<T>`, e.g. `enum Expr { IntLit(i64), Binary(string, Box<Expr>, Box<Expr>) }`

## Test plan
- [x] New test `w0/test/run/types/box_recursive_enum.w` — recursive enum with `Box<Expr>`, expression tree evaluation
- [x] Full test suite passes (256/256)

Closes #328