### PR TITLE
fix: allow const struct fields to be assigned in init() methods

### DIFF
--- a/w0/checker.c
+++ b/w0/checker.c
@@ -1941,9 +1941,11 @@ static void check_func_decl(Checker* checker, Node* node) {
 
     // For methods, inject 'self' into scope and set private field access context.
     const char* old_receiver = checker->current_method_receiver;
+    int         old_in_init  = checker->in_init;
     if (is_method) {
         define_method_self_symbol(checker, receiver_type, fdn->receiver_is_const);
         checker->current_method_receiver = receiver_type;
+        checker->in_init                 = (strcmp(name, "init") == 0);
     }
 
     define_func_params_in_scope(checker, fdn, func_type);
@@ -1954,6 +1956,7 @@ static void check_func_decl(Checker* checker, Node* node) {
     checker->modules.current_accessible_modules_count = old_accessible_modules_count;
 
     checker->current_method_receiver = old_receiver;
+    checker->in_init                 = old_in_init;
     checker->current_func_return     = old_return;
     checker_pop_scope(checker);
     free(mangled_name);

--- a/w0/checker.h
+++ b/w0/checker.h
@@ -209,6 +209,7 @@ struct Checker {
     Scope* scope;
     Type*  current_func_return; // Return type of current function
     int    in_loop;             // Are we inside a loop?
+    int    in_init;             // Are we inside an init() method?
     int    error_count;
 
     CheckerModules    modules;

--- a/w0/checker_expr.c
+++ b/w0/checker_expr.c
@@ -1108,8 +1108,11 @@ static int check_member_assignment_mutability(Checker* checker, Node* target, in
             return 0;
         }
     }
-    if (sem_info_get_member_is_const_access(checker->sem, target,
-                                            target->as.member.is_const_access)) {
+    // In init(), allow assigning to const fields of self directly.
+    int in_init_self =
+        checker->in_init && obj->type == NODE_IDENT && strcmp(obj->as.ident.name, "self") == 0;
+    if (!in_init_self && sem_info_get_member_is_const_access(checker->sem, target,
+                                                             target->as.member.is_const_access)) {
         check_error(checker, line, column, "Cannot assign to const field '%s'",
                     target->as.member.name);
         return 0;

--- a/w0/checker_internal.h
+++ b/w0/checker_internal.h
@@ -30,21 +30,21 @@ GenericDef*      lookup_generic_def(Checker* checker, const char* name);
 GenericInstance* lookup_generic_instance(Checker* checker, const char* mangled_name);
 
 // --- From checker_types.c: generic free function management ---
-void            register_generic_func_def(Checker* checker, const char* name, char** type_params,
-                                          char** type_param_bounds, int type_param_count, Node* decl);
-GenericFuncDef* lookup_generic_func_def(Checker* checker, const char* name);
+void register_generic_func_def(Checker* checker, const char* name, char** type_params,
+                               char** type_param_bounds, int type_param_count, Node* decl);
+GenericFuncDef*      lookup_generic_func_def(Checker* checker, const char* name);
 GenericFuncInstance* lookup_generic_func_instance(Checker* checker, const char* mangled_name);
 GenericFuncInstance* instantiate_generic_func(Checker* checker, GenericFuncDef* def,
                                               Type** type_args, int type_arg_count, int line,
                                               int col);
 
 // --- From checker_types.c: method-level generic function management ---
-void                 register_generic_method_func_def(Checker* checker, const char* receiver_type,
-                                                      const char* method_name, char** combined_params,
-                                                      char** combined_bounds, int combined_count,
-                                                      int receiver_param_count, Node* decl);
-GenericFuncDef*      lookup_generic_method_func_def(Checker* checker, const char* receiver_type,
-                                                    const char* method_name);
+void            register_generic_method_func_def(Checker* checker, const char* receiver_type,
+                                                 const char* method_name, char** combined_params,
+                                                 char** combined_bounds, int combined_count,
+                                                 int receiver_param_count, Node* decl);
+GenericFuncDef* lookup_generic_method_func_def(Checker* checker, const char* receiver_type,
+                                               const char* method_name);
 GenericFuncInstance* instantiate_generic_method_func(Checker* checker, GenericFuncDef* def,
                                                      Type** combined_args, int combined_count,
                                                      Type* receiver_concrete, int line, int col);

--- a/w0/checker_types.c
+++ b/w0/checker_types.c
@@ -1391,7 +1391,9 @@ static void check_instantiated_struct_method_body(Checker* checker, GenericInsta
 
     // Set private field access context for generic method body.
     const char* old_receiver         = checker->current_method_receiver;
+    int         old_in_init          = checker->in_init;
     checker->current_method_receiver = base_name;
+    checker->in_init                 = (strcmp(mfdn->name, "init") == 0);
 
     // Inject 'self' into scope.
     checker_define(checker, "self", SYM_VAR, struct_type, mfdn->receiver_is_const, 0, NULL);
@@ -1411,6 +1413,7 @@ static void check_instantiated_struct_method_body(Checker* checker, GenericInsta
     checker->modules.current_accessible_modules       = old_accessible_modules;
     checker->modules.current_accessible_modules_count = old_accessible_modules_count;
     checker->current_method_receiver                  = old_receiver;
+    checker->in_init                                  = old_in_init;
     checker->current_func_return                      = old_return;
     checker_pop_scope(checker);
 }

--- a/w0/codegen_expr.c
+++ b/w0/codegen_expr.c
@@ -192,10 +192,10 @@ static void emit_enum_value(CodeGen* gen, Node* node) {
         return;
     }
 
-    const char* enum_name    = codegen_enum_value_resolved_name(gen, node);
-    int         enum_len     = codegen_enum_value_resolved_name_length(gen, node);
-    int         is_data_enum = sem_info_get_enum_value_is_data_enum(gen->checker.sem, node,
-                                                                    node->as.enum_value.is_data_enum);
+    const char* enum_name = codegen_enum_value_resolved_name(gen, node);
+    int         enum_len  = codegen_enum_value_resolved_name_length(gen, node);
+    int is_data_enum      = sem_info_get_enum_value_is_data_enum(gen->checker.sem, node,
+                                                                 node->as.enum_value.is_data_enum);
 
     if (!is_data_enum) {
         // Simple enum: emit qualified value name (EnumName_ValueName)

--- a/w0/codegen_rc.c
+++ b/w0/codegen_rc.c
@@ -818,10 +818,10 @@ void emit_vec_user_methods(CodeGen* gen, Node* ast) {
 // Emit __Vec_T_cleanup functions that free Vec elements and data array
 void emit_vec_cleanup(CodeGen* gen) {
     for (int i = 0; i < gen->checker.vec_count; i++) {
-        VecInstance* inst        = &gen->checker.vecs[i];
-        Type*        elem_type   = inst->elem_type;
-        const char*  elem_tname  = type_mangle_name(elem_type);
-        int          elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC ||
+        VecInstance* inst       = &gen->checker.vecs[i];
+        Type*        elem_type  = inst->elem_type;
+        const char*  elem_tname = type_mangle_name(elem_type);
+        int elem_is_ptr = (elem_type->kind == TYPE_STRUCT || elem_type->kind == TYPE_VEC ||
                            elem_type->kind == TYPE_BOX || elem_type->kind == TYPE_STRINGBUILDER);
         int elem_is_rc_enum = (elem_type->kind == TYPE_ENUM && elem_type->as.enm.has_rc_fields);
 

--- a/w0/codegen_stmt.c
+++ b/w0/codegen_stmt.c
@@ -406,7 +406,7 @@ static int emit_rc_member_assign_stmt(CodeGen* gen, Node* expr) {
 
     Node* member    = expr->as.assign.target;
     int   obj_is_rc = member->as.member.object->type == NODE_IDENT &&
-                    rc_is_tracked(gen, member->as.member.object->as.ident.name);
+                      rc_is_tracked(gen, member->as.member.object->as.ident.name);
 
     if (obj_is_rc) {
         const char* obj_name  = member->as.member.object->as.ident.name;
@@ -696,11 +696,11 @@ static void emit_var_decl_rc_copy(CodeGen* gen, Node* node) {
     Type* rc_type  = node->as.var_decl.resolved_type;
     Node* init     = node->as.var_decl.init;
     int   skip_inc = init->type == NODE_CALL || init->type == NODE_STRING_LIT ||
-                   init->type == NODE_STRING_INTERP ||
-                   (init->type == NODE_BINARY && init->as.binary.is_string_op) ||
-                   (init->type == NODE_SLICE && init->as.slice.is_string) ||
-                   (rc_type && rc_type->kind == TYPE_ENUM && init->type == NODE_ENUM_VALUE) ||
-                   (init->type == NODE_ENUM_VALUE && init->as.enum_value.is_module_call);
+                     init->type == NODE_STRING_INTERP ||
+                     (init->type == NODE_BINARY && init->as.binary.is_string_op) ||
+                     (init->type == NODE_SLICE && init->as.slice.is_string) ||
+                     (rc_type && rc_type->kind == TYPE_ENUM && init->type == NODE_ENUM_VALUE) ||
+                     (init->type == NODE_ENUM_VALUE && init->as.enum_value.is_module_call);
     if (!skip_inc && rc_type) {
         const char* inc_fn = get_inc_func_for_type(rc_type);
         emit_indent(gen);

--- a/w0/test/errors/error_const_field_assign_non_init.w
+++ b/w0/test/errors/error_const_field_assign_non_init.w
@@ -1,0 +1,23 @@
+// ERROR TEST: Cannot assign to const field outside init()
+// Expected error: Cannot assign to const field 'max_size'
+
+struct Config {
+    const max_size: i64,
+    name: string,
+}
+
+impl Config {
+    func init(size: i64) {
+        self.max_size = size;
+        self.name = "default";
+    }
+
+    func reset() {
+        self.max_size = 0;
+    }
+}
+
+func main() -> i32 {
+    var c = new Config(100);
+    return 0;
+}

--- a/w0/test/valid/const_field_init.w
+++ b/w0/test/valid/const_field_init.w
@@ -1,0 +1,18 @@
+// Test: const struct fields can be assigned in init()
+
+struct Config {
+    const max_size: i64,
+    name: string,
+}
+
+impl Config {
+    func init(size: i64, n: string) {
+        self.max_size = size;
+        self.name = n;
+    }
+}
+
+func main() -> i32 {
+    var c = new Config(100, "test");
+    return 0;
+}

--- a/w0/test/valid/const_field_init_generic.w
+++ b/w0/test/valid/const_field_init_generic.w
@@ -1,0 +1,18 @@
+// Test: const struct fields can be assigned in init() for generic types
+
+struct Container<T> {
+    items: Vec<T>,
+    const capacity: i64,
+}
+
+impl Container<T> {
+    func init(cap: i64) {
+        self.items = new Vec<T>{};
+        self.capacity = cap;
+    }
+}
+
+func main() -> i32 {
+    var c = new Container<i64>(10);
+    return 0;
+}

--- a/w0/test/valid/const_field_init_method.w
+++ b/w0/test/valid/const_field_init_method.w
@@ -1,0 +1,20 @@
+// Test: const struct fields can be assigned in init() (multiple const fields)
+
+struct Rect {
+    const width: i64,
+    const height: i64,
+    label: string,
+}
+
+impl Rect {
+    func init(w: i64, h: i64, l: string) {
+        self.width = w;
+        self.height = h;
+        self.label = l;
+    }
+}
+
+func main() -> i32 {
+    var r = new Rect(10, 20, "box");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add `in_init` flag to the Checker struct, set when checking an `init()` method body
- Skip the const field assignment check for direct `self.field` targets when inside `init()`
- Covers both `check_func_decl` (non-generic) and `check_instantiated_struct_method_body` (generic struct) paths

Closes #272

## Details

The checker rejected `self.capacity = cap` inside `init()` because `capacity` is a `const` field. This made it impossible to use `const` fields with `init()` constructors — users had to choose between const enforcement and custom initialization.

The fix is minimal: a single boolean flag (`in_init`) that gates the existing const field check in `check_member_assignment_mutability`. Only direct `self.field` assignments are permitted — assignments through nested objects (`self.sub.const_field`) are still rejected.

## Test plan

- [x] `test/valid/const_field_init.w` — impl block form with const field
- [x] `test/valid/const_field_init_method.w` — multiple const fields  
- [x] `test/valid/const_field_init_generic.w` — generic struct (`Container<T>` with const capacity)
- [x] `test/errors/error_const_field_assign_non_init.w` — const fields still rejected in non-init methods
- [x] Full test suite: 257/257 pass